### PR TITLE
Add Cluster Setup ARM template.

### DIFF
--- a/service/arm_templates/cluster_setup.json
+++ b/service/arm_templates/cluster_setup.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "clusterID": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique ID of this guest cluster."
+      }
+    },
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_GRS",
+        "Standard_ZRS",
+        "Premium_LRS"
+      ],
+      "metadata": {
+        "description": "Storage Account type."
+      }
+    }
+  },
+  "variables": {
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'clustersa')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "apiVersion": "2016-01-01",
+      "location": "[resourceGroup().location]",
+      "sku": {
+        "name": "[parameters('storageAccountType')]"
+      },
+      "tags": {
+        "clusterID": "[parameters('clusterID')]"
+      },
+      "kind": "Storage"
+    }
+  ],
+  "outputs": {
+    "storageAccountName": {
+      "type": "string",
+      "value": "[variables('storageAccountName')]"
+    }
+  }
+}


### PR DESCRIPTION
Towards #7 

A first version of the Cluster Setup template. For now, it just creates the Storage Account and outputs the name.

The storage account name is very restrictive (3-24 chars only lowercase alphanumeric). So the uniquestring function is used to generate it. The storage account is tagged with the clusterID so we can query for it.

See https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions