### PR TITLE
Create an active release

### DIFF
--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -72,7 +72,7 @@ func newVersionBundles() []versionbundle.Bundle {
 			Name:         "azure-operator",
 			Time:         time.Date(2018, time.January, 7, 8, 35, 0, 0, time.UTC),
 			Version:      "0.1.0",
-			WIP:          true,
+			WIP:          false,
 		},
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/giantswarm/azure-operator/issues/110

There is currently no active release for azure, since this component does not have a non-wip versionbundle.

This means customers won't be able to create clusters.

Is this ready to be set to WIP: false ?