### PR TITLE
Set a default backoff framework backoff configuration

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -156,6 +156,7 @@ func New(config Config) (*Service, error) {
 	{
 		frameworkConfig := framework.DefaultConfig()
 
+		frameworkConfig.BackOff = backoff.NewExponentialBackOff()
 		frameworkConfig.Logger = config.Logger
 		frameworkConfig.Resources = []framework.Resource{
 			resourceGroupResource,


### PR DESCRIPTION
This fixes the operator. Otherwise, it would complain anout the BackOff configuration being empty and would fail.