### PR TITLE
Fix script name for get secrets unit

### DIFF
--- a/service/cloudconfig/template.go
+++ b/service/cloudconfig/template.go
@@ -3,7 +3,7 @@ package cloudconfig
 const (
 	fileOwner                  = "root:root"
 	filePermission             = 0700
-	getKeyVaultSecretsFileName = "/opt/bin/get-key-vault-secrets"
+	getKeyVaultSecretsFileName = "/opt/bin/get-keyvault-secrets"
 	getKeyVaultSecretsTemplate = `#!/bin/bash -e
 
 KEY_VAULT_HOST={{ .VaultName }}.vault.azure.net


### PR DESCRIPTION
Fixes a problem with the `get-keyvault-secrets.service` it should be called `/opt/bin/get-keyvault-secrets` to match the unit. Thanks for spotting this @Cocotton! 