### PR TITLE
cloudconfig: extract loopbackAddr const

### DIFF
--- a/service/cloudconfig/service.go
+++ b/service/cloudconfig/service.go
@@ -21,7 +21,7 @@ const (
 	// TODO: use randomkeys to fill the value properly.
 	apiserverEncryptionKey = "UShZb2zOWvY5Svkf8+oSSa0dEZxprPWz0xYYsAsFuP0="
 
-	// loopbackAddr is used to set varioius cloud config template
+	// loopbackAddr is used to set various cloud config template
 	// parameters to work around Azure load balancers limitation.
 	loopbackAddr = "127.0.0.1"
 )

--- a/service/cloudconfig/service.go
+++ b/service/cloudconfig/service.go
@@ -15,11 +15,15 @@ import (
 )
 
 const (
-	// apiserverEncryptionKey is **insecure** encryption key just to satisfy newest
-	// master of k8scloudconfigs.
+	// apiserverEncryptionKey is **insecure** encryption key just to
+	// satisfy newest master of k8scloudconfigs.
 	//
 	// TODO: use randomkeys to fill the value properly.
 	apiserverEncryptionKey = "UShZb2zOWvY5Svkf8+oSSa0dEZxprPWz0xYYsAsFuP0="
+
+	// loopbackAddr is used to set varioius cloud config template
+	// parameters to work around Azure load balancers limitation.
+	loopbackAddr = "127.0.0.1"
 )
 
 // Config represents the configuration used to create a cloudconfig service.
@@ -128,7 +132,7 @@ func (c CloudConfig) NewMasterCloudConfig(customObject providerv1alpha1.AzureCon
 		ExtraManifests: []string{
 			"calico-azure.yaml",
 		},
-		MasterAPIDomain: "127.0.0.1",
+		MasterAPIDomain: loopbackAddr,
 	}
 
 	return newCloudConfig(k8scloudconfig.MasterTemplate, params)
@@ -156,7 +160,7 @@ func (c CloudConfig) NewWorkerCloudConfig(customObject providerv1alpha1.AzureCon
 			AzureConfig:  c.azureConfig,
 			CustomObject: customObject,
 		},
-		MasterAPIDomain: "127.0.0.1",
+		MasterAPIDomain: loopbackAddr,
 	}
 
 	return newCloudConfig(k8scloudconfig.WorkerTemplate, params)


### PR DESCRIPTION
This is to enable clean removal in the future. When removing const and
there is still some loopback address left, the code will not compile.