### PR TITLE
deployment,resourcegroup: increase timeouts to 30m

### DIFF
--- a/service/resource/deployment/resource.go
+++ b/service/resource/deployment/resource.go
@@ -22,7 +22,7 @@ const (
 	// Name is the identifier of the resource.
 	Name = "deployment"
 
-	createTimeout = 5 * time.Minute
+	createTimeout = 30 * time.Minute
 )
 
 type Config struct {

--- a/service/resource/resourcegroup/resource.go
+++ b/service/resource/resourcegroup/resource.go
@@ -21,7 +21,7 @@ const (
 
 	clusterIDTag  = "ClusterID"
 	customerIDTag = "CustomerID"
-	deleteTimeout = 5 * time.Minute
+	deleteTimeout = 30 * time.Minute
 	managedBy     = "azure-operator"
 )
 


### PR DESCRIPTION
Number of resources we create is much bigger than in the beginning.
Right now creation/deletion takes often >20m.

Hopefully this decrease after we remove storage account resource.