### PR TITLE
Local setup guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 azure-operator
 TODO
 !vendor/**
+
+/examples/local/*.yaml
+!/examples/local/*.tmpl.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.5
+
+RUN apk add --no-cache ca-certificates
+
+ADD ./azure-operator /azure-operator
+
+ENTRYPOINT ["/azure-operator"]

--- a/examples/cluster.yaml
+++ b/examples/cluster.yaml
@@ -1,0 +1,59 @@
+apiVersion: "giantswarm.io/v1"
+kind: AzureCluster
+metadata:
+  name: example-cluster
+spec:
+  cluster:
+    cluster:
+      id: "example-cluster"
+
+    customer:
+      id: "example-customer"
+
+    docker:
+      imageNamespace: "giantswarm"
+
+    etcd:
+      domain: "etcd.example.azure.giantswarm.io"
+      prefix: "example-cluster"
+      port: 2379
+
+    calico:
+      subnet: "192.168.0.0"
+      cidr: 24
+      mtu: 1500
+
+    kubernetes:
+      api:
+        domain: "api.example.azure.giantswarm.io"
+        insecurePort: 8080
+        ip: "172.31.0.1" 
+        securePort: 443
+        clusterIPRange: "172.31.0.0/24"
+      dns:
+        ip: "172.31.0.10"
+      domain: "cluster.local"
+      hyperkube:
+        docker:
+          image: "quay.io/giantswarm/hyperkube:v1.6.4_coreos.0"
+      ingressController:
+        docker:
+          image: "quay.io/giantswarm/nginx-ingress-controller:0.9.0-beta.1"
+        insecurePort: 30010
+        securePort: 30011
+        domain: "ingress.example.azure.gigantic.io"
+        wildcardDomain: "*.example.azure.gigantic.io"
+      kubelet:
+        port: 10250
+      networkSetup:
+        docker:
+          image: "giantswarm/k8s-setup-network-environment:ba2b57155d859a1fc5d378c2a09a77d7c2c755ed"
+
+    masters:
+    - hostname: "master-1"
+
+    workers:
+    - hostname: "worker-1"
+
+  azure:
+    location: "westeurope"

--- a/examples/local/README.md
+++ b/examples/local/README.md
@@ -1,0 +1,102 @@
+# Running azure-operator Locally
+
+**Note:** This should only be used for testing and development.
+
+This guide explains how to get azure-operator running locally - on minikube, for
+example. 
+
+All commands are assumed to be run from `examples/local` directory.
+
+## Preparing Templates
+
+All yaml files in this directory are templates. Before continuing with this
+guide, all placeholders must be replaced with sensible values.
+
+- *CLUSTER_NAME* - Cluster's name.
+- *COMMON_DOMAIN* - Cluster's etcd and API common domain.
+- *COMMON_DOMAIN_INGRESS* - Ingress common domain.
+- *AZURE_LOCATION* - Azure location.
+
+This is a handy snippet that makes it painless - works in bash and zsh.
+
+```bash
+export CLUSTER_NAME="example-cluster"
+export COMMON_DOMAIN="internal.company.com"
+export COMMON_DOMAIN_INGRESS="company.com"
+export AZURE_LOCATION="westeurope"
+
+for f in *.tmpl.yaml; do
+    sed \
+        -e 's|${CLUSTER_NAME}|'"${CLUSTER_NAME}"'|g' \
+        -e 's|${COMMON_DOMAIN}|'"${COMMON_DOMAIN}"'|g' \
+        -e 's|${COMMON_DOMAIN_INGRESS}|'"${COMMON_DOMAIN_INGRESS}"'|g' \
+        -e 's|${AZURE_LOCATION}|'"${AZURE_LOCATION}"'|g' \
+        ./$f > ./${f%.tmpl.yaml}.yaml
+done
+```
+
+- Note: `|` characters are used in `sed` substitution to avoid escaping.
+
+## Cluster-Local Docker Image
+
+The operator needs a connection to the K8s API. The simplest approach is to run
+the operator as a deployment and use the "in cluster" configuration.
+
+In that case the Docker image needs to be accessible from the K8s cluster
+running the operator. For Minikube run `eval $(minikube docker-env)` before
+`docker build`, see [reusing the Docker daemon] for details.
+
+[reusing the docker daemon]: https://github.com/kubernetes/minikube/blob/master/docs/reusing_the_docker_daemon.md 
+
+```bash
+# Optional. Only when using Minikube.
+eval $(minikube docker-env)
+
+GOOS=linux go build github.com/giantswarm/azure-operator
+docker build -t quay.io/giantswarm/azure-operator:local-dev .
+
+# Optional. Restart running operator after image update.
+# Does nothing when the operator is not deployed.
+#kubectl delete pod -l app=azure-operator-local
+```
+
+## Operator Startup
+
+Create the operator config map and deployment.
+
+```bash
+kubectl apply -f ./configmap.yaml
+kubectl apply -f ./deployment.yaml
+```
+
+## Creating A New Cluster
+
+Create a new cluster ThirdPartyObject.
+
+```bash
+kubectl create -f ./cluster.yaml
+```
+
+## Access Logs
+
+```bash
+kubectl logs -l app=azure-operator-local
+```
+
+## Cleaning Up
+
+First delete the cluster TPO.
+
+```bash
+export CLUSTER_NAME="example-cluster"
+
+kubectl delete azurecluster ${CLUSTER_NAME}
+```
+
+Wait for the operator to delete the cluster, and then remove the operator's
+deployment and configuration.
+
+```bash
+kubectl delete -f ./deployment.yaml
+kubectl delete -f ./configmap.yaml
+```

--- a/examples/local/cluster.tmpl.yaml
+++ b/examples/local/cluster.tmpl.yaml
@@ -1,0 +1,59 @@
+apiVersion: "giantswarm.io/v1"
+kind: AzureCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  cluster:
+    cluster:
+      id: "${CLUSTER_NAME}"
+
+    customer:
+      id: "example-customer"
+
+    docker:
+      imageNamespace: "giantswarm"
+
+    etcd:
+      domain: "etcd.${CLUSTER_NAME}.${COMMON_DOMAIN}"
+      prefix: "${CLUSTER_NAME}"
+      port: 2379
+
+    calico:
+      subnet: "192.168.0.0"
+      cidr: 24
+      mtu: 1500
+
+    kubernetes:
+      api:
+        domain: "api.${CLUSTER_NAME}.${COMMON_DOMAIN}"
+        insecurePort: 8080
+        ip: "172.31.0.1" 
+        securePort: 443
+        clusterIPRange: "172.31.0.0/24"
+      dns:
+        ip: "172.31.0.10"
+      domain: "cluster.local"
+      hyperkube:
+        docker:
+          image: "quay.io/giantswarm/hyperkube:v1.6.4_coreos.0"
+      ingressController:
+        docker:
+          image: "quay.io/giantswarm/nginx-ingress-controller:0.9.0-beta.1"
+        insecurePort: 30010
+        securePort: 30011
+        domain: "api.${CLUSTER_NAME}.${COMMON_DOMAIN_INGRESS}"
+        wildcardDomain: "*.${CLUSTER_NAME}.${COMMON_DOMAIN_INGRESS}"
+      kubelet:
+        port: 10250
+      networkSetup:
+        docker:
+          image: "giantswarm/k8s-setup-network-environment:ba2b57155d859a1fc5d378c2a09a77d7c2c755ed"
+
+    masters:
+    - hostname: "master-1"
+
+    workers:
+    - hostname: "worker-1"
+
+  azure:
+    location: "${AZURE_LOCATION}"

--- a/examples/local/configmap.tmpl.yaml
+++ b/examples/local/configmap.tmpl.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: azure-operator-configmap
+data:
+  config.yml: |
+    kubernetes:
+      incluster: true
+    server:
+      listen:
+        address: 'http://0.0.0.0:8000'

--- a/examples/local/deployment.tmpl.yaml
+++ b/examples/local/deployment.tmpl.yaml
@@ -1,0 +1,42 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: azure-operator-local
+  labels:
+    app: azure-operator-local
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: azure-operator-local
+    spec:
+      volumes:
+      - name: azure-operator-configmap
+        configMap:
+          name: azure-operator-configmap
+          items:
+          - key: config.yml
+            path: config.yml
+      containers:
+      - name: azure-operator
+        image: quay.io/giantswarm/azure-operator:local-dev
+        volumeMounts:
+        - name: azure-operator-configmap
+          mountPath: /var/run/azure-operator/configmap/
+        ports:
+        - name: http
+          containerPort: 8000
+        args:
+        - daemon
+        - --config.dirs=/var/run/azure-operator/configmap/
+        - --config.files=config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 20Mi
+          limits:
+            cpu: 250m
+            memory: 250Mi


### PR DESCRIPTION
Towards giantswarm/giantswarm#1707

This PR adds a local setup guide as well as the Dockerfile and an example TPO. The local setup doesn't cover certs yet because we don't need them till we're ready to boot machines.