### PR TITLE
azureconfig/v1: remove etcd DNS

### DIFF
--- a/service/azureconfig/v1/arm_templates/main.json
+++ b/service/azureconfig/v1/arm_templates/main.json
@@ -108,7 +108,7 @@
     "dnsZones": {
       "type": "object",
       "metadata": {
-        "description": "The DNS zones for kubernetes api, etcd and ingress."
+        "description": "The DNS zones for kubernetes api and ingress."
       }
     }
   },
@@ -275,24 +275,6 @@
               }
             ]
           }
-        }
-      }
-    },
-    {
-      "apiVersion": "2016-09-01",
-      "name": "etcd_dns_setup",
-      "type": "Microsoft.Resources/deployments",
-      "properties": {
-        "mode": "incremental",
-        "templateLink": {
-          "uri": "[variables('dnsASetupTemplateURI')]",
-          "contentVersion": "1.0.0.0"
-        },
-        "parameters": {
-          "dnsZone": { "value": "[concat(parameters('clusterID'), '.k8s.', parameters('dnsZones').etcd.name)]" },
-          "GiantSwarmTags": {"value": "[parameters('GiantSwarmTags')]"},
-          "prefix": { "value": "etcd" },
-          "ipAddress": { "value": "[reference('master_nodes_setup_1').outputs.ipAddress.value]" }
         }
       }
     },

--- a/service/azureconfig/v1/cloudconfig/service.go
+++ b/service/azureconfig/v1/cloudconfig/service.go
@@ -69,6 +69,9 @@ func (c CloudConfig) NewMasterCloudConfig(customObject providerv1alpha1.AzureCon
 		return "", microerror.Mask(err)
 	}
 
+	// On Azure only master nodes access etcd, so it is locked down.
+	customObject.Spec.Cluster.Etcd.Domain = "127.0.0.1"
+
 	params := k8scloudconfig.Params{
 		ApiserverEncryptionKey: apiserverEncryptionKey,
 		Cluster:                customObject.Spec.Cluster,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2490 https://github.com/giantswarm/giantswarm/issues/2483

On Azure only master nodes use etcd, so it is locked down for
simplification and security.