### PR TITLE
Main arm template

### DIFF
--- a/service/arm_templates/cluster_setup.json
+++ b/service/arm_templates/cluster_setup.json
@@ -4,22 +4,9 @@
   "parameters": {
     "clusterID": {
       "type": "string",
-      "metadata": {
-        "description": "Unique ID of this guest cluster."
-      }
     },
     "storageAccountType": {
       "type": "string",
-      "defaultValue": "Standard_LRS",
-      "allowedValues": [
-        "Standard_LRS",
-        "Standard_GRS",
-        "Standard_ZRS",
-        "Premium_LRS"
-      ],
-      "metadata": {
-        "description": "Storage Account type."
-      }
     }
   },
   "variables": {

--- a/service/arm_templates/cluster_setup.json
+++ b/service/arm_templates/cluster_setup.json
@@ -16,7 +16,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "2017-06-01",
+      "apiVersion": "2016-09-01",
       "location": "[resourceGroup().location]",
       "sku": {
         "name": "[parameters('storageAccountType')]"

--- a/service/arm_templates/cluster_setup.json
+++ b/service/arm_templates/cluster_setup.json
@@ -10,7 +10,7 @@
     }
   },
   "variables": {
-    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'clustersa')]"
+    "storageAccountName": "[concat(parameters('clusterID'), '-StorageAccount')]"
   },
   "resources": [
     {

--- a/service/arm_templates/cluster_setup.json
+++ b/service/arm_templates/cluster_setup.json
@@ -10,7 +10,7 @@
     }
   },
   "variables": {
-    "storageAccountName": "[concat(parameters('clusterID'), '-StorageAccount')]"
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'clustersa')]"
   },
   "resources": [
     {

--- a/service/arm_templates/cluster_setup.json
+++ b/service/arm_templates/cluster_setup.json
@@ -16,7 +16,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "2016-01-01",
+      "apiVersion": "2017-06-01",
       "location": "[resourceGroup().location]",
       "sku": {
         "name": "[parameters('storageAccountType')]"

--- a/service/arm_templates/cluster_setup.json
+++ b/service/arm_templates/cluster_setup.json
@@ -16,7 +16,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "2016-09-01",
+      "apiVersion": "2016-05-01",
       "location": "[resourceGroup().location]",
       "sku": {
         "name": "[parameters('storageAccountType')]"

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -73,6 +73,18 @@
     "kubernetesKubeletPort": {
       "type": "string",
       "defaultValue": "10250"
+    },
+    "clusterSetupTemplate": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/giantswarm/azure-operator/main-arm-template/service/arm_templates/cluster_setup.json"
+    },
+    "securityGroupsSetupTemplate": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/giantswarm/azure-operator/main-arm-template/service/arm_templates/security_groups_setup.json"
+    },
+    "virtualNetworkSetupTemplate": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/giantswarm/azure-operator/main-arm-template/service/arm_templates/virtual_network_setup.json"
     }
   },
   "resources": [
@@ -83,7 +95,7 @@
       "properties": {
         "mode": "incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/giantswarm/azure-operator/main-arm-template/service/arm_templates/cluster_setup.json",
+          "uri": "[parameters('clusterSetupTemplate')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -99,7 +111,7 @@
       "properties": {
         "mode": "incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/giantswarm/azure-operator/main-arm-template/service/arm_templates/security_groups_setup.json",
+          "uri": "[parameters('securityGroupsSetupTemplate')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -123,7 +135,7 @@
       "properties": {
         "mode": "incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/giantswarm/azure-operator/main-arm-template/service/arm_templates/virtual_network_setup.json",
+          "uri": "[parameters('virtualNetworkSetupTemplate')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -42,10 +42,16 @@
         "description": "The masters subnet's CIDR."
       }
     },
-    "masterLoadBalancerCidr": {
+    "apiLoadBalancerCidr": {
       "type": "string",
       "metadata": {
-        "description": "The masters load balancer's CIDR."
+        "description": "The Kubernetes API load balancer's CIDR."
+      }
+    },
+    "etcdLoadBalancerCidr": {
+      "type": "string",
+      "metadata": {
+        "description": "The Etcd load balancer's CIDR."
       }
     },
     "workerLoadBalancerCidr": {
@@ -116,7 +122,8 @@
         },
         "parameters": {
           "clusterID": {"value": "[parameters('clusterID')]"},
-          "masterLoadBalancerCidr": {"value": "[parameters('masterLoadBalancerCidr')]"},
+          "apiLoadBalancerCidr": {"value": "[parameters('apiLoadBalancerCidr')]"},
+          "etcdLoadBalancerCidr": {"value": "[parameters('etcdLoadBalancerCidr')]"},
           "workerLoadBalancerCidr": {"value": "[parameters('workerLoadBalancerCidr')]"},
           "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
           "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -39,16 +39,16 @@
       "type": "string"
     },
     "kubernetesAPISecurePort": {
-      "type": "string"
+      "type": "int"
     },
     "etcdPort": {
-      "type": "string"
+      "type": "int"
     },
     "kubernetesIngressSecurePort": {
-      "type": "string"
+      "type": "int"
     },
     "kubernetesIngressInsecurePort": {
-      "type": "string"
+      "type": "int"
     },
     "templatesBaseURI" : {
       "type": "string",

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -21,6 +21,13 @@
         "description": "Storage Account type."
       }
     },
+    "addressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "The main CIDR block reserved for this virtual network."
+      }
+    },
     "subnetMastersCIDR": {
       "type": "string",
       "defaultValue": "10.0.1.0/24",
@@ -108,6 +115,26 @@
           "kubernetesKubeletPort": {"value": "[parameters('kubernetesKubeletPort')]"}
         }
       }
-    }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "virtual_network_setup",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "incremental",
+        "templateLink": {
+          "uri": "https://raw.githubusercontent.com/giantswarm/azure-operator/main-arm-template/service/arm_templates/virtual_network_setup.json",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "clusterID": {"value": "[parameters('clusterID')]"},
+          "addressPrefix": {"value": "[parameters('addressPrefix')]"},
+          "subnetMastersCIDR": {"value": "[parameters('subnetMastersCIDR')]"},
+          "subnetWorkersCIDR": {"value": "[parameters('subnetWorkersCIDR')]"},
+          "mastersSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.mastersSecurityGroupID.value]"},
+          "workersSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.workersSecurityGroupID.value]"},
+        }
+      }
+    },
   ]
 }

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -21,7 +21,7 @@
         "description": "Storage Account type."
       }
     },
-    "mainCidr": {
+    "virtualNetworkCidr": {
       "type": "string",
       "defaultValue": "10.0.0.0/16",
       "metadata": {
@@ -128,7 +128,7 @@
         },
         "parameters": {
           "clusterID": {"value": "[parameters('clusterID')]"},
-          "mainCidr": {"value": "[parameters('mainCidr')]"},
+          "virtualNetworkCidr": {"value": "[parameters('virtualNetworkCidr')]"},
           "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
           "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},
           "masterSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.masterSecurityGroupID.value]"},

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -20,24 +20,92 @@
       "metadata": {
         "description": "Storage Account type."
       }
+    },
+    "subnetMastersCIDR": {
+      "type": "string",
+      "defaultValue": "10.0.1.0/24",
+      "metadata": {
+        "description": "The masters subnet's CIDR."
+      }
+    },
+    "subnetWorkersCIDR": {
+      "type": "string",
+      "defaultValue": "10.0.2.0/24",
+      "metadata": {
+        "description": "The masters subnet's CIDR."
+      }
+    },
+    "loadBalancerMastersCIDR": {
+      "type": "string",
+      "metadata": {
+        "description": "The masters load balancer's CIDR."
+      }
+    },
+    "loadBalancerWorkersCIDR": {
+      "type": "string",
+      "metadata": {
+        "description": "The workers load balancer's CIDR."
+      }
+    },
+    "kubernetesAPISecurePort": {
+      "type": "string",
+      "defaultValue": "443"
+    },
+    "etcdPort": {
+      "type": "string",
+      "defaultValue": "2379"
+    },
+    "kubernetesIngressSecurePort": {
+      "type": "string",
+      "defaultValue": "30011"
+    },
+    "kubernetesIngressInsecurePort": {
+      "type": "string",
+      "defaultValue": "30010"
+    },
+    "kubernetesKubeletPort": {
+      "type": "string",
+      "defaultValue": "10250"
     }
-  },
-  "variables": {
   },
   "resources": [
     {
       "apiVersion": "2017-05-10",
-      "name": "clusterSetup",
+      "name": "cluster_setup",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/giantswarm/azure-operator/master/service/arm_templates/cluster_setup.json",
+          "uri": "https://raw.githubusercontent.com/giantswarm/azure-operator/main-arm-template/service/arm_templates/cluster_setup.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
           "clusterID": {"value": "[parameters('clusterID')]"},
           "storageAccountType": {"value": "[parameters('storageAccountType')]"}
+        }
+      }
+    },
+    {
+      "apiVersion": "2017-05-10",
+      "name": "security_groups_setup",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "incremental",
+        "templateLink": {
+          "uri": "https://raw.githubusercontent.com/giantswarm/azure-operator/main-arm-template/service/arm_templates/security_groups_setup.json",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "clusterID": {"value": "[parameters('clusterID')]"},
+          "loadBalancerMastersCIDR": {"value": "[parameters('loadBalancerMastersCIDR')]"},
+          "loadBalancerWorkersCIDR": {"value": "[parameters('loadBalancerWorkersCIDR')]"},
+          "subnetMastersCIDR": {"value": "[parameters('subnetMastersCIDR')]"},
+          "subnetWorkersCIDR": {"value": "[parameters('subnetWorkersCIDR')]"},
+          "kubernetesAPISecurePort": {"value": "[parameters('kubernetesAPISecurePort')]"},
+          "etcdPort": {"value": "[parameters('etcdPort')]"},
+          "kubernetesIngressSecurePort": {"value": "[parameters('kubernetesIngressSecurePort')]"},
+          "kubernetesIngressInsecurePort": {"value": "[parameters('kubernetesIngressInsecurePort')]"},
+          "kubernetesKubeletPort": {"value": "[parameters('kubernetesKubeletPort')]"}
         }
       }
     }

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -21,34 +21,34 @@
         "description": "Storage Account type."
       }
     },
-    "addressPrefix": {
+    "mainCidr": {
       "type": "string",
       "defaultValue": "10.0.0.0/16",
       "metadata": {
         "description": "The main CIDR block reserved for this virtual network."
       }
     },
-    "subnetMastersCIDR": {
+    "masterSubnetCidr": {
       "type": "string",
       "defaultValue": "10.0.1.0/24",
       "metadata": {
         "description": "The masters subnet's CIDR."
       }
     },
-    "subnetWorkersCIDR": {
+    "workerSubnetCidr": {
       "type": "string",
       "defaultValue": "10.0.2.0/24",
       "metadata": {
         "description": "The masters subnet's CIDR."
       }
     },
-    "loadBalancerMastersCIDR": {
+    "masterLoadBalancerCidr": {
       "type": "string",
       "metadata": {
         "description": "The masters load balancer's CIDR."
       }
     },
-    "loadBalancerWorkersCIDR": {
+    "workerLoadBalancerCidr": {
       "type": "string",
       "metadata": {
         "description": "The workers load balancer's CIDR."
@@ -104,10 +104,10 @@
         },
         "parameters": {
           "clusterID": {"value": "[parameters('clusterID')]"},
-          "loadBalancerMastersCIDR": {"value": "[parameters('loadBalancerMastersCIDR')]"},
-          "loadBalancerWorkersCIDR": {"value": "[parameters('loadBalancerWorkersCIDR')]"},
-          "subnetMastersCIDR": {"value": "[parameters('subnetMastersCIDR')]"},
-          "subnetWorkersCIDR": {"value": "[parameters('subnetWorkersCIDR')]"},
+          "masterLoadBalancerCidr": {"value": "[parameters('masterLoadBalancerCidr')]"},
+          "workerLoadBalancerCidr": {"value": "[parameters('workerLoadBalancerCidr')]"},
+          "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
+          "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},
           "kubernetesAPISecurePort": {"value": "[parameters('kubernetesAPISecurePort')]"},
           "etcdPort": {"value": "[parameters('etcdPort')]"},
           "kubernetesIngressSecurePort": {"value": "[parameters('kubernetesIngressSecurePort')]"},
@@ -128,9 +128,9 @@
         },
         "parameters": {
           "clusterID": {"value": "[parameters('clusterID')]"},
-          "addressPrefix": {"value": "[parameters('addressPrefix')]"},
-          "subnetMastersCIDR": {"value": "[parameters('subnetMastersCIDR')]"},
-          "subnetWorkersCIDR": {"value": "[parameters('subnetWorkersCIDR')]"},
+          "mainCidr": {"value": "[parameters('mainCidr')]"},
+          "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
+          "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},
           "mastersSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.mastersSecurityGroupID.value]"},
           "workersSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.workersSecurityGroupID.value]"},
         }

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -131,8 +131,8 @@
           "mainCidr": {"value": "[parameters('mainCidr')]"},
           "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
           "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},
-          "mastersSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.masterSecurityGroupID.value]"},
-          "workersSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.workerSecurityGroupID.value]"},
+          "masterSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.masterSecurityGroupID.value]"},
+          "workerSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.workerSecurityGroupID.value]"},
         }
       }
     },

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -89,7 +89,7 @@
   },
   "resources": [
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2016-09-01",
       "name": "cluster_setup",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -105,7 +105,7 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2016-09-01",
       "name": "security_groups_setup",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -129,7 +129,7 @@
       }
     },
     {
-      "apiVersion": "2017-05-10",
+      "apiVersion": "2016-09-01",
       "name": "virtual_network_setup",
       "type": "Microsoft.Resources/deployments",
       "properties": {

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "clusterID": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique ID of this guest cluster."
+      }
+    },
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_GRS",
+        "Standard_ZRS",
+        "Premium_LRS"
+      ],
+      "metadata": {
+        "description": "Storage Account type."
+      }
+    }
+  },
+  "variables": {
+  },
+  "resources": [
+    {
+      "apiVersion": "2017-05-10",
+      "name": "clusterSetup",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "incremental",
+        "templateLink": {
+          "uri": "https://raw.githubusercontent.com/giantswarm/azure-operator/master/service/arm_templates/cluster_setup.json",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "clusterID": {"value": "[parameters('clusterID')]"},
+          "storageAccountType": {"value": "[parameters('storageAccountType')]"}
+        }
+      }
+    }
+  ]
+}

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -131,8 +131,8 @@
           "mainCidr": {"value": "[parameters('mainCidr')]"},
           "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
           "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},
-          "mastersSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.mastersSecurityGroupID.value]"},
-          "workersSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.workersSecurityGroupID.value]"},
+          "mastersSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.masterSecurityGroupID.value]"},
+          "workersSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.workerSecurityGroupID.value]"},
         }
       }
     },

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -10,83 +10,54 @@
     },
     "storageAccountType": {
       "type": "string",
-      "defaultValue": "Standard_LRS",
       "allowedValues": [
         "Standard_LRS",
         "Standard_GRS",
         "Standard_ZRS",
         "Premium_LRS"
-      ],
-      "metadata": {
-        "description": "Storage Account type."
-      }
+      ]
     },
     "virtualNetworkCidr": {
       "type": "string",
-      "defaultValue": "10.0.0.0/16",
       "metadata": {
         "description": "The main CIDR block reserved for this virtual network."
       }
     },
     "masterSubnetCidr": {
-      "type": "string",
-      "defaultValue": "10.0.1.0/24",
-      "metadata": {
-        "description": "The masters subnet's CIDR."
-      }
+      "type": "string"
     },
     "workerSubnetCidr": {
-      "type": "string",
-      "defaultValue": "10.0.2.0/24",
-      "metadata": {
-        "description": "The masters subnet's CIDR."
-      }
+      "type": "string"
     },
     "apiLoadBalancerCidr": {
-      "type": "string",
-      "metadata": {
-        "description": "The Kubernetes API load balancer's CIDR."
-      }
+      "type": "string"
     },
     "etcdLoadBalancerCidr": {
-      "type": "string",
-      "metadata": {
-        "description": "The Etcd load balancer's CIDR."
-      }
+      "type": "string"
     },
     "ingressLoadBalancerCidr": {
-      "type": "string",
-      "metadata": {
-        "description": "The ingress load balancer's CIDR."
-      }
+      "type": "string"
     },
     "kubernetesAPISecurePort": {
-      "type": "string",
-      "defaultValue": "443"
+      "type": "string"
     },
     "etcdPort": {
-      "type": "string",
-      "defaultValue": "2379"
+      "type": "string"
     },
     "kubernetesIngressSecurePort": {
-      "type": "string",
-      "defaultValue": "30011"
+      "type": "string"
     },
     "kubernetesIngressInsecurePort": {
-      "type": "string",
-      "defaultValue": "30010"
+      "type": "string"
     },
     "clusterSetupTemplate": {
-      "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/giantswarm/azure-operator/main-arm-template/service/arm_templates/cluster_setup.json"
+      "type": "string"
     },
     "securityGroupsSetupTemplate": {
-      "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/giantswarm/azure-operator/main-arm-template/service/arm_templates/security_groups_setup.json"
+      "type": "string"
     },
     "virtualNetworkSetupTemplate": {
-      "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/giantswarm/azure-operator/main-arm-template/service/arm_templates/virtual_network_setup.json"
+      "type": "string"
     }
   },
   "resources": [

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -54,10 +54,10 @@
         "description": "The Etcd load balancer's CIDR."
       }
     },
-    "workerLoadBalancerCidr": {
+    "ingressLoadBalancerCidr": {
       "type": "string",
       "metadata": {
-        "description": "The workers load balancer's CIDR."
+        "description": "The ingress load balancer's CIDR."
       }
     },
     "kubernetesAPISecurePort": {
@@ -124,7 +124,7 @@
           "clusterID": {"value": "[parameters('clusterID')]"},
           "apiLoadBalancerCidr": {"value": "[parameters('apiLoadBalancerCidr')]"},
           "etcdLoadBalancerCidr": {"value": "[parameters('etcdLoadBalancerCidr')]"},
-          "workerLoadBalancerCidr": {"value": "[parameters('workerLoadBalancerCidr')]"},
+          "ingressLoadBalancerCidr": {"value": "[parameters('ingressLoadBalancerCidr')]"},
           "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
           "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},
           "kubernetesAPISecurePort": {"value": "[parameters('kubernetesAPISecurePort')]"},

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -76,10 +76,6 @@
       "type": "string",
       "defaultValue": "30010"
     },
-    "kubernetesKubeletPort": {
-      "type": "string",
-      "defaultValue": "10250"
-    },
     "clusterSetupTemplate": {
       "type": "string",
       "defaultValue": "https://raw.githubusercontent.com/giantswarm/azure-operator/main-arm-template/service/arm_templates/cluster_setup.json"
@@ -131,7 +127,6 @@
           "etcdPort": {"value": "[parameters('etcdPort')]"},
           "kubernetesIngressSecurePort": {"value": "[parameters('kubernetesIngressSecurePort')]"},
           "kubernetesIngressInsecurePort": {"value": "[parameters('kubernetesIngressInsecurePort')]"},
-          "kubernetesKubeletPort": {"value": "[parameters('kubernetesKubeletPort')]"}
         }
       }
     },

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -50,15 +50,29 @@
     "kubernetesIngressInsecurePort": {
       "type": "string"
     },
-    "clusterSetupTemplate": {
-      "type": "string"
+    "templatesBaseURI" : {
+      "type": "string",
+      "metadata": {
+        "description": "The base URI from which the templates will be fetched. Ends with a trailing '/'."
+      }
     },
-    "securityGroupsSetupTemplate": {
-      "type": "string"
+    "clusterSetupTemplateFile": {
+      "type": "string",
+      "defaultValue": "cluster_setup.json"
     },
-    "virtualNetworkSetupTemplate": {
-      "type": "string"
+    "securityGroupsSetupTemplateFile": {
+      "type": "string",
+      "defaultValue": "security_groups_setup.json"
+    },
+    "virtualNetworkSetupTemplateFile": {
+      "type": "string",
+      "defaultValue": "virtual_network_setup.json"
     }
+  },
+  "variables": {
+    "clusterSetupTemplateURI": "[concat(parameters('templatesBaseURI'), parameters('clusterSetupTemplateFile'))]",
+    "securityGroupsSetupTemplateURI": "[concat(parameters('templatesBaseURI'), parameters('securityGroupsSetupTemplateFile'))]",
+    "virtualNetworkSetupTemplateURI": "[concat(parameters('templatesBaseURI'), parameters('virtualNetworkSetupTemplateFile'))]"
   },
   "resources": [
     {
@@ -68,7 +82,7 @@
       "properties": {
         "mode": "incremental",
         "templateLink": {
-          "uri": "[parameters('clusterSetupTemplate')]",
+          "uri": "[variables('clusterSetupTemplateURI')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -84,7 +98,7 @@
       "properties": {
         "mode": "incremental",
         "templateLink": {
-          "uri": "[parameters('securityGroupsSetupTemplate')]",
+          "uri": "[variables('securityGroupsSetupTemplateURI')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -108,7 +122,7 @@
       "properties": {
         "mode": "incremental",
         "templateLink": {
-          "uri": "[parameters('virtualNetworkSetupTemplate')]",
+          "uri": "[variables('virtualNetworkSetupTemplateURI')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/service/arm_templates/security_groups_setup.json
+++ b/service/arm_templates/security_groups_setup.json
@@ -12,7 +12,10 @@
     "clusterID": {
       "type": "string"
     },
-    "masterLoadBalancerCidr": {
+    "apiLoadBalancerCidr": {
+      "type": "string"
+    },
+    "etcdLoadBalancerCidr": {
       "type": "string"
     },
     "workerLoadBalancerCidr": {
@@ -95,13 +98,13 @@
             }
           },
           {
-            "name": "masterLBToKubernetesAPI",
+            "name": "apiLoadBalancerRule",
             "properties": {
-              "description": "Allow the master load balancer to reach the kubernetes API.",
+              "description": "Allow the API load balancer to reach the kubernetes API.",
               "protocol": "tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('kubernetesAPISecurePort')]",
-              "sourceAddressPrefix": "[parameters('masterLoadBalancerCidr')]",
+              "sourceAddressPrefix": "[parameters('apiLoadBalancerCidr')]",
               "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
               "access": "Allow",
               "direction": "Inbound",
@@ -109,13 +112,13 @@
             }
           },
           {
-            "name": "masterLBToEtcd",
+            "name": "etcdLoadBalancerRule",
             "properties": {
-              "description": "Allow the master load balancer to reach etcd.",
+              "description": "Allow the Etcd load balancer to reach etcd.",
               "protocol": "tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('etcdPort')]",
-              "sourceAddressPrefix": "[parameters('masterLoadBalancerCidr')]",
+              "sourceAddressPrefix": "[parameters('etcdLoadBalancerCidr')]",
               "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
               "access": "Allow",
               "direction": "Inbound",

--- a/service/arm_templates/security_groups_setup.json
+++ b/service/arm_templates/security_groups_setup.json
@@ -28,16 +28,16 @@
       "type": "string"
     },
     "kubernetesAPISecurePort": {
-      "type": "string"
+      "type": "int"
     },
     "etcdPort": {
-      "type": "string"
+      "type": "int"
     },
     "kubernetesIngressSecurePort": {
-      "type": "string"
+      "type": "int"
     },
     "kubernetesIngressInsecurePort": {
-      "type": "string"
+      "type": "int"
     }
   },
   "variables": {
@@ -103,7 +103,7 @@
               "description": "Allow the API load balancer to reach the kubernetes API.",
               "protocol": "tcp",
               "sourcePortRange": "*",
-              "destinationPortRange": "[parameters('kubernetesAPISecurePort')]",
+              "destinationPortRange": "[string(parameters('kubernetesAPISecurePort'))]",
               "sourceAddressPrefix": "[parameters('apiLoadBalancerCidr')]",
               "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
               "access": "Allow",
@@ -117,7 +117,7 @@
               "description": "Allow the Etcd load balancer to reach etcd.",
               "protocol": "tcp",
               "sourcePortRange": "*",
-              "destinationPortRange": "[parameters('etcdPort')]",
+              "destinationPortRange": "[string(parameters('etcdPort'))]",
               "sourceAddressPrefix": "[parameters('etcdLoadBalancerCidr')]",
               "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
               "access": "Allow",
@@ -197,7 +197,7 @@
               "description": "Allow the ingress load balancer to reach the ingress controller secure port.",
               "protocol": "tcp",
               "sourcePortRange": "*",
-              "destinationPortRange": "[parameters('kubernetesIngressSecurePort')]",
+              "destinationPortRange": "[string(parameters('kubernetesIngressSecurePort'))]",
               "sourceAddressPrefix": "[parameters('ingressLoadBalancerCidr')]",
               "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
               "access": "Allow",
@@ -211,7 +211,7 @@
               "description": "Allow the ingress load balancer to reach the ingress controller insecure port.",
               "protocol": "tcp",
               "sourcePortRange": "*",
-              "destinationPortRange": "[parameters('kubernetesIngressInsecurePort')]",
+              "destinationPortRange": "[string(parameters('kubernetesIngressInsecurePort'))]",
               "sourceAddressPrefix": "[parameters('ingressLoadBalancerCidr')]",
               "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
               "access": "Allow",

--- a/service/arm_templates/security_groups_setup.json
+++ b/service/arm_templates/security_groups_setup.json
@@ -2,15 +2,15 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "clusterID": {
-      "type": "string"
-    },
     "networkSecurityGroupsAPIVersion": {
       "type": "string",
       "defaultValue": "2017-03-01",
       "metadata": {
         "description": "API version used by the Microsoft.Network/networkSecurityGroups resource."
       }
+    },
+    "clusterID": {
+      "type": "string"
     },
     "loadBalancerMastersCIDR": {
       "type": "string"
@@ -25,32 +25,22 @@
       "type": "string"
     },
     "kubernetesAPISecurePort": {
-      "type": "string",
-      "defaultValue": "443"
+      "type": "string"
     },
     "etcdPort": {
-      "type": "string",
-      "defaultValue": "2379"
+      "type": "string"
     },
     "sshPort": {
-      "type": "string",
-      "defaultValue": "22"
-    },
-    "calicoBGPNetworkPort": {
-      "type": "string",
-      "defaultValue": "179"
+      "type": "string"
     },
     "kubernetesIngressSecurePort": {
-      "type": "string",
-      "defaultValue": "30011"
+      "type": "string"
     },
     "kubernetesIngressInsecurePort": {
-      "type": "string",
-      "defaultValue": "30010"
+      "type": "string"
     },
     "kubernetesKubeletPort": {
-      "type": "string",
-      "defaultValue": "10250"
+      "type": "string"
     }
   },
   "variables": {

--- a/service/arm_templates/security_groups_setup.json
+++ b/service/arm_templates/security_groups_setup.json
@@ -15,7 +15,7 @@
     "masterLoadBalancerCidr": {
       "type": "string"
     },
-    "masterLoadBalancerCidr": {
+    "workerLoadBalancerCidr": {
       "type": "string"
     },
     "masterSubnetCidr": {
@@ -98,7 +98,7 @@
             }
           },
           {
-            "name": "mastersLBToKubernetesAPI",
+            "name": "masterLBToKubernetesAPI",
             "properties": {
               "description": "Allow the masters' load balancer to reach the kubernetes API.",
               "protocol": "tcp",
@@ -112,7 +112,7 @@
             }
           },
           {
-            "name": "mastersLBToEtcd",
+            "name": "masterLBToEtcd",
             "properties": {
               "description": "Allow the masters' load balancer to reach etcd.",
               "protocol": "tcp",
@@ -126,7 +126,7 @@
             }
           },
           {
-            "name": "workersSubnetToMastersSubnet",
+            "name": "workerSubnetToMasterSubnet",
             "properties": {
               "description": "Allow the workers machines to reach the masters machines on any ports.",
               "protocol": "*",
@@ -192,7 +192,7 @@
             }
           },
           {
-            "name": "workersLBToIngressSecurePort",
+            "name": "workerLBToIngressSecurePort",
             "properties": {
               "description": "Allow the workers' load balancer to reach the ingress controller secure port.",
               "protocol": "tcp",
@@ -206,7 +206,7 @@
             }
           },
           {
-            "name": "workersLBToIngressInsecurePort",
+            "name": "workerLBToIngressInsecurePort",
             "properties": {
               "description": "Allow the workers' load balancer to reach the ingress controller insecure port.",
               "protocol": "tcp",
@@ -220,7 +220,7 @@
             }
           },
           {
-            "name": "workersLBToKubelet",
+            "name": "workerLBToKubelet",
             "properties": {
               "description": "Allow the workers' load balancer to reach the kubelet port.",
               "protocol": "tcp",
@@ -234,7 +234,7 @@
             }
           },
           {
-            "name": "mastersSubnetToWorkersSubnet",
+            "name": "masterSubnetToWorkersSubnet",
             "properties": {
               "description": "Allow the masters machines to reach the workers machines on any ports.",
               "protocol": "*",
@@ -254,11 +254,11 @@
   "outputs": {
     "mastersSecurityGroupID": {
       "type": "string",
-      "value": "[variables('mastersSecurityGroupID')]"
+      "value": "[variables('masterSecurityGroupID')]"
     },
     "workersSecurityGroupID": {
       "type": "string",
-      "value": "[variables('workersSecurityGroupID')]"
+      "value": "[variables('workerSecurityGroupID')]"
     }
   }
 }

--- a/service/arm_templates/security_groups_setup.json
+++ b/service/arm_templates/security_groups_setup.json
@@ -41,16 +41,16 @@
     }
   },
   "variables": {
-    "mastersSecurityGroupName": "[concat(parameters('clusterID'), '-MastersSecurityGroup')]",
-    "mastersSecurityGroupID": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('mastersSecurityGroupName'))]",
+    "masterSecurityGroupName": "[concat(parameters('clusterID'), '-MasterSecurityGroup')]",
+    "masterSecurityGroupID": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('masterSecurityGroupName'))]",
 
-    "workersSecurityGroupName": "[concat(parameters('clusterID'), '-WorkersSecurityGroup')]",
-    "workersSecurityGroupID": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('workersSecurityGroupName'))]",
+    "workerSecurityGroupName": "[concat(parameters('clusterID'), '-WorkerSecurityGroup')]",
+    "workerSecurityGroupID": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('workerSecurityGroupName'))]",
   },
   "resources": [
     {
       "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('mastersSecurityGroupName')]",
+      "name": "[variables('masterSecurityGroupName')]",
       "apiVersion": "[parameters('networkSecurityGroupsAPIVersion')]",
       "location": "[resourceGroup().location]",
       "properties": {
@@ -86,7 +86,7 @@
           {
             "name": "defaultInClusterRule",
             "properties": {
-              "description": "Default rule that allows any traffic within the masters' subnet.",
+              "description": "Default rule that allows any traffic within the master subnet.",
               "protocol": "*",
               "sourcePortRange": "*",
               "destinationPortRange": "*",
@@ -100,7 +100,7 @@
           {
             "name": "masterLBToKubernetesAPI",
             "properties": {
-              "description": "Allow the masters' load balancer to reach the kubernetes API.",
+              "description": "Allow the master load balancer to reach the kubernetes API.",
               "protocol": "tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('kubernetesAPISecurePort')]",
@@ -114,7 +114,7 @@
           {
             "name": "masterLBToEtcd",
             "properties": {
-              "description": "Allow the masters' load balancer to reach etcd.",
+              "description": "Allow the master load balancer to reach etcd.",
               "protocol": "tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('etcdPort')]",
@@ -128,7 +128,7 @@
           {
             "name": "workerSubnetToMasterSubnet",
             "properties": {
-              "description": "Allow the workers machines to reach the masters machines on any ports.",
+              "description": "Allow the worker machines to reach the master machines on any ports.",
               "protocol": "*",
               "sourcePortRange": "*",
               "destinationPortRange": "*",
@@ -144,7 +144,7 @@
     },
     {
       "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('workersSecurityGroupName')]",
+      "name": "[variables('workerSecurityGroupName')]",
       "apiVersion": "[parameters('networkSecurityGroupsAPIVersion')]",
       "location": "[resourceGroup().location]",
       "properties": {
@@ -180,7 +180,7 @@
           {
             "name": "defaultInClusterRule",
             "properties": {
-              "description": "Default rule that allows any traffic within the workers' subnet.",
+              "description": "Default rule that allows any traffic within the worker subnet.",
               "protocol": "*",
               "sourcePortRange": "*",
               "destinationPortRange": "*",
@@ -194,7 +194,7 @@
           {
             "name": "workerLBToIngressSecurePort",
             "properties": {
-              "description": "Allow the workers' load balancer to reach the ingress controller secure port.",
+              "description": "Allow the worker load balancer to reach the ingress controller secure port.",
               "protocol": "tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('kubernetesIngressSecurePort')]",
@@ -208,7 +208,7 @@
           {
             "name": "workerLBToIngressInsecurePort",
             "properties": {
-              "description": "Allow the workers' load balancer to reach the ingress controller insecure port.",
+              "description": "Allow the worker load balancer to reach the ingress controller insecure port.",
               "protocol": "tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('kubernetesIngressInsecurePort')]",
@@ -222,7 +222,7 @@
           {
             "name": "workerLBToKubelet",
             "properties": {
-              "description": "Allow the workers' load balancer to reach the kubelet port.",
+              "description": "Allow the worker load balancer to reach the kubelet port.",
               "protocol": "tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('kubernetesKubeletPort')]",
@@ -234,9 +234,9 @@
             }
           },
           {
-            "name": "masterSubnetToWorkersSubnet",
+            "name": "masterSubnetToWorkerSubnet",
             "properties": {
-              "description": "Allow the masters machines to reach the workers machines on any ports.",
+              "description": "Allow the master machines to reach the worker machines on any ports.",
               "protocol": "*",
               "sourcePortRange": "*",
               "destinationPortRange": "*",
@@ -252,11 +252,11 @@
     }
   ],
   "outputs": {
-    "mastersSecurityGroupID": {
+    "masterSecurityGroupID": {
       "type": "string",
       "value": "[variables('masterSecurityGroupID')]"
     },
-    "workersSecurityGroupID": {
+    "workerSecurityGroupID": {
       "type": "string",
       "value": "[variables('workerSecurityGroupID')]"
     }

--- a/service/arm_templates/security_groups_setup.json
+++ b/service/arm_templates/security_groups_setup.json
@@ -12,16 +12,16 @@
     "clusterID": {
       "type": "string"
     },
-    "loadBalancerMastersCIDR": {
+    "masterLoadBalancerCidr": {
       "type": "string"
     },
-    "loadBalancerWorkersCIDR": {
+    "masterLoadBalancerCidr": {
       "type": "string"
     },
-    "subnetMastersCIDR": {
+    "masterSubnetCidr": {
       "type": "string"
     },
-    "subnetWorkersCIDR": {
+    "workerSubnetCidr": {
       "type": "string"
     },
     "kubernetesAPISecurePort": {
@@ -63,7 +63,7 @@
               "sourcePortRange": "*",
               "destinationPortRange": "*",
               "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "[parameters('subnetMastersCIDR')]",
+              "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
               "access": "Deny",
               "direction": "Inbound",
               "priority": "4096"
@@ -76,7 +76,7 @@
               "protocol": "*",
               "sourcePortRange": "*",
               "destinationPortRange": "*",
-              "sourceAddressPrefix": "[parameters('subnetMastersCIDR')]",
+              "sourceAddressPrefix": "[parameters('masterSubnetCidr')]",
               "destinationAddressPrefix": "*",
               "access": "Allow",
               "direction": "Outbound",
@@ -90,8 +90,8 @@
               "protocol": "*",
               "sourcePortRange": "*",
               "destinationPortRange": "*",
-              "sourceAddressPrefix": "[parameters('subnetMastersCIDR')]",
-              "destinationAddressPrefix": "[parameters('subnetMastersCIDR')]",
+              "sourceAddressPrefix": "[parameters('masterSubnetCidr')]",
+              "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
               "access": "Allow",
               "direction": "Inbound",
               "priority": "4094"
@@ -104,8 +104,8 @@
               "protocol": "tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('kubernetesAPISecurePort')]",
-              "sourceAddressPrefix": "[parameters('loadBalancerMastersCIDR')]",
-              "destinationAddressPrefix": "[parameters('subnetMastersCIDR')]",
+              "sourceAddressPrefix": "[parameters('masterLoadBalancerCidr')]",
+              "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
               "access": "Allow",
               "direction": "Inbound",
               "priority": "3900"
@@ -118,8 +118,8 @@
               "protocol": "tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('etcdPort')]",
-              "sourceAddressPrefix": "[parameters('loadBalancerMastersCIDR')]",
-              "destinationAddressPrefix": "[parameters('subnetMastersCIDR')]",
+              "sourceAddressPrefix": "[parameters('masterLoadBalancerCidr')]",
+              "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
               "access": "Allow",
               "direction": "Inbound",
               "priority": "3800"
@@ -132,8 +132,8 @@
               "protocol": "*",
               "sourcePortRange": "*",
               "destinationPortRange": "*",
-              "sourceAddressPrefix": "[parameters('subnetWorkersCIDR')]",
-              "destinationAddressPrefix": "[parameters('subnetMastersCIDR')]",
+              "sourceAddressPrefix": "[parameters('workerSubnetCidr')]",
+              "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
               "access": "Allow",
               "direction": "Inbound",
               "priority": "3700"
@@ -157,7 +157,7 @@
               "sourcePortRange": "*",
               "destinationPortRange": "*",
               "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "[parameters('subnetWorkersCIDR')]",
+              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
               "access": "Deny",
               "direction": "Inbound",
               "priority": "4096"
@@ -170,7 +170,7 @@
               "protocol": "*",
               "sourcePortRange": "*",
               "destinationPortRange": "*",
-              "sourceAddressPrefix": "[parameters('subnetWorkersCIDR')]",
+              "sourceAddressPrefix": "[parameters('workerSubnetCidr')]",
               "destinationAddressPrefix": "*",
               "access": "Allow",
               "direction": "Outbound",
@@ -184,8 +184,8 @@
               "protocol": "*",
               "sourcePortRange": "*",
               "destinationPortRange": "*",
-              "sourceAddressPrefix": "[parameters('subnetWorkersCIDR')]",
-              "destinationAddressPrefix": "[parameters('subnetWorkersCIDR')]",
+              "sourceAddressPrefix": "[parameters('workerSubnetCidr')]",
+              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
               "access": "Allow",
               "direction": "Inbound",
               "priority": "4094"
@@ -198,8 +198,8 @@
               "protocol": "tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('kubernetesIngressSecurePort')]",
-              "sourceAddressPrefix": "[parameters('loadBalancerWorkersCIDR')]",
-              "destinationAddressPrefix": "[parameters('subnetWorkersCIDR')]",
+              "sourceAddressPrefix": "[parameters('workerLoadBalancerCidr')]",
+              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
               "access": "Allow",
               "direction": "Inbound",
               "priority": "3900"
@@ -212,8 +212,8 @@
               "protocol": "tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('kubernetesIngressInsecurePort')]",
-              "sourceAddressPrefix": "[parameters('loadBalancerWorkersCIDR')]",
-              "destinationAddressPrefix": "[parameters('subnetWorkersCIDR')]",
+              "sourceAddressPrefix": "[parameters('workerLoadBalancerCidr')]",
+              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
               "access": "Allow",
               "direction": "Inbound",
               "priority": "3800"
@@ -226,8 +226,8 @@
               "protocol": "tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('kubernetesKubeletPort')]",
-              "sourceAddressPrefix": "[parameters('loadBalancerWorkersCIDR')]",
-              "destinationAddressPrefix": "[parameters('subnetWorkersCIDR')]",
+              "sourceAddressPrefix": "[parameters('workerLoadBalancerCidr')]",
+              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
               "access": "Allow",
               "direction": "Inbound",
               "priority": "3700"
@@ -240,8 +240,8 @@
               "protocol": "*",
               "sourcePortRange": "*",
               "destinationPortRange": "*",
-              "sourceAddressPrefix": "[parameters('subnetMastersCIDR')]",
-              "destinationAddressPrefix": "[parameters('subnetWorkersCIDR')]",
+              "sourceAddressPrefix": "[parameters('masterSubnetCidr')]",
+              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
               "access": "Allow",
               "direction": "Inbound",
               "priority": "3600"

--- a/service/arm_templates/security_groups_setup.json
+++ b/service/arm_templates/security_groups_setup.json
@@ -30,9 +30,6 @@
     "etcdPort": {
       "type": "string"
     },
-    "sshPort": {
-      "type": "string"
-    },
     "kubernetesIngressSecurePort": {
       "type": "string"
     },

--- a/service/arm_templates/security_groups_setup.json
+++ b/service/arm_templates/security_groups_setup.json
@@ -220,20 +220,6 @@
             }
           },
           {
-            "name": "workerLBToKubelet",
-            "properties": {
-              "description": "Allow the worker load balancer to reach the kubelet port.",
-              "protocol": "tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "[parameters('kubernetesKubeletPort')]",
-              "sourceAddressPrefix": "[parameters('workerLoadBalancerCidr')]",
-              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
-              "access": "Allow",
-              "direction": "Inbound",
-              "priority": "3700"
-            }
-          },
-          {
             "name": "masterSubnetToWorkerSubnet",
             "properties": {
               "description": "Allow the master machines to reach the worker machines on any ports.",

--- a/service/arm_templates/security_groups_setup.json
+++ b/service/arm_templates/security_groups_setup.json
@@ -4,7 +4,7 @@
   "parameters": {
     "networkSecurityGroupsAPIVersion": {
       "type": "string",
-      "defaultValue": "2017-03-01",
+      "defaultValue": "2016-09-01",
       "metadata": {
         "description": "API version used by the Microsoft.Network/networkSecurityGroups resource."
       }

--- a/service/arm_templates/security_groups_setup.json
+++ b/service/arm_templates/security_groups_setup.json
@@ -18,7 +18,7 @@
     "etcdLoadBalancerCidr": {
       "type": "string"
     },
-    "workerLoadBalancerCidr": {
+    "ingressLoadBalancerCidr": {
       "type": "string"
     },
     "masterSubnetCidr": {
@@ -192,13 +192,13 @@
             }
           },
           {
-            "name": "workerLBToIngressSecurePort",
+            "name": "ingressSecurePortRule",
             "properties": {
-              "description": "Allow the worker load balancer to reach the ingress controller secure port.",
+              "description": "Allow the ingress load balancer to reach the ingress controller secure port.",
               "protocol": "tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('kubernetesIngressSecurePort')]",
-              "sourceAddressPrefix": "[parameters('workerLoadBalancerCidr')]",
+              "sourceAddressPrefix": "[parameters('ingressLoadBalancerCidr')]",
               "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
               "access": "Allow",
               "direction": "Inbound",
@@ -206,13 +206,13 @@
             }
           },
           {
-            "name": "workerLBToIngressInsecurePort",
+            "name": "ingressInsecurePortRule",
             "properties": {
-              "description": "Allow the worker load balancer to reach the ingress controller insecure port.",
+              "description": "Allow the ingress load balancer to reach the ingress controller insecure port.",
               "protocol": "tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "[parameters('kubernetesIngressInsecurePort')]",
-              "sourceAddressPrefix": "[parameters('workerLoadBalancerCidr')]",
+              "sourceAddressPrefix": "[parameters('ingressLoadBalancerCidr')]",
               "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
               "access": "Allow",
               "direction": "Inbound",

--- a/service/arm_templates/security_groups_setup.json
+++ b/service/arm_templates/security_groups_setup.json
@@ -35,9 +35,6 @@
     },
     "kubernetesIngressInsecurePort": {
       "type": "string"
-    },
-    "kubernetesKubeletPort": {
-      "type": "string"
     }
   },
   "variables": {

--- a/service/arm_templates/virtual_network_setup.json
+++ b/service/arm_templates/virtual_network_setup.json
@@ -55,7 +55,7 @@
           {
             "name": "[variables('mastersSubnetName')]",
             "properties": {
-              "addressPrefix": "[parameters('subnetMasterCIDR')]",
+              "addressPrefix": "[parameters('subnetMastersCIDR')]",
               "networkSecurityGroup": {
                 "id": "[parameters('mastersSecurityGroupID')]"
               }
@@ -64,7 +64,7 @@
           {
             "name": "[variables('workersSubnetName')]",
             "properties": {
-              "addressPrefix": "[parameters('subnetWorkerCIDR')]",
+              "addressPrefix": "[parameters('subnetWorkersCIDR')]",
               "networkSecurityGroup": {
                 "id": "[parameters('workersSecurityGroupID')]"
               }

--- a/service/arm_templates/virtual_network_setup.json
+++ b/service/arm_templates/virtual_network_setup.json
@@ -7,7 +7,7 @@
     },
     "virtualNetworksAPIVersion": {
       "type": "string",
-      "defaultValue": "2017-03-01",
+      "defaultValue": "2016-09-01",
       "metadata": {
         "description": "API version used by the Microsoft.Network/virtualNetworks resource."
       }

--- a/service/arm_templates/virtual_network_setup.json
+++ b/service/arm_templates/virtual_network_setup.json
@@ -13,25 +13,13 @@
       }
     },
     "addressPrefix": {
-      "type": "string",
-      "defaultValue": "10.0.0.0/16",
-      "metadata": {
-        "description": "The main address block reserved for this virtual network."
-      }
+      "type": "string"
     },
-    "subnetMasterCIDR": {
-      "type": "string",
-      "defaultValue": "10.0.1.0/24",
-      "metadata": {
-        "description": "The CIDR block for the Kubernetes masters' subnet"
-      }
+    "subnetMastersCIDR": {
+      "type": "string"
     },
-    "subnetWorkerCIDR": {
-      "type": "string",
-      "defaultValue": "10.0.2.0/24",
-      "metadata": {
-        "description": "The CIDR block for the Kubernetes workers' subnet"
-      }
+    "subnetWorkersCIDR": {
+      "type": "string"
     },
     "mastersSecurityGroupID": {
       "type": "string"

--- a/service/arm_templates/virtual_network_setup.json
+++ b/service/arm_templates/virtual_network_setup.json
@@ -12,7 +12,7 @@
         "description": "API version used by the Microsoft.Network/virtualNetworks resource."
       }
     },
-    "mainCidr": {
+    "virtualNetworkCidr": {
       "type": "string"
     },
     "masterSubnetCidr": {
@@ -48,7 +48,7 @@
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('mainCidr')]"
+            "[parameters('virtualNetworkCidr')]"
           ]
         },
         "subnets": [

--- a/service/arm_templates/virtual_network_setup.json
+++ b/service/arm_templates/virtual_network_setup.json
@@ -12,13 +12,13 @@
         "description": "API version used by the Microsoft.Network/virtualNetworks resource."
       }
     },
-    "addressPrefix": {
+    "mainCidr": {
       "type": "string"
     },
-    "subnetMastersCIDR": {
+    "masterSubnetCidr": {
       "type": "string"
     },
-    "subnetWorkersCIDR": {
+    "workerSubnetCidr": {
       "type": "string"
     },
     "mastersSecurityGroupID": {
@@ -48,14 +48,14 @@
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('addressPrefix')]"
+            "[parameters('mainCidr')]"
           ]
         },
         "subnets": [
           {
             "name": "[variables('mastersSubnetName')]",
             "properties": {
-              "addressPrefix": "[parameters('subnetMastersCIDR')]",
+              "addressPrefix": "[parameters('masterSubnetCidr')]",
               "networkSecurityGroup": {
                 "id": "[parameters('mastersSecurityGroupID')]"
               }
@@ -64,7 +64,7 @@
           {
             "name": "[variables('workersSubnetName')]",
             "properties": {
-              "addressPrefix": "[parameters('subnetWorkersCIDR')]",
+              "addressPrefix": "[parameters('workerSubnetCidr')]",
               "networkSecurityGroup": {
                 "id": "[parameters('workersSecurityGroupID')]"
               }

--- a/service/arm_templates/virtual_network_setup.json
+++ b/service/arm_templates/virtual_network_setup.json
@@ -21,10 +21,10 @@
     "workerSubnetCidr": {
       "type": "string"
     },
-    "mastersSecurityGroupID": {
+    "masterSecurityGroupID": {
       "type": "string"
     },
-    "workersSecurityGroupID": {
+    "workerSecurityGroupID": {
       "type": "string"
     }
   },
@@ -32,11 +32,11 @@
     "virtualNetworkName": "[concat(parameters('clusterID'), '-VirtualNetwork')]",
     "virtualNetworkID": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
 
-    "mastersSubnetName": "[concat(variables('virtualNetworkName'), '-MastersSubnet')]",
-    "mastersSubnetID": "[concat(variables('virtualNetworkID'), '/subnets/', variables('mastersSubnetName'))]",
+    "masterSubnetName": "[concat(variables('virtualNetworkName'), '-MasterSubnet')]",
+    "masterSubnetID": "[concat(variables('virtualNetworkID'), '/subnets/', variables('masterSubnetName'))]",
 
-    "workersSubnetName": "[concat(variables('virtualNetworkName'), '-WorkersSubnet')]",
-    "workersSubnetID": "[concat(variables('virtualNetworkID'), '/subnets/', variables('workersSubnetName'))]"
+    "workerSubnetName": "[concat(variables('virtualNetworkName'), '-WorkerSubnet')]",
+    "workerSubnetID": "[concat(variables('virtualNetworkID'), '/subnets/', variables('workerSubnetName'))]"
 
   },
   "resources": [
@@ -53,20 +53,20 @@
         },
         "subnets": [
           {
-            "name": "[variables('mastersSubnetName')]",
+            "name": "[variables('masterSubnetName')]",
             "properties": {
               "addressPrefix": "[parameters('masterSubnetCidr')]",
               "networkSecurityGroup": {
-                "id": "[parameters('mastersSecurityGroupID')]"
+                "id": "[parameters('masterSecurityGroupID')]"
               }
             }
           },
           {
-            "name": "[variables('workersSubnetName')]",
+            "name": "[variables('workerSubnetName')]",
             "properties": {
               "addressPrefix": "[parameters('workerSubnetCidr')]",
               "networkSecurityGroup": {
-                "id": "[parameters('workersSecurityGroupID')]"
+                "id": "[parameters('workerSecurityGroupID')]"
               }
             }
           }
@@ -79,13 +79,13 @@
       "type": "string",
       "value": "[variables('virtualNetworkID')]"
     },
-    "mastersSubnetID": {
+    "masterSubnetID": {
       "type": "string",
-      "value": "[variables('mastersSubnetID')]"
+      "value": "[variables('masterSubnetID')]"
     },
-    "workersSubnetID": {
+    "workerSubnetID": {
       "type": "string",
-      "value": "[variables('workersSubnetID')]"
+      "value": "[variables('workerSubnetID')]"
     }
   }
 }


### PR DESCRIPTION
It is now possible to call the template main.json to deploy the cluster_setup.json, security_groups_setup.json and virtual_network_setup.json templates.

If you want to test it with the azure-cli, you'll only have to provide the clusterID, masterLoadBalancerCidr and workerLoadBalancerCidr parameters since they don't have defaults. If you have an idea of what a good default address could be for the 2 loadbalancers, let me know.

I also tried matching the templates' parameters to the azuretpr [structures elements](https://github.com/giantswarm/azuretpr/tree/39b23dfc8bebc3a706b3b8dd286a3612e0fe35b2/spec/azure). 

I think an important part to review is the [parameters block](https://github.com/giantswarm/azure-operator/pull/16/files#diff-bdfeb20a499ae8d7abc02b96a7ec37a5R4) in the main template to define good parameters names that will be used in the templates as well as in the tpr.