### PR TITLE
key: fix KeyVault name

### DIFF
--- a/service/key/key.go
+++ b/service/key/key.go
@@ -9,7 +9,14 @@ import (
 )
 
 const (
-	defaultAzureCloudType     = "AZUREPUBLICCLOUD"
+	defaultAzureCloudType = "AZUREPUBLICCLOUD"
+
+	// globalPrefix is added to all resources created by azure-operator.
+	// This is to avoid problems witch resources which names has to start
+	// with a letter, as sometimes guest cluster IDs start with number.
+	globalPrefix = "gs"
+
+	keyVaultSuffix            = "keyvault"
 	routeTableSuffix          = "RouteTable"
 	masterSecurityGroupSuffix = "MasterSecurityGroup"
 	workerSecurityGroupSuffix = "WorkerSecurityGroup"
@@ -107,7 +114,7 @@ func HostClusterCIDR(customObject providerv1alpha1.AzureConfig) string {
 
 // KeyVaultName returns the Azure Key Vault name for this cluster.
 func KeyVaultName(customObject providerv1alpha1.AzureConfig) string {
-	return ClusterID(customObject) + "-vault"
+	return fmt.Sprintf("%s-%s-%s", globalPrefix, ClusterID(customObject), keyVaultSuffix)
 }
 
 // KeyVaultKey takes a certificate file path and returns KeyVault key under

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -12,7 +12,7 @@ const (
 	defaultAzureCloudType = "AZUREPUBLICCLOUD"
 
 	// globalPrefix is added to all resources created by azure-operator.
-	// This is to avoid problems witch resources which names has to start
+	// This is to avoid problems with resources which names has to start
 	// with a letter, as sometimes guest cluster IDs start with number.
 	globalPrefix = "gs"
 

--- a/service/key/key_test.go
+++ b/service/key/key_test.go
@@ -58,22 +58,6 @@ func Test_ClusterCustomer(t *testing.T) {
 	}
 }
 
-func Test_KeyVaultName(t *testing.T) {
-	expectedVaultName := "test-cluster-vault"
-
-	customObject := providerv1alpha1.AzureConfig{
-		Spec: providerv1alpha1.AzureConfigSpec{
-			Cluster: providerv1alpha1.Cluster{
-				ID: "test-cluster",
-			},
-		},
-	}
-
-	if KeyVaultName(customObject) != expectedVaultName {
-		t.Fatalf("Expected key vault name %s but was %s", expectedVaultName, KeyVaultName(customObject))
-	}
-}
-
 func Test_KeyVaultKey(t *testing.T) {
 	var (
 		path        = "/etc/kubernetes/ssl/calico/client-ca.pem"
@@ -107,12 +91,16 @@ func Test_Location(t *testing.T) {
 }
 
 func Test_Functions_for_AzureResourceKeys(t *testing.T) {
-	clusterID := "test-cluster"
+	clusterID := "eggs2"
 
 	testCases := []struct {
 		Func           func(providerv1alpha1.AzureConfig) string
 		ExpectedResult string
 	}{
+		{
+			Func:           KeyVaultName,
+			ExpectedResult: "gs-eggs2-keyvault",
+		},
 		{
 			Func:           MasterSecurityGroupName,
 			ExpectedResult: fmt.Sprintf("%s-%s", clusterID, masterSecurityGroupSuffix),
@@ -146,7 +134,7 @@ func Test_Functions_for_AzureResourceKeys(t *testing.T) {
 	customObject := providerv1alpha1.AzureConfig{
 		Spec: providerv1alpha1.AzureConfigSpec{
 			Cluster: providerv1alpha1.Cluster{
-				ID: "test-cluster",
+				ID: clusterID,
 			},
 		},
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2491


Prefixing KeyVault with cluster ID is risky because of naming
constraints. KeyVault name must not start with a number. The name has to
be globally unique.

I decided to prefix it (and eventually all other resources) with gs- to
guarantee we always start with a letter and avoid such situations in the
future.

Follow up issue https://github.com/giantswarm/giantswarm/issues/2535