### PR TITLE
Fix msi rbac

### DIFF
--- a/service/arm_templates/node_setup.json
+++ b/service/arm_templates/node_setup.json
@@ -210,7 +210,7 @@
     {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2014-10-01-preview",
-      "name": "[variables('roleAssignmentName')]",
+      "name": "[guid(variables('roleAssignmentName'))]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
       ],


### PR DESCRIPTION
- Fix role assignment. Azure complained about name, because it should be in `guid` format.
- We need additional role for azure-operator account to assign MSI roles. Added section how to create azure-operator service principal and assign additional role.