### PR TITLE
service: set template URI version to the git SHA

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,10 +16,14 @@ import (
 	"github.com/giantswarm/azure-operator/service"
 )
 
+const (
+	notAvailable = "n/a"
+)
+
 var (
 	description string     = "The azure-operator manages Kubernetes clusters on Azure."
 	f           *flag.Flag = flag.New()
-	gitCommit   string     = "n/a"
+	gitCommit   string     = notAvailable
 	name        string     = "azure-operator"
 	source      string     = "https://github.com/giantswarm/azure-operator"
 )
@@ -121,13 +125,20 @@ func main() {
 		}
 	}
 
+	var defaultTemplateVersion string
+	{
+		if gitCommit != notAvailable {
+			defaultTemplateVersion = gitCommit
+		}
+	}
+
 	daemonCommand := newCommand.DaemonCommand().CobraCommand()
 
 	daemonCommand.PersistentFlags().String(f.Service.Azure.ClientID, "", "ID of the Active Directory Service Principal.")
 	daemonCommand.PersistentFlags().String(f.Service.Azure.ClientSecret, "", "Secret of the Active Directory Service Principal.")
 	daemonCommand.PersistentFlags().String(f.Service.Azure.SubscriptionID, "", "ID of the Azure Subscription.")
 	daemonCommand.PersistentFlags().String(f.Service.Azure.TenantID, "", "ID of the Active Directory Tenant.")
-	daemonCommand.PersistentFlags().String(f.Service.Azure.Template.URI.Version, "master", "URI version for ARM template links.")
+	daemonCommand.PersistentFlags().String(f.Service.Azure.Template.URI.Version, defaultTemplateVersion, "URI version for ARM template links.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.Address, "", "Address used to connect to Kubernetes. When empty in-cluster config is created.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Kubernetes.InCluster, true, "Whether to use the in-cluster config to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CAFile, "", "Certificate authority file path to use to authenticate with Kubernetes.")

--- a/service/resource/deployment/resource.go
+++ b/service/resource/deployment/resource.go
@@ -53,7 +53,7 @@ func DefaultConfig() Config {
 
 		// Settings.
 
-		TemplateVersion: templateVersionDefault,
+		TemplateVersion: "",
 	}
 }
 

--- a/service/resource/deployment/resource_test.go
+++ b/service/resource/deployment/resource_test.go
@@ -52,6 +52,7 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 		resourceConfig.CertWatcher = certificatetprtest.NewService()
 		resourceConfig.CloudConfig = cloudConfigService
 		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.TemplateVersion = "master"
 		newResource, err = New(resourceConfig)
 		if err != nil {
 			t.Fatalf("expected '%v' got '%#v'", nil, err)
@@ -183,6 +184,7 @@ func Test_Resource_Deployment_newCreateChange(t *testing.T) {
 		resourceConfig.CertWatcher = certificatetprtest.NewService()
 		resourceConfig.CloudConfig = cloudConfigService
 		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.TemplateVersion = "master"
 		newResource, err = New(resourceConfig)
 		if err != nil {
 			t.Fatalf("expected '%#v' got '%#v'", nil, err)

--- a/service/resource/deployment/template.go
+++ b/service/resource/deployment/template.go
@@ -5,9 +5,6 @@ import "fmt"
 const (
 	templateURIFmt = "https://raw.githubusercontent.com/giantswarm/azure-operator/%s/service/arm_templates/%s"
 
-	// templateVersionDefault is the default value for Config.TemplateVersion.
-	templateVersionDefault = "master"
-
 	mainTemplate = "main.json"
 )
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/azure-operator/issues/30

Pointing to master was unpredictable as changes may be merged any time.
Now when templates are changed we need to redeploy the operator as well.