### PR TITLE
Remove loopback reference to kubernetes API

### DIFF
--- a/service/cloudconfig/service.go
+++ b/service/cloudconfig/service.go
@@ -16,12 +16,6 @@ import (
 	"github.com/giantswarm/randomkeys"
 )
 
-const (
-	// loopbackAddr is used to set various cloud config template
-	// parameters to work around Azure load balancers limitation.
-	loopbackAddr = "127.0.0.1"
-)
-
 // Config represents the configuration used to create a cloudconfig service.
 type Config struct {
 	// Dependencies.
@@ -140,7 +134,6 @@ func (c CloudConfig) NewMasterCloudConfig(customObject providerv1alpha1.AzureCon
 		ExtraManifests: []string{
 			"calico-azure.yaml",
 		},
-		MasterAPIDomain: loopbackAddr,
 	}
 
 	return newCloudConfig(k8scloudconfig.MasterTemplate, params)
@@ -167,7 +160,6 @@ func (c CloudConfig) NewWorkerCloudConfig(customObject providerv1alpha1.AzureCon
 			AzureConfig:  c.azureConfig,
 			CustomObject: customObject,
 		},
-		MasterAPIDomain: loopbackAddr,
 	}
 
 	return newCloudConfig(k8scloudconfig.WorkerTemplate, params)

--- a/service/cloudconfig/service.go
+++ b/service/cloudconfig/service.go
@@ -93,7 +93,6 @@ func (c CloudConfig) NewMasterCloudConfig(customObject providerv1alpha1.AzureCon
 		DisableCalico:          true,
 		Hyperkube: k8scloudconfig.Hyperkube{
 			Apiserver: k8scloudconfig.HyperkubeApiserver{
-				BindAddress: "0.0.0.0",
 				Docker: k8scloudconfig.HyperkubeDocker{
 					RunExtraArgs: []string{
 						"-v /etc/kubernetes/config:/etc/kubernetes/config",


### PR DESCRIPTION
As this limitation (https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-troubleshoot#cause-3-accessing-the-load-balancer-from-the-same-vm-and-network-interface) is not valid anymore - we can use the same approach for accessing API as in other operators. 

Do we want to remove the possibility of overriding this in k8scloudconfig? E.g. here:
https://github.com/giantswarm/k8scloudconfig/blob/master/v_3_1_1/cloudconfig.go#L39-L44