### PR TITLE
Adds Helm chart

### DIFF
--- a/helm/azure-operator-chart/Chart.yaml
+++ b/helm/azure-operator-chart/Chart.yaml
@@ -1,0 +1,2 @@
+name: azure-operator-chart
+version: 1.0.0-[[ .SHA ]]

--- a/helm/azure-operator-chart/templates/configmap.yaml
+++ b/helm/azure-operator-chart/templates/configmap.yaml
@@ -8,10 +8,5 @@ data:
     server:
       listen:
         address: 'http://0.0.0.0:8000'
-    service:
-      azure:
-        template:
-          uri:
-            version: "master"
       kubernetes:
         incluster: true

--- a/helm/azure-operator-chart/templates/configmap.yaml
+++ b/helm/azure-operator-chart/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: azure-operator-configmap
+  namespace: giantswarm
+data:
+  config.yaml: |
+    server:
+      listen:
+        address: 'http://0.0.0.0:8000'
+    service:
+      azure:
+        template:
+          uri:
+            version: "master"
+      kubernetes:
+        incluster: true

--- a/helm/azure-operator-chart/templates/deployment.yaml
+++ b/helm/azure-operator-chart/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: azure-operator
+  namespace: giantswarm
+  labels:
+    app: azure-operator
+spec:
+  replicas: 1
+  revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: azure-operator
+    spec:
+      volumes:
+      - name: azure-operator-configmap
+        configMap:
+          name: azure-operator-configmap
+          items:
+          - key: config.yaml
+            path: config.yaml
+      - name: azure-operator-secret
+        secret:
+          secretName: azure-operator-secret
+          items:
+          - key: secret.yaml
+            path: secret.yaml
+      - name: certs
+        hostPath:
+          path: /etc/ssl/certs/ca-certificates.crt
+      containers:
+      - name: azure-operator
+        image: quay.io/giantswarm/azure-operator:[[ .SHA ]]
+        volumeMounts:
+        - name: azure-operator-configmap
+          mountPath: /var/run/azure-operator/configmap/
+        - name: azure-operator-secret
+          mountPath: /var/run/azure-operator/secret/
+          readOnly: true
+        - name: certs
+          mountPath: /etc/ssl/certs/ca-certificates.crt
+          readOnly: true
+        ports:
+        - name: http
+          containerPort: 8000
+        args:
+        - daemon
+        - --config.dirs=/var/run/azure-operator/configmap/
+        - --config.dirs=/var/run/azure-operator/secret/
+        - --config.files=config
+        - --config.files=secret
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8000
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 20Mi
+          limits:
+            cpu: 250m
+            memory: 250Mi
+      imagePullSecrets:
+      - name: azure-operator-pull-secret

--- a/helm/azure-operator-chart/templates/deployment.yaml
+++ b/helm/azure-operator-chart/templates/deployment.yaml
@@ -54,8 +54,8 @@ spec:
         - --config.files=secret
         resources:
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 250m
+            memory: 250Mi
           limits:
             cpu: 250m
             memory: 250Mi

--- a/helm/azure-operator-chart/templates/deployment.yaml
+++ b/helm/azure-operator-chart/templates/deployment.yaml
@@ -52,18 +52,6 @@ spec:
         - --config.dirs=/var/run/azure-operator/secret/
         - --config.files=config
         - --config.files=secret
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8000
-          initialDelaySeconds: 15
-          timeoutSeconds: 1
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8000
-          initialDelaySeconds: 15
-          timeoutSeconds: 1
         resources:
           requests:
             cpu: 100m

--- a/helm/azure-operator-chart/templates/pull-secret.yml
+++ b/helm/azure-operator-chart/templates/pull-secret.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/dockerconfigjson
+metadata:
+  name: azure-operator-pull-secret
+  namespace: giantswarm
+data:
+  .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}

--- a/helm/azure-operator-chart/templates/secret.yaml
+++ b/helm/azure-operator-chart/templates/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: azure-operator-secret
+  namespace: giantswarm
+data:
+  secret.yaml: {{ .Values.Installation.V1.Secret.AzureOperator.SecretYaml | b64enc | quote }}

--- a/helm/azure-operator-chart/templates/service.yaml
+++ b/helm/azure-operator-chart/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: azure-operator
+  namespace: giantswarm
+  labels:
+    app: azure-operator
+spec:
+  type: NodePort
+  ports:
+  - port: 8000
+  selector:
+    app: azure-operator


### PR DESCRIPTION
Minimal drop required to use in `gollum` Azure host cluster.

Related change: https://github.com/giantswarm/installations/pull/153