### PR TITLE
Allow azure load balancer health check traffic

### DIFF
--- a/service/arm_templates/security_groups_setup.json
+++ b/service/arm_templates/security_groups_setup.json
@@ -229,6 +229,20 @@
             }
           },
           {
+            "name": "azureLoadBalancerHealthChecks",
+            "properties": {
+              "description": "Allow Azure Load Balancer health checks.",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "AzureLoadBalancer",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "direction": "Inbound",
+              "priority": "4000"
+            }
+          },
+          {
             "name": "ingressSecurePortRule",
             "properties": {
               "description": "Allow anyone to reach the ingress controller secure port.",


### PR DESCRIPTION
This is required for the case when user is using
Azure Load balancer w/o ingress controller.

Kubernetes creates rule only for the targer port itself
(e.g. 80) and assumes that health checks from Azure are allowed
(which is default). In our case we disabled default rules.
This change just brings back default Azure rule.

For reference: https://github.com/kubernetes/kubernetes/issues/58759