### PR TITLE
service: remove viper dependency in subpackages

### DIFF
--- a/service/cloudconfig/service.go
+++ b/service/cloudconfig/service.go
@@ -7,9 +7,6 @@ import (
 	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_0_1_0"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/spf13/viper"
-
-	"github.com/giantswarm/azure-operator/flag"
 )
 
 // Config represents the configuration used to create a cloudconfig service.
@@ -17,11 +14,6 @@ type Config struct {
 	// Dependencies.
 
 	Logger micrologger.Logger
-
-	// Settings.
-
-	Flag  *flag.Flag
-	Viper *viper.Viper
 }
 
 // DefaultConfig provides a default configuration to create a new cloudconfig service
@@ -30,10 +22,6 @@ func DefaultConfig() Config {
 	return Config{
 		// Dependencies.
 		Logger: nil,
-
-		// Settings.
-		Flag:  nil,
-		Viper: nil,
 	}
 }
 
@@ -48,14 +36,6 @@ func New(config Config) (*CloudConfig, error) {
 	// Dependencies.
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "logger must not be empty")
-	}
-
-	// Settings.
-	if config.Flag == nil {
-		return nil, microerror.Maskf(invalidConfigError, "flag must not be empty")
-	}
-	if config.Viper == nil {
-		return nil, microerror.Maskf(invalidConfigError, "viper must not be empty")
 	}
 
 	newService := &CloudConfig{

--- a/service/operator/framework.go
+++ b/service/operator/framework.go
@@ -30,9 +30,7 @@ func newFramework(config Config) (*framework.Framework, error) {
 	var cloudConfigService *cloudconfig.CloudConfig
 	{
 		cloudConfigConfig := cloudconfig.DefaultConfig()
-		cloudConfigConfig.Flag = config.Flag
 		cloudConfigConfig.Logger = config.Logger
-		cloudConfigConfig.Viper = config.Viper
 
 		cloudConfigService, err = cloudconfig.New(cloudConfigConfig)
 		if err != nil {
@@ -55,7 +53,7 @@ func newFramework(config Config) (*framework.Framework, error) {
 	var deploymentResource framework.Resource
 	{
 		deploymentConfig := deployment.DefaultConfig()
-		deploymentConfig.TemplateVersion = config.Viper.GetString(config.Flag.Service.Azure.Template.URI.Version)
+		deploymentConfig.TemplateVersion = config.TemplateVersion
 		deploymentConfig.AzureConfig = config.AzureConfig
 		deploymentConfig.CertWatcher = certWatcher
 		deploymentConfig.CloudConfig = cloudConfigService

--- a/service/operator/service.go
+++ b/service/operator/service.go
@@ -6,11 +6,9 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/framework"
-	"github.com/spf13/viper"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/azure-operator/client"
-	"github.com/giantswarm/azure-operator/flag"
 )
 
 // Config represents the configuration used to create an Operator service.
@@ -24,8 +22,7 @@ type Config struct {
 
 	// Settings.
 
-	Flag  *flag.Flag
-	Viper *viper.Viper
+	TemplateVersion string
 }
 
 // DefaultConfig provides a default configuration to create a new operator
@@ -36,10 +33,6 @@ func DefaultConfig() Config {
 		AzureConfig: nil,
 		K8sClient:   nil,
 		Logger:      nil,
-
-		// Settings.
-		Flag:  nil,
-		Viper: nil,
 	}
 }
 
@@ -69,11 +62,8 @@ func New(config Config) (*Service, error) {
 	}
 
 	// Settings.
-	if config.Flag == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.Flag must not be empty")
-	}
-	if config.Viper == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.Viper must not be empty")
+	if config.TemplateVersion == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.TemplateVersion must not be empty")
 	}
 
 	operatorFramework, err := newFramework(config)

--- a/service/resource/deployment/resource_test.go
+++ b/service/resource/deployment/resource_test.go
@@ -10,10 +10,8 @@ import (
 	"github.com/giantswarm/clustertpr"
 	"github.com/giantswarm/clustertpr/spec"
 	"github.com/giantswarm/micrologger/microloggertest"
-	"github.com/spf13/viper"
 
 	"github.com/giantswarm/azure-operator/client"
-	"github.com/giantswarm/azure-operator/flag"
 	"github.com/giantswarm/azure-operator/service/cloudconfig"
 )
 
@@ -38,9 +36,7 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 	var newResource *Resource
 	{
 		cloudConfigConfig := cloudconfig.DefaultConfig()
-		cloudConfigConfig.Flag = flag.New()
 		cloudConfigConfig.Logger = microloggertest.New()
-		cloudConfigConfig.Viper = viper.New()
 
 		cloudConfigService, err := cloudconfig.New(cloudConfigConfig)
 		if err != nil {
@@ -170,9 +166,7 @@ func Test_Resource_Deployment_newCreateChange(t *testing.T) {
 	var newResource *Resource
 	{
 		cloudConfigConfig := cloudconfig.DefaultConfig()
-		cloudConfigConfig.Flag = flag.New()
 		cloudConfigConfig.Logger = microloggertest.New()
-		cloudConfigConfig.Viper = viper.New()
 
 		cloudConfigService, err := cloudconfig.New(cloudConfigConfig)
 		if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -98,10 +98,8 @@ func New(config Config) (*Service, error) {
 	{
 		operatorConfig := operator.DefaultConfig()
 		operatorConfig.AzureConfig = azureConfig
-		operatorConfig.Flag = config.Flag
 		operatorConfig.K8sClient = k8sClient
-		operatorConfig.Logger = config.Logger
-		operatorConfig.Viper = config.Viper
+		operatorConfig.TemplateVersion = config.Viper.GetString(config.Flag.Service.Azure.Template.URI.Version)
 
 		operatorService, err = operator.New(operatorConfig)
 		if err != nil {


### PR DESCRIPTION
I think having Viper and Flag spread across packages isn't nice. It's confusing and makes test setup harder. Now only service package has knowledge how to deal with that. It wires dependencies and passes them to the subpackages.