### PR TITLE
client,dnsrecord: use mgmt/2017-09-01/dns package

### DIFF
--- a/client/azure.go
+++ b/client/azure.go
@@ -7,8 +7,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
-	"github.com/Azure/azure-sdk-for-go/arm/dns"
 	"github.com/Azure/azure-sdk-for-go/arm/resources/resources"
+	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2017-09-01/dns"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"

--- a/service/resource/dnsrecord/current.go
+++ b/service/resource/dnsrecord/current.go
@@ -3,7 +3,7 @@ package dnsrecord
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/arm/dns"
+	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2017-09-01/dns"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/azure-operator/client"
 	"github.com/giantswarm/azure-operator/service/key"
@@ -28,7 +28,7 @@ func (r *Resource) getCurrentState(ctx context.Context, obj providerv1alpha1.Azu
 	current := newPartialDNSRecords(obj)
 
 	for i, record := range current {
-		resp, err := recordSetsClient.Get(record.ZoneRG, record.Zone, record.RelativeName, dns.NS)
+		resp, err := recordSetsClient.Get(ctx, record.ZoneRG, record.Zone, record.RelativeName, dns.NS)
 		if client.ResponseWasNotFound(resp.Response) {
 			continue
 		} else if err != nil {

--- a/service/resource/dnsrecord/delete.go
+++ b/service/resource/dnsrecord/delete.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/arm/dns"
+	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2017-09-01/dns"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/azure-operator/service/key"
 	"github.com/giantswarm/microerror"
@@ -41,7 +41,7 @@ func (r *Resource) applyDeleteChange(ctx context.Context, obj providerv1alpha1.A
 	for _, record := range change {
 		r.logger.LogCtx(ctx, "debug", fmt.Sprintf("deleting host cluster DNS record=%#v", record))
 
-		_, err := recordSetsClient.Delete(record.ZoneRG, record.Zone, record.RelativeName, dns.NS, "")
+		_, err := recordSetsClient.Delete(ctx, record.ZoneRG, record.Zone, record.RelativeName, dns.NS, "")
 		if err != nil {
 			return microerror.Maskf(err, fmt.Sprintf("deleting host cluster DNS record=%#v", record))
 		}

--- a/service/resource/dnsrecord/desired.go
+++ b/service/resource/dnsrecord/desired.go
@@ -29,7 +29,7 @@ func (r *Resource) getDesiredState(ctx context.Context, obj providerv1alpha1.Azu
 
 	for i, record := range desired {
 		zone := record.RelativeName + "." + record.Zone
-		resp, err := zonesClient.Get(key.ResourceGroupName(obj), zone)
+		resp, err := zonesClient.Get(ctx, key.ResourceGroupName(obj), zone)
 		if client.ResponseWasNotFound(resp.Response) {
 			return dnsRecords{}, nil
 		} else if err != nil {

--- a/service/resource/dnsrecord/resource.go
+++ b/service/resource/dnsrecord/resource.go
@@ -1,7 +1,7 @@
 package dnsrecord
 
 import (
-	"github.com/Azure/azure-sdk-for-go/arm/dns"
+	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2017-09-01/dns"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/framework"

--- a/service/resource/dnsrecord/update.go
+++ b/service/resource/dnsrecord/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/arm/dns"
+	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2017-09-01/dns"
 	"github.com/Azure/go-autorest/autorest/to"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/azure-operator/service/key"
@@ -54,7 +54,7 @@ func (r *Resource) applyUpdateChange(ctx context.Context, obj providerv1alpha1.A
 			}
 		}
 
-		_, err := recordSetsClient.CreateOrUpdate(record.ZoneRG, record.Zone, record.RelativeName, dns.NS, params, "", "")
+		_, err := recordSetsClient.CreateOrUpdate(ctx, record.ZoneRG, record.Zone, record.RelativeName, dns.NS, params, "", "")
 		if err != nil {
 			return microerror.Maskf(err, fmt.Sprintf("ensuring host cluster DNS record=%#v", record))
 		}


### PR DESCRIPTION
`azure-sdk-for-go/arm/dns` is deprecated. This also bumps the API
version.