### PR TITLE
Add reconciler framework and key service

### DIFF
--- a/service/key/key.go
+++ b/service/key/key.go
@@ -1,0 +1,17 @@
+package key
+
+import (
+	"github.com/giantswarm/azuretpr"
+)
+
+func ClusterCustomer(customObject azuretpr.CustomObject) string {
+	return customObject.Spec.Cluster.Customer.ID
+}
+
+func ClusterID(customObject azuretpr.CustomObject) string {
+	return customObject.Spec.Cluster.Cluster.ID
+}
+
+func Location(customObject azuretpr.CustomObject) string {
+	return customObject.Spec.Azure.Location
+}

--- a/service/key/key_test.go
+++ b/service/key/key_test.go
@@ -1,0 +1,79 @@
+package key
+
+import (
+	"testing"
+
+	"github.com/giantswarm/azuretpr"
+	azurespec "github.com/giantswarm/azuretpr/spec"
+	"github.com/giantswarm/clustertpr"
+	"github.com/giantswarm/clustertpr/spec"
+)
+
+func Test_ClusterID(t *testing.T) {
+	expectedID := "test-cluster"
+
+	cluster := clustertpr.Spec{
+		Cluster: spec.Cluster{
+			ID: expectedID,
+		},
+		Customer: spec.Customer{
+			ID: "test-customer",
+		},
+	}
+
+	customObject := azuretpr.CustomObject{
+		Spec: azuretpr.Spec{
+			Cluster: cluster,
+		},
+	}
+
+	if ClusterID(customObject) != expectedID {
+		t.Fatalf("Expected cluster ID %s but was %s", expectedID, ClusterID(customObject))
+	}
+}
+
+func Test_ClusterCustomer(t *testing.T) {
+	expectedID := "test-customer"
+
+	cluster := clustertpr.Spec{
+		Cluster: spec.Cluster{
+			ID: "test-cluster",
+		},
+		Customer: spec.Customer{
+			ID: expectedID,
+		},
+	}
+
+	customObject := azuretpr.CustomObject{
+		Spec: azuretpr.Spec{
+			Cluster: cluster,
+		},
+	}
+
+	if ClusterCustomer(customObject) != expectedID {
+		t.Fatalf("Expected customer ID %s but was %s", expectedID, ClusterCustomer(customObject))
+	}
+}
+
+func Test_Location(t *testing.T) {
+	expectedLocation := "West Europe"
+
+	cluster := clustertpr.Spec{
+		Cluster: spec.Cluster{
+			ID: "test-cluster",
+		},
+	}
+
+	customObject := azuretpr.CustomObject{
+		Spec: azuretpr.Spec{
+			Azure: azurespec.Azure{
+				Location: expectedLocation,
+			},
+			Cluster: cluster,
+		},
+	}
+
+	if Location(customObject) != expectedLocation {
+		t.Fatalf("Expected location %s but was %s", expectedLocation, Location(customObject))
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/client/k8s"
+	"github.com/giantswarm/operatorkit/framework"
 	"github.com/spf13/viper"
 	"k8s.io/client-go/kubernetes"
 
@@ -94,6 +95,18 @@ func New(config Config) (*Service, error) {
 		}
 	}
 
+	var operatorFramework *framework.Framework
+	{
+		frameworkConfig := framework.DefaultConfig()
+
+		frameworkConfig.Logger = config.Logger
+
+		operatorFramework, err = framework.New(frameworkConfig)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var operatorService *operator.Service
 	{
 		operatorConfig := operator.DefaultConfig()
@@ -101,6 +114,8 @@ func New(config Config) (*Service, error) {
 		operatorConfig.Flag = config.Flag
 		operatorConfig.K8sClient = k8sClient
 		operatorConfig.Logger = config.Logger
+		operatorConfig.OperatorFramework = operatorFramework
+		operatorConfig.Resources = []framework.Resource{}
 		operatorConfig.Viper = config.Viper
 
 		operatorService, err = operator.New(operatorConfig)


### PR DESCRIPTION
Towards #5 

This PR adds the operatorkit reconciler framework and uses it in the addFunc and deleteFunc. The resources collection is currently empty. I'll add the ResourceGroup resource in a later PR.

This PR also adds the key service for retrieving values from the cluster TPO.