### PR TITLE
Msi roles assignment

### DIFF
--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -438,7 +438,8 @@
           "osImageSKU": {"value": "[parameters('mastersCustomConfig')[copyIndex()].osImage.sku]"},
           "osImageVersion": {"value": "[parameters('mastersCustomConfig')[copyIndex()].osImage.version]"},
           "cloudConfigData": {"value": "[parameters('masterCloudConfigData')]"},
-          "loadBalancerBackendPoolIDs": {"value": "[createArray(reference('api_load_balancer_setup').outputs.loadBalancerBackendPoolID.value)]"}
+          "loadBalancerBackendPoolIDs": {"value": "[createArray(reference('api_load_balancer_setup').outputs.loadBalancerBackendPoolID.value)]"},
+          "assignContributorRole": {"value": "[bool('true')]"}
         }
       }
     },
@@ -472,7 +473,8 @@
           "osImageSKU": {"value": "[parameters('workersCustomConfig')[copyIndex()].osImage.sku]"},
           "osImageVersion": {"value": "[parameters('workersCustomConfig')[copyIndex()].osImage.version]"},
           "cloudConfigData": {"value": "[parameters('workerCloudConfigData')]"},
-          "loadBalancerBackendPoolIDs": {"value": "[createArray(reference('ingress_load_balancer_setup').outputs.loadBalancerBackendPoolID.value)]"}
+          "loadBalancerBackendPoolIDs": {"value": "[createArray(reference('ingress_load_balancer_setup').outputs.loadBalancerBackendPoolID.value)]"},
+          "assignContributorRole": {"value": "[bool('false')]"}
         }
       }
     }

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -438,8 +438,7 @@
           "osImageSKU": {"value": "[parameters('mastersCustomConfig')[copyIndex()].osImage.sku]"},
           "osImageVersion": {"value": "[parameters('mastersCustomConfig')[copyIndex()].osImage.version]"},
           "cloudConfigData": {"value": "[parameters('masterCloudConfigData')]"},
-          "loadBalancerBackendPoolIDs": {"value": "[createArray(reference('api_load_balancer_setup').outputs.loadBalancerBackendPoolID.value)]"},
-          "assignContributorRole": {"value": "[bool('true')]"}
+          "loadBalancerBackendPoolIDs": {"value": "[createArray(reference('api_load_balancer_setup').outputs.loadBalancerBackendPoolID.value)]"}
         }
       }
     },
@@ -473,8 +472,7 @@
           "osImageSKU": {"value": "[parameters('workersCustomConfig')[copyIndex()].osImage.sku]"},
           "osImageVersion": {"value": "[parameters('workersCustomConfig')[copyIndex()].osImage.version]"},
           "cloudConfigData": {"value": "[parameters('workerCloudConfigData')]"},
-          "loadBalancerBackendPoolIDs": {"value": "[createArray(reference('ingress_load_balancer_setup').outputs.loadBalancerBackendPoolID.value)]"},
-          "assignContributorRole": {"value": "[bool('false')]"}
+          "loadBalancerBackendPoolIDs": {"value": "[createArray(reference('ingress_load_balancer_setup').outputs.loadBalancerBackendPoolID.value)]"}
         }
       }
     }

--- a/service/arm_templates/node_setup.json
+++ b/service/arm_templates/node_setup.json
@@ -23,6 +23,13 @@
         "description": "API version used by the Microsoft.Compute/virtualMachines/extensions resource."
       }
     },
+    "roleAssignmentsAPIVersion": {
+      "type": "string",
+      "defaultValue": "2016-09-01",
+      "metadata": {
+        "description": "API version used by the Microsoft.Authorization/roleAssignments resource."
+      }
+    },
     "clusterID": {
       "type": "string"
     },
@@ -71,6 +78,13 @@
     },
     "loadBalancerBackendPoolIDs": {
       "type": "array"
+    },
+    "contributorRoleDefinitionId": {
+      "type": "string",
+      "defaultValue": "b24988ac-6180-42a0-ab88-20f7382dd24c",
+      "metadata": {
+        "description": "The ID of the contributor role."
+      }
     }
   },
   "variables": {
@@ -79,7 +93,8 @@
     "nicName": "[concat(parameters('clusterID'), '-', parameters('prefix'),'-NIC')]",
     "vmName": "[concat(parameters('clusterID'), '-', parameters('prefix'))]",
     "osDiskName": "[concat(parameters('clusterID'), '-', parameters('prefix'), '-OSDisk')]",
-    "dataDiskName": "[concat(parameters('clusterID'), '-', parameters('prefix') ,'-DataDisk')]"
+    "dataDiskName": "[concat(parameters('clusterID'), '-', parameters('prefix') ,'-DataDisk')]",
+    "contributorRoleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', parameters('contributorRoleDefinitionId'))]"
   },
   "resources": [
     {
@@ -192,12 +207,12 @@
       }
     },
     {
+      "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2014-10-01-preview",
       "name": "[concat(variables('vmName'), '-RoleAssignment')]",
-      "type": "Microsoft.Authorization/roleAssignments",
       "properties": {
-        "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-        "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('vmName')), '2017-03-30', 'Full').identity.principalId]"
+        "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
+        "principalId": "[reference(concat(resourceId('Microsoft.Compute/virtualMachines/', variables('vmName')), '/providers/Microsoft.ManagedIdentity/Identities/default'), '2015-08-31-PREVIEW').principalId]"
       }
     }
   ],

--- a/service/arm_templates/node_setup.json
+++ b/service/arm_templates/node_setup.json
@@ -190,6 +190,15 @@
           ]
         }
       }
+    },
+    {
+      "apiVersion": "2014-10-01-preview",
+      "name": "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), '-Identity')]",
+      "type": "Microsoft.Authorization/roleAssignments",
+      "properties": {
+        "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+        "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex()), '2017-03-30', 'Full').identity.principalId]"
+      }
     }
   ],
   "outputs": {

--- a/service/arm_templates/node_setup.json
+++ b/service/arm_templates/node_setup.json
@@ -193,7 +193,7 @@
     },
     {
       "apiVersion": "2014-10-01-preview",
-      "name": "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), '-Identity')]",
+      "name": "[concat(variables('vmName'), '-RoleAssignment')]",
       "type": "Microsoft.Authorization/roleAssignments",
       "properties": {
         "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",

--- a/service/arm_templates/node_setup.json
+++ b/service/arm_templates/node_setup.json
@@ -79,9 +79,6 @@
     "loadBalancerBackendPoolIDs": {
       "type": "array"
     },
-    "assignContributorRole": {
-      "type": "bool"
-    },
     "contributorRoleDefinitionId": {
       "type": "string",
       "defaultValue": "b24988ac-6180-42a0-ab88-20f7382dd24c",
@@ -214,7 +211,6 @@
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2014-10-01-preview",
       "name": "[variables('roleAssignmentName')]",
-      "condition": "[and(parameters('assignContributorRole'), bool('true'))]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
       ],

--- a/service/arm_templates/node_setup.json
+++ b/service/arm_templates/node_setup.json
@@ -97,6 +97,7 @@
     "vmName": "[concat(parameters('clusterID'), '-', parameters('prefix'))]",
     "osDiskName": "[concat(parameters('clusterID'), '-', parameters('prefix'), '-OSDisk')]",
     "dataDiskName": "[concat(parameters('clusterID'), '-', parameters('prefix') ,'-DataDisk')]",
+    "roleAssignmentName": "[concat(parameters('clusterID'), '-', parameters('prefix') ,'-RoleAssignment')]",
     "contributorRoleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', parameters('contributorRoleDefinitionId'))]"
   },
   "resources": [
@@ -212,7 +213,7 @@
     {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2014-10-01-preview",
-      "name": "[concat(variables('vmName'), '-RoleAssignment')]",
+      "name": "[variables('roleAssignmentName')]",
       "condition": "[and(parameters('assignContributorRole'), bool('true'))]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/service/arm_templates/node_setup.json
+++ b/service/arm_templates/node_setup.json
@@ -79,6 +79,9 @@
     "loadBalancerBackendPoolIDs": {
       "type": "array"
     },
+    "assignContributorRole": {
+      "type": "bool"
+    },
     "contributorRoleDefinitionId": {
       "type": "string",
       "defaultValue": "b24988ac-6180-42a0-ab88-20f7382dd24c",
@@ -210,6 +213,10 @@
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2014-10-01-preview",
       "name": "[concat(variables('vmName'), '-RoleAssignment')]",
+      "condition": "[and(parameters('assignContributorRole'), bool('true'))]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
+      ],
       "properties": {
         "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
         "principalId": "[reference(concat(resourceId('Microsoft.Compute/virtualMachines/', variables('vmName')), '/providers/Microsoft.ManagedIdentity/Identities/default'), '2015-08-31-PREVIEW').principalId]"

--- a/service/arm_templates/node_setup.json
+++ b/service/arm_templates/node_setup.json
@@ -197,7 +197,7 @@
       "type": "Microsoft.Authorization/roleAssignments",
       "properties": {
         "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-        "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex()), '2017-03-30', 'Full').identity.principalId]"
+        "principalId": "[reference(concat('Microsoft.Compute/virtualMachines/', variables('vmName')), '2017-03-30', 'Full').identity.principalId]"
       }
     }
   ],


### PR DESCRIPTION
This PR adds the parameter `assignContributorRole` to the node_setup.json template.

When passing `true`, to node is assigned the "contributor role" in the resource group.

I added that flag because I was not sure we wanted to give that role to the worker nodes.

Unfortunately, I cannot test this completely because I don't have the permission to give the contributor role to a VM. See the following error
```
The client 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX' with object id 'XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX' does not have permission to perform action 'Microsoft.Authorization/roleAssignments/write'
```