### PR TITLE
Network imporovements for Calico

### DIFF
--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -143,6 +143,7 @@
         "parameters": {
           "clusterID": {"value": "[parameters('clusterID')]"},
           "virtualNetworkCidr": {"value": "[parameters('virtualNetworkCidr')]"},
+          "calicoSubnetCidr": {"value": "[parameters('calicoSubnetCidr')]"},
           "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
           "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},
           "hostClusterCidr": {"value": "[parameters('hostClusterCidr')]"},
@@ -183,7 +184,6 @@
         "parameters": {
           "clusterID": {"value": "[parameters('clusterID')]"},
           "virtualNetworkCidr": {"value": "[parameters('virtualNetworkCidr')]"},
-          "calicoSubnetCidr": {"value": "[parameters('calicoSubnetCidr')]"},
           "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
           "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},
           "masterSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.masterSecurityGroupID.value]"},

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -303,12 +303,12 @@
           "ports": {"value":
             [
               {
-                "frontend": 443,
-                "backend": 443
+                "frontend": 80,
+                "backend": 30010
               },
               {
-                "frontend": 80,
-                "backend": 80
+                "frontend": 443,
+                "backend": 30011
               }
             ]
           }

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -143,7 +143,6 @@
         "parameters": {
           "clusterID": {"value": "[parameters('clusterID')]"},
           "virtualNetworkCidr": {"value": "[parameters('virtualNetworkCidr')]"},
-          "calicoSubnetCidr": {"value": "[parameters('calicoSubnetCidr')]"},
           "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
           "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},
           "hostClusterCidr": {"value": "[parameters('hostClusterCidr')]"},

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -14,6 +14,9 @@
         "description": "The main CIDR block reserved for this virtual network."
       }
     },
+    "calicoSubnetCidr": {
+      "type": "string"
+    },
     "masterSubnetCidr": {
       "type": "string"
     },
@@ -139,6 +142,7 @@
         },
         "parameters": {
           "clusterID": {"value": "[parameters('clusterID')]"},
+          "calicoSubnetCidr": {"value": "[parameters('calicoSubnetCidr')]"},
           "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
           "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},
           "hostClusterCidr": {"value": "[parameters('hostClusterCidr')]"},
@@ -179,6 +183,7 @@
         "parameters": {
           "clusterID": {"value": "[parameters('clusterID')]"},
           "virtualNetworkCidr": {"value": "[parameters('virtualNetworkCidr')]"},
+          "calicoSubnetCidr": {"value": "[parameters('calicoSubnetCidr')]"},
           "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
           "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},
           "masterSecurityGroupID": {"value": "[reference('security_groups_setup').outputs.masterSecurityGroupID.value]"},

--- a/service/arm_templates/main.json
+++ b/service/arm_templates/main.json
@@ -142,6 +142,7 @@
         },
         "parameters": {
           "clusterID": {"value": "[parameters('clusterID')]"},
+          "virtualNetworkCidr": {"value": "[parameters('virtualNetworkCidr')]"},
           "calicoSubnetCidr": {"value": "[parameters('calicoSubnetCidr')]"},
           "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
           "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},

--- a/service/arm_templates/node_setup.json
+++ b/service/arm_templates/node_setup.json
@@ -182,6 +182,7 @@
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
       "properties": {
+        "enableIPForwarding": true,
         "ipConfigurations": [
           {
             "name": "[variables('ipName')]",

--- a/service/arm_templates/security_groups_setup.json
+++ b/service/arm_templates/security_groups_setup.json
@@ -12,6 +12,9 @@
     "clusterID": {
       "type": "string"
     },
+    "calicoSubnetCidr": {
+      "type": "string"
+    },
     "masterSubnetCidr": {
       "type": "string"
     },
@@ -54,7 +57,7 @@
               "sourcePortRange": "*",
               "destinationPortRange": "*",
               "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
+              "destinationAddressPrefix": "*",
               "access": "Deny",
               "direction": "Inbound",
               "priority": "4096"
@@ -67,7 +70,7 @@
               "protocol": "*",
               "sourcePortRange": "*",
               "destinationPortRange": "*",
-              "sourceAddressPrefix": "[parameters('masterSubnetCidr')]",
+              "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
               "access": "Allow",
               "direction": "Outbound",
@@ -82,7 +85,7 @@
               "sourcePortRange": "*",
               "destinationPortRange": "*",
               "sourceAddressPrefix": "[parameters('masterSubnetCidr')]",
-              "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
+              "destinationAddressPrefix": "[parameters('virtualNetworkCidr')]",
               "access": "Allow",
               "direction": "Inbound",
               "priority": "4094"
@@ -117,17 +120,31 @@
             }
           },
           {
-            "name": "workerSubnetToMasterSubnet",
+            "name": "allowWorkerSubnet",
             "properties": {
               "description": "Allow the worker machines to reach the master machines on any ports.",
               "protocol": "*",
               "sourcePortRange": "*",
               "destinationPortRange": "*",
               "sourceAddressPrefix": "[parameters('workerSubnetCidr')]",
-              "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
+              "destinationAddressPrefix": "[parameters('virtualNetworkCidr')]",
               "access": "Allow",
               "direction": "Inbound",
               "priority": "3800"
+            }
+          },
+          {
+            "name": "allowCalicoSubnet",
+            "properties": {
+              "description": "Allow pods to reach the master machines on any ports.",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "[parameters('calicoSubnetCidr')]",
+              "destinationAddressPrefix": "[parameters('virtualNetworkCidr')]",
+              "access": "Allow",
+              "direction": "Inbound",
+              "priority": "3700"
             }
           }
         ]
@@ -148,7 +165,7 @@
               "sourcePortRange": "*",
               "destinationPortRange": "*",
               "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
+              "destinationAddressPrefix": "*",
               "access": "Deny",
               "direction": "Inbound",
               "priority": "4096"
@@ -161,7 +178,7 @@
               "protocol": "*",
               "sourcePortRange": "*",
               "destinationPortRange": "*",
-              "sourceAddressPrefix": "[parameters('workerSubnetCidr')]",
+              "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
               "access": "Allow",
               "direction": "Outbound",
@@ -176,7 +193,7 @@
               "sourcePortRange": "*",
               "destinationPortRange": "*",
               "sourceAddressPrefix": "[parameters('workerSubnetCidr')]",
-              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
+              "destinationAddressPrefix": "[parameters('virtualNetworkCidr')]",
               "access": "Allow",
               "direction": "Inbound",
               "priority": "4094"
@@ -225,17 +242,31 @@
             }
           },
           {
-            "name": "masterSubnetToWorkerSubnet",
+            "name": "allowMasterSubnet",
             "properties": {
               "description": "Allow the master machines to reach the worker machines on any ports.",
               "protocol": "*",
               "sourcePortRange": "*",
               "destinationPortRange": "*",
               "sourceAddressPrefix": "[parameters('masterSubnetCidr')]",
-              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
+              "destinationAddressPrefix": "[parameters('virtualNetworkCidr')]",
               "access": "Allow",
               "direction": "Inbound",
               "priority": "3700"
+            }
+          },
+          {
+            "name": "allowCalicoSubnet",
+            "properties": {
+              "description": "Allow pods to reach the worker machines on any ports.",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "[parameters('calicoSubnetCidr')]",
+              "destinationAddressPrefix": "[parameters('virtualNetworkCidr')]",
+              "access": "Allow",
+              "direction": "Inbound",
+              "priority": "3600"
             }
           }
         ]

--- a/service/arm_templates/security_groups_setup.json
+++ b/service/arm_templates/security_groups_setup.json
@@ -12,6 +12,9 @@
     "clusterID": {
       "type": "string"
     },
+    "virtualNetworkCidr": {
+      "type": "string"
+    },
     "calicoSubnetCidr": {
       "type": "string"
     },

--- a/service/cloudconfig/template.go
+++ b/service/cloudconfig/template.go
@@ -4,8 +4,8 @@ const (
 	calicoAzureFileName       = "/srv/calico-azure.yaml"
 	calicoAzureFileOwner      = "root:root"
 	calicoAzureFilePermission = 0600
-	calicoAzureFileTemplate   = `# Calico Version v2.6.3
-# https://docs.projectcalico.org/v2.6/releases#v2.6.3
+	calicoAzureFileTemplate   = `# Calico Version v3.0.1
+# https://docs.projectcalico.org/v3.0/releases#v3.0.1
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -30,6 +30,17 @@ rules:
       - get
       - list
       - watch
+      - patch
+  - apiGroups: [""]
+    resources:
+      - services
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - endpoints
+    verbs:
+      - get
   - apiGroups: [""]
     resources:
       - nodes
@@ -48,10 +59,14 @@ rules:
   - apiGroups: ["crd.projectcalico.org"]
     resources:
       - globalfelixconfigs
+      - felixconfigurations
       - bgppeers
       - globalbgpconfigs
+      - bgpconfigurations
       - ippools
       - globalnetworkpolicies
+      - networkpolicies
+      - clusterinformations
     verbs:
       - create
       - get
@@ -76,11 +91,11 @@ subjects:
 
 ---
 
-# Calico Version v2.6.3
-# https://docs.projectcalico.org/v2.6/releases#v2.6.3
+# Calico Version v3.0.1
+# https://docs.projectcalico.org/v3.0/releases#v3.0.1
 # This manifest includes the following component versions:
-#   calico/node:v2.6.3
-#   calico/cni:v1.11.1
+#   calico/node:v3.0.1
+#   calico/cni:v2.0.0
 
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
@@ -89,29 +104,142 @@ metadata:
   name: calico-config
   namespace: kube-system
 data:
+  # To enable Typha, set this to "calico-typha" *and* set a non-zero value for Typha replicas
+  # below.  We recommend using Typha if you have more than 50 nodes. Above 100 nodes it is
+  # essential.
+  typha_service_name: "none"
   # The CNI network configuration to install on each node.
   cni_network_config: |-
     {
-        "name": "k8s-pod-network",
-        "cniVersion": "0.1.0",
-        "type": "calico",
-        "log_level": "info",
-        "datastore_type": "kubernetes",
-        "nodename": "__KUBERNETES_NODE_NAME__",
-        "mtu": 1500,
-        "ipam": {
-            "type": "host-local",
-            "subnet": "usePodCidr"
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.0",
+      "plugins": [
+        {
+          "type": "calico",
+          "log_level": "info",
+          "datastore_type": "kubernetes",
+          "nodename": "__KUBERNETES_NODE_NAME__",
+          "mtu": 1500,
+          "ipam": {
+              "type": "host-local",
+              "subnet": "usePodCidr"
+          },
+          "policy": {
+              "type": "k8s",
+              "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+          },
+          "kubernetes": {
+              "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+              "kubeconfig": "__KUBECONFIG_FILEPATH__"
+          }
         },
-        "policy": {
-            "type": "k8s",
-            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
-        },
-        "kubernetes": {
-            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
-            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+        {
+          "type": "portmap",
+          "snat": true,
+          "capabilities": {"portMappings": true}
         }
+      ]
     }
+
+---
+
+# This manifest creates a Service, which will be backed by Calico's Typha daemon.
+# Typha sits in between Felix and the API server, reducing Calico's load on the API server.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: calico-typha
+  namespace: kube-system
+  labels:
+    k8s-app: calico-typha
+spec:
+  ports:
+    - port: 5473
+      protocol: TCP
+      targetPort: calico-typha
+      name: calico-typha
+  selector:
+    k8s-app: calico-typha
+
+---
+
+# This manifest creates a Deployment of Typha to back the above service.
+
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: calico-typha
+  namespace: kube-system
+  labels:
+    k8s-app: calico-typha
+spec:
+  # Number of Typha replicas.  To enable Typha, set this to a non-zero value *and* set the
+  # typha_service_name variable in the calico-config ConfigMap above.
+  #
+  # We recommend using Typha if you have more than 50 nodes.  Above 100 nodes it is essential
+  # (when using the Kubernetes datastore).  Use one replica for every 100-200 nodes.  In
+  # production, we recommend running at least 3 replicas to reduce the impact of rolling upgrade.
+  replicas: 0
+  revisionHistoryLimit: 2
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-typha
+      annotations:
+        # This, along with the CriticalAddonsOnly toleration below, marks the pod as a critical
+        # add-on, ensuring it gets priority scheduling and that its resources are reserved
+        # if it ever gets evicted.
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      # Since Calico can't network a pod until Typha is up, we need to run Typha itself
+      # as a host-networked pod.
+      hostNetwork: true
+      serviceAccountName: calico-node
+      containers:
+      - image: quay.io/calico/typha:v0.6.0
+        name: calico-typha
+        ports:
+        - containerPort: 5473
+          name: calico-typha
+          protocol: TCP
+        env:
+          # Enable "info" logging by default.  Can be set to "debug" to increase verbosity.
+          - name: TYPHA_LOGSEVERITYSCREEN
+            value: "info"
+          # Disable logging to file and syslog since those don't make sense in Kubernetes.
+          - name: TYPHA_LOGFILEPATH
+            value: "none"
+          - name: TYPHA_LOGSEVERITYSYS
+            value: "none"
+          # Monitor the Kubernetes API to find the number of running instances and rebalance
+          # connections.
+          - name: TYPHA_CONNECTIONREBALANCINGMODE
+            value: "kubernetes"
+          - name: TYPHA_DATASTORETYPE
+            value: "kubernetes"
+          - name: TYPHA_HEALTHENABLED
+            value: "true"
+          # Uncomment these lines to enable prometheus metrics.  Since Typha is host-networked,
+          # this opens a port on the host, which may need to be secured.
+          #- name: TYPHA_PROMETHEUSMETRICSENABLED
+          #  value: "true"
+          #- name: TYPHA_PROMETHEUSMETRICSPORT
+          #  value: "9093"
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 9098
+          periodSeconds: 30
+          initialDelaySeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 9098
+          periodSeconds: 10
 
 ---
 
@@ -129,6 +257,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: calico-node
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
   template:
     metadata:
       labels:
@@ -148,8 +280,8 @@ spec:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
         # Mark the pod as a critical add-on for rescheduling.
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
+        - key: CriticalAddonsOnly
+          operator: Exists
       # Minimize downtime during a rolling upgrade or deletion; tell Kubernetes to do a "force
       # deletion": https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods.
       terminationGracePeriodSeconds: 0
@@ -158,7 +290,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v2.6.3
+          image: quay.io/calico/node:v3.0.1
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -172,7 +304,7 @@ spec:
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "k8s"
-            # Disable file logging so kubectl logs works.
+            # Disable file logging so `kubectl logs` works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             # Set Felix endpoint to host default action to ACCEPT.
@@ -184,12 +316,18 @@ spec:
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"
-            # The Calico IPv4 pool to use.  This should match --cluster-cidr
+            # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
             - name: CALICO_IPV4POOL_CIDR
               value: "{{.Cluster.Calico.Subnet}}/{{.Cluster.Calico.CIDR}}"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
-              value: "always"
+              value: "off"
+            # Typha support: controlled by the ConfigMap.
+            - name: FELIX_TYPHAK8SSERVICENAME
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: typha_service_name
             # Set based on the k8s node name.
             - name: NODENAME
               valueFrom:
@@ -227,9 +365,12 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v1.11.1
+          image: quay.io/calico/cni:v2.0.0
           command: ["/install-cni.sh"]
           env:
+            # Name of the CNI config file to create.
+            - name: CNI_CONF_NAME
+              value: "10-calico.conflist"
             # The CNI network config to install on each node.
             - name: CNI_NETWORK_CONFIG
               valueFrom:
@@ -267,34 +408,34 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global Felix Configuration
+description: Calico Felix Configuration
 kind: CustomResourceDefinition
 metadata:
-   name: globalfelixconfigs.crd.projectcalico.org
+   name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: GlobalFelixConfig
-    plural: globalfelixconfigs
-    singular: globalfelixconfig
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration
 
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Calico Global BGP Configuration
+description: Calico BGP Configuration
 kind: CustomResourceDefinition
 metadata:
-  name: globalbgpconfigs.crd.projectcalico.org
+  name: bgpconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
   version: v1
   names:
-    kind: GlobalBGPConfig
-    plural: globalbgpconfigs
-    singular: globalbgpconfig
+    kind: BGPConfiguration
+    plural: bgpconfigurations
+    singular: bgpconfiguration
 
 ---
 
@@ -315,6 +456,22 @@ spec:
 ---
 
 apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Cluster Information
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: ClusterInformation
+    plural: clusterinformations
+    singular: clusterinformation
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
 description: Calico Global Network Policies
 kind: CustomResourceDefinition
 metadata:
@@ -327,6 +484,22 @@ spec:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Calico Network Policies
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  version: v1
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    singular: networkpolicy
 
 ---
 

--- a/service/cloudconfig/template.go
+++ b/service/cloudconfig/template.go
@@ -304,7 +304,7 @@ spec:
             # Cluster type to identify the deployment type
             - name: CLUSTER_TYPE
               value: "k8s"
-            # Disable file logging so `kubectl logs` works.
+            # Disable file logging so kubectl logs works.
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             # Set Felix endpoint to host default action to ACCEPT.
@@ -316,7 +316,7 @@ spec:
             # Wait for the datastore.
             - name: WAIT_FOR_DATASTORE
               value: "true"
-            # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
+            # The Calico IPv4 pool to use.  This should match --cluster-cidr
             - name: CALICO_IPV4POOL_CIDR
               value: "{{.Cluster.Calico.Subnet}}/{{.Cluster.Calico.CIDR}}"
             # Enable IPIP

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -26,7 +26,7 @@ func AzureCloudType(customObject providerv1alpha1.AzureConfig) string {
 
 // CalicoSubnetCidr returns subnet for Calico in CIDR notation format.
 func CalicoSubnetCidr(customObject providerv1alpha1.AzureConfig) string {
-	return fmt.Sprintf("%s/%s", customObject.Spec.Cluster.Calico.Subnet, customObject.Spec.Cluster.Calico.CIDR)
+	return fmt.Sprintf("%s/%d", customObject.Spec.Cluster.Calico.Subnet, customObject.Spec.Cluster.Calico.CIDR)
 }
 
 // ClusterCustomer returns the customer ID for this cluster.

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -26,7 +26,7 @@ func AzureCloudType(customObject providerv1alpha1.AzureConfig) string {
 
 // CalicoSubnetCidr returns subnet for Calico in CIDR notation format.
 func CalicoSubnetCidr(customObject providerv1alpha1.AzureConfig) string {
-	return fmt.Sprintf("%s/%s", customObject.Spec.Cluster.Calico.Subnet, customObject.Spec.Cluster.Calico.Cidr)
+	return fmt.Sprintf("%s/%s", customObject.Spec.Cluster.Calico.Subnet, customObject.Spec.Cluster.Calico.CIDR)
 }
 
 // ClusterCustomer returns the customer ID for this cluster.

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -24,6 +24,11 @@ func AzureCloudType(customObject providerv1alpha1.AzureConfig) string {
 	return defaultAzureCloudType
 }
 
+// CalicoSubnetCidr returns subnet for Calico in CIDR notation format.
+func CalicoSubnetCidr(customObject providerv1alpha1.AzureConfig) string {
+	return fmt.Sprintf("%s/%s", customObject.Spec.Cluster.Calico.Subnet, customObject.Spec.Cluster.Calico.Cidr)
+}
+
 // ClusterCustomer returns the customer ID for this cluster.
 func ClusterCustomer(customObject providerv1alpha1.AzureConfig) string {
 	return customObject.Spec.Cluster.Customer.ID

--- a/service/resource/deployment/deployment.go
+++ b/service/resource/deployment/deployment.go
@@ -41,6 +41,7 @@ func (r Resource) newMainDeployment(cluster providerv1alpha1.AzureConfig) (Deplo
 	params := map[string]interface{}{
 		"clusterID":                     key.ClusterID(cluster),
 		"virtualNetworkCidr":            cluster.Spec.Azure.VirtualNetwork.CIDR,
+		"calicoSubnetCidr":              key.CalicoSubnetCidr(cluster),
 		"masterSubnetCidr":              cluster.Spec.Azure.VirtualNetwork.MasterSubnetCIDR,
 		"workerSubnetCidr":              cluster.Spec.Azure.VirtualNetwork.WorkerSubnetCIDR,
 		"mastersCustomConfig":           cluster.Spec.Azure.Masters,


### PR DESCRIPTION
- allow ip forwarding
- add security rules to allow pods/calico traffic
- fix ingress load balancer ports

TL;DR allow pods subnet in security groups

For context:
In Azure Calico uses native Azure routing. So pods will (should) use ip range from virtual network range.

For example
virtual network: 10.0.0.0/16
calico/pods network: 10.0.128.0/17 <-  my recommendation to just pick up second half of virt.network range. Every Kubernetes node will pick /24 from this subnet.

 
  