### PR TITLE
cloudconfig: fix waagent race

### DIFF
--- a/service/cloudconfig/service.go
+++ b/service/cloudconfig/service.go
@@ -130,7 +130,7 @@ func (c CloudConfig) NewMasterCloudConfig(customObject providerv1alpha1.AzureCon
 			Kubelet: k8scloudconfig.HyperkubeKubelet{
 				Docker: k8scloudconfig.HyperkubeDocker{
 					RunExtraArgs: []string{
-						"-v /var/lib/waagent/ManagedIdentity-Settings:/var/lib/waagent/ManagedIdentity-Settings:ro",
+						"-v /var/lib/waagent:/var/lib/waagent:ro",
 					},
 					CommandExtraArgs: []string{
 						"--cloud-config=/etc/kubernetes/config/azure.yaml",
@@ -159,7 +159,7 @@ func (c CloudConfig) NewWorkerCloudConfig(customObject providerv1alpha1.AzureCon
 			Kubelet: k8scloudconfig.HyperkubeKubelet{
 				Docker: k8scloudconfig.HyperkubeDocker{
 					RunExtraArgs: []string{
-						"-v /var/lib/waagent/ManagedIdentity-Settings:/var/lib/waagent/ManagedIdentity-Settings:ro",
+						"-v /var/lib/waagent:/var/lib/waagent:ro",
 					},
 					CommandExtraArgs: []string{
 						"--cloud-config=/etc/kubernetes/config/azure.yaml",


### PR DESCRIPTION
There was a race between kubelet and waagent. When certs are passed with
cloudconfigs instead of downloading them from KeyVault, kubelet starts
way faster. /var/lib/waagent/ManagedIdentity-Settings is mounted to the
kubelet container. If waagent doesn't have enough time to write to this
file, docker container with kubelet starts and makes it a directory, and
then waagent fails to write to the file (because it's a directory).
Mounting /var/lib/waagent instead solves the problem