### PR TITLE
Resource tags

### DIFF
--- a/flag/service/installation/installation.go
+++ b/flag/service/installation/installation.go
@@ -1,0 +1,5 @@
+package installation
+
+type Installation struct {
+	Name string
+}

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -2,10 +2,12 @@ package service
 
 import (
 	"github.com/giantswarm/azure-operator/flag/service/azure"
+	"github.com/giantswarm/azure-operator/flag/service/installation"
 	"github.com/giantswarm/azure-operator/flag/service/kubernetes"
 )
 
 type Service struct {
-	Azure      azure.Azure
-	Kubernetes kubernetes.Kubernetes
+	Azure        azure.Azure
+	Installation installation.Installation
+	Kubernetes   kubernetes.Kubernetes
 }

--- a/helm/azure-operator-chart/templates/configmap.yaml
+++ b/helm/azure-operator-chart/templates/configmap.yaml
@@ -8,5 +8,8 @@ data:
     server:
       listen:
         address: 'http://0.0.0.0:8000'
+    service:
+      installation:
+        name: '{{ .Values.Installation.V1.Name }}'
       kubernetes:
         incluster: true

--- a/main.go
+++ b/main.go
@@ -148,6 +148,7 @@ func mainWithError() error {
 	daemonCommand.PersistentFlags().String(f.Service.Azure.SubscriptionID, "", "ID of the Azure Subscription.")
 	daemonCommand.PersistentFlags().String(f.Service.Azure.TenantID, "", "ID of the Active Directory Tenant.")
 	daemonCommand.PersistentFlags().String(f.Service.Azure.Template.URI.Version, defaultTemplateVersion, "URI version for ARM template links.")
+	daemonCommand.PersistentFlags().String(f.Service.Installation.Name, "", "Installation name for tagging Azure resources.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.Address, "", "Address used to connect to Kubernetes. When empty in-cluster config is created.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Kubernetes.InCluster, true, "Whether to use the in-cluster config to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CAFile, "", "Certificate authority file path to use to authenticate with Kubernetes.")

--- a/service/azureconfig/framework.go
+++ b/service/azureconfig/framework.go
@@ -18,10 +18,11 @@ import (
 )
 
 type FrameworkConfig struct {
-	G8sClient    gsclient.Interface
-	K8sClient    kubernetes.Interface
-	K8sExtClient apiextensionsclient.Interface
-	Logger       micrologger.Logger
+	G8sClient        gsclient.Interface
+	InstallationName string
+	K8sClient        kubernetes.Interface
+	K8sExtClient     apiextensionsclient.Interface
+	Logger           micrologger.Logger
 
 	AzureConfig     client.AzureConfig
 	ProjectName     string
@@ -90,12 +91,13 @@ func NewFramework(config FrameworkConfig) (*framework.Framework, error) {
 	var v1ResourceSet *framework.ResourceSet
 	{
 		c := v1.ResourceSetConfig{
-			K8sClient:       config.K8sClient,
-			K8sExtClient:    config.K8sExtClient,
-			Logger:          config.Logger,
-			AzureConfig:     config.AzureConfig,
-			ProjectName:     config.ProjectName,
-			TemplateVersion: config.TemplateVersion,
+			K8sClient:        config.K8sClient,
+			K8sExtClient:     config.K8sExtClient,
+			Logger:           config.Logger,
+			AzureConfig:      config.AzureConfig,
+			InstallationName: config.InstallationName,
+			ProjectName:      config.ProjectName,
+			TemplateVersion:  config.TemplateVersion,
 		}
 
 		v1ResourceSet, err = v1.NewResourceSet(c)

--- a/service/azureconfig/v1/key/key.go
+++ b/service/azureconfig/v1/key/key.go
@@ -11,6 +11,7 @@ const (
 	defaultAzureCloudType = "AZUREPUBLICCLOUD"
 
 	clusterTagName      = "GiantSwarmCluster"
+	installationTagName = "GiantSwarmInstallation"
 	organizationTagName = "GiantSwarmOrganization"
 
 	routeTableSuffix          = "RouteTable"
@@ -62,9 +63,10 @@ func ClusterOrganization(customObject providerv1alpha1.AzureConfig) string {
 }
 
 // ClusterTags returns a map with the resource tags for this cluster.
-func ClusterTags(customObject providerv1alpha1.AzureConfig) map[string]string {
+func ClusterTags(customObject providerv1alpha1.AzureConfig, installationName string) map[string]string {
 	tags := map[string]string{
 		clusterTagName:      ClusterID(customObject),
+		installationTagName: installationName,
 		organizationTagName: ClusterOrganization(customObject),
 	}
 

--- a/service/azureconfig/v1/key/key.go
+++ b/service/azureconfig/v1/key/key.go
@@ -10,8 +10,8 @@ import (
 const (
 	defaultAzureCloudType = "AZUREPUBLICCLOUD"
 
-	clusterTagName      = "giantswarm.io/cluster"
-	organizationTagName = "giantswarm.io/organization"
+	clusterTagName      = "GiantSwarmCluster"
+	organizationTagName = "GiantSwarmOrganization"
 
 	routeTableSuffix          = "RouteTable"
 	masterSecurityGroupSuffix = "MasterSecurityGroup"

--- a/service/azureconfig/v1/key/key.go
+++ b/service/azureconfig/v1/key/key.go
@@ -10,6 +10,9 @@ import (
 const (
 	defaultAzureCloudType = "AZUREPUBLICCLOUD"
 
+	clusterTagName      = "giantswarm.io/cluster"
+	organizationTagName = "giantswarm.io/organization"
+
 	routeTableSuffix          = "RouteTable"
 	masterSecurityGroupSuffix = "MasterSecurityGroup"
 	workerSecurityGroupSuffix = "WorkerSecurityGroup"
@@ -50,6 +53,22 @@ func ClusterCustomer(customObject providerv1alpha1.AzureConfig) string {
 // ClusterID returns the unique ID for this cluster.
 func ClusterID(customObject providerv1alpha1.AzureConfig) string {
 	return customObject.Spec.Cluster.ID
+}
+
+// ClusterOrganization returns the org name from the custom object.
+// It uses ClusterCustomer until this field is renamed in the custom object.
+func ClusterOrganization(customObject providerv1alpha1.AzureConfig) string {
+	return ClusterCustomer(customObject)
+}
+
+// ClusterTags returns a map with the resource tags for this cluster.
+func ClusterTags(customObject providerv1alpha1.AzureConfig) map[string]string {
+	tags := map[string]string{
+		clusterTagName:      ClusterID(customObject),
+		organizationTagName: ClusterOrganization(customObject),
+	}
+
+	return tags
 }
 
 // DNSZoneAPI returns api parent DNS zone domain name.

--- a/service/azureconfig/v1/key/key_test.go
+++ b/service/azureconfig/v1/key/key_test.go
@@ -81,8 +81,8 @@ func Test_ClusterOrganization(t *testing.T) {
 
 func Test_ClusterTags(t *testing.T) {
 	expectedTags := map[string]string{
-		"giantswarm.io/cluster":      "test-cluster",
-		"giantswarm.io/organization": "test-org",
+		"GiantSwarmCluster":      "test-cluster",
+		"GiantSwarmOrganization": "test-org",
 	}
 
 	customObject := providerv1alpha1.AzureConfig{

--- a/service/azureconfig/v1/key/key_test.go
+++ b/service/azureconfig/v1/key/key_test.go
@@ -2,6 +2,7 @@ package key
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
@@ -55,6 +56,49 @@ func Test_ClusterCustomer(t *testing.T) {
 
 	if ClusterCustomer(customObject) != expectedID {
 		t.Fatalf("Expected customer ID %s but was %s", expectedID, ClusterCustomer(customObject))
+	}
+}
+
+func Test_ClusterOrganization(t *testing.T) {
+	expectedID := "test-org"
+
+	customObject := providerv1alpha1.AzureConfig{
+		Spec: providerv1alpha1.AzureConfigSpec{
+			Cluster: providerv1alpha1.Cluster{
+				ID: "test-org",
+				// Organization uses Customer until its renamed in the CRD.
+				Customer: providerv1alpha1.ClusterCustomer{
+					ID: expectedID,
+				},
+			},
+		},
+	}
+
+	if ClusterOrganization(customObject) != expectedID {
+		t.Fatalf("Expected organization %s but was %s", expectedID, ClusterOrganization(customObject))
+	}
+}
+
+func Test_ClusterTags(t *testing.T) {
+	expectedTags := map[string]string{
+		"giantswarm.io/cluster":      "test-cluster",
+		"giantswarm.io/organization": "test-org",
+	}
+
+	customObject := providerv1alpha1.AzureConfig{
+		Spec: providerv1alpha1.AzureConfigSpec{
+			Cluster: providerv1alpha1.Cluster{
+				ID: "test-cluster",
+				// Organization uses Customer until its renamed in the CRD.
+				Customer: providerv1alpha1.ClusterCustomer{
+					ID: "test-org",
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(expectedTags, ClusterTags(customObject)) {
+		t.Fatalf("Expected cluster tags %v but was %v", expectedTags, ClusterTags(customObject))
 	}
 }
 

--- a/service/azureconfig/v1/key/key_test.go
+++ b/service/azureconfig/v1/key/key_test.go
@@ -80,8 +80,11 @@ func Test_ClusterOrganization(t *testing.T) {
 }
 
 func Test_ClusterTags(t *testing.T) {
+	installName := "test-install"
+
 	expectedTags := map[string]string{
 		"GiantSwarmCluster":      "test-cluster",
+		"GiantSwarmInstallation": "test-install",
 		"GiantSwarmOrganization": "test-org",
 	}
 
@@ -97,8 +100,8 @@ func Test_ClusterTags(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(expectedTags, ClusterTags(customObject)) {
-		t.Fatalf("Expected cluster tags %v but was %v", expectedTags, ClusterTags(customObject))
+	if !reflect.DeepEqual(expectedTags, ClusterTags(customObject, installName)) {
+		t.Fatalf("Expected cluster tags %v but was %v", expectedTags, ClusterTags(customObject, installName))
 	}
 }
 

--- a/service/azureconfig/v1/resource/resourcegroup/resource.go
+++ b/service/azureconfig/v1/resource/resourcegroup/resource.go
@@ -25,26 +25,26 @@ const (
 
 type Config struct {
 	AzureConfig      client.AzureConfig
-	InstallationName string
 	Logger           micrologger.Logger
+	InstallationName string
 }
 
 // Resource manages Azure resource groups.
 type Resource struct {
 	azureConfig      client.AzureConfig
-	installationName string
 	logger           micrologger.Logger
+	installationName string
 }
 
 func New(config Config) (*Resource, error) {
 	if err := config.AzureConfig.Validate(); err != nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.AzureConfig.%s", err)
 	}
-	if config.InstallationName == "" {
-		return nil, microerror.Maskf(invalidConfigError, "config.InstallationName must not be empty")
-	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+	if config.InstallationName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.InstallationName must not be empty")
 	}
 
 	r := &Resource{

--- a/service/azureconfig/v1/resource/resourcegroup/resource.go
+++ b/service/azureconfig/v1/resource/resourcegroup/resource.go
@@ -19,8 +19,6 @@ const (
 	// Name is the identifier of the resource.
 	Name = "resourcegroupv1"
 
-	clusterIDTag  = "ClusterID"
-	customerIDTag = "CustomerID"
 	deleteTimeout = 30 * time.Minute
 	managedBy     = "azure-operator"
 )
@@ -92,14 +90,10 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	tags := map[string]string{
-		clusterIDTag:  key.ClusterID(customObject),
-		customerIDTag: key.ClusterCustomer(customObject),
-	}
 	resourceGroup := Group{
 		Name:     key.ClusterID(customObject),
 		Location: key.Location(customObject),
-		Tags:     tags,
+		Tags:     key.ClusterTags(customObject),
 	}
 
 	return resourceGroup, nil

--- a/service/azureconfig/v1/resource/resourcegroup/resource_test.go
+++ b/service/azureconfig/v1/resource/resourcegroup/resource_test.go
@@ -36,8 +36,8 @@ func Test_Resource_ResourceGroup_GetDesiredState(t *testing.T) {
 			ExpectedName:     "5xchu",
 			ExpectedLocation: "West Europe",
 			ExpectedTags: map[string]string{
-				"giantswarm.io/cluster":      "5xchu",
-				"giantswarm.io/organization": "giantswarm",
+				"GiantSwarmCluster":      "5xchu",
+				"GiantSwarmOrganization": "giantswarm",
 			},
 		},
 		{
@@ -58,8 +58,8 @@ func Test_Resource_ResourceGroup_GetDesiredState(t *testing.T) {
 			ExpectedName:     "test-cluster",
 			ExpectedLocation: "East Asia",
 			ExpectedTags: map[string]string{
-				"giantswarm.io/cluster":      "test-cluster",
-				"giantswarm.io/organization": "acme",
+				"GiantSwarmCluster":      "test-cluster",
+				"GiantSwarmOrganization": "acme",
 			},
 		},
 	}

--- a/service/azureconfig/v1/resource/resourcegroup/resource_test.go
+++ b/service/azureconfig/v1/resource/resourcegroup/resource_test.go
@@ -36,8 +36,8 @@ func Test_Resource_ResourceGroup_GetDesiredState(t *testing.T) {
 			ExpectedName:     "5xchu",
 			ExpectedLocation: "West Europe",
 			ExpectedTags: map[string]string{
-				"ClusterID":  "5xchu",
-				"CustomerID": "giantswarm",
+				"giantswarm.io/cluster":      "5xchu",
+				"giantswarm.io/organization": "giantswarm",
 			},
 		},
 		{
@@ -58,8 +58,8 @@ func Test_Resource_ResourceGroup_GetDesiredState(t *testing.T) {
 			ExpectedName:     "test-cluster",
 			ExpectedLocation: "East Asia",
 			ExpectedTags: map[string]string{
-				"ClusterID":  "test-cluster",
-				"CustomerID": "acme",
+				"giantswarm.io/cluster":      "test-cluster",
+				"giantswarm.io/organization": "acme",
 			},
 		},
 	}

--- a/service/azureconfig/v1/resource/resourcegroup/resource_test.go
+++ b/service/azureconfig/v1/resource/resourcegroup/resource_test.go
@@ -14,6 +14,7 @@ import (
 func Test_Resource_ResourceGroup_GetDesiredState(t *testing.T) {
 	testCases := []struct {
 		Obj              interface{}
+		InstallationName string
 		ExpectedName     string
 		ExpectedLocation string
 		ExpectedTags     map[string]string
@@ -33,10 +34,12 @@ func Test_Resource_ResourceGroup_GetDesiredState(t *testing.T) {
 					},
 				},
 			},
+			InstallationName: "gollum",
 			ExpectedName:     "5xchu",
 			ExpectedLocation: "West Europe",
 			ExpectedTags: map[string]string{
 				"GiantSwarmCluster":      "5xchu",
+				"GiantSwarmInstallation": "gollum",
 				"GiantSwarmOrganization": "giantswarm",
 			},
 		},
@@ -55,10 +58,12 @@ func Test_Resource_ResourceGroup_GetDesiredState(t *testing.T) {
 					},
 				},
 			},
+			InstallationName: "coyote",
 			ExpectedName:     "test-cluster",
 			ExpectedLocation: "East Asia",
 			ExpectedTags: map[string]string{
 				"GiantSwarmCluster":      "test-cluster",
+				"GiantSwarmInstallation": "coyote",
 				"GiantSwarmOrganization": "acme",
 			},
 		},
@@ -67,16 +72,17 @@ func Test_Resource_ResourceGroup_GetDesiredState(t *testing.T) {
 	var err error
 	var newResource *Resource
 	{
-		resourceConfig := Config{
-			AzureConfig: fakeclient.NewAzureConfig(),
-			Logger:      microloggertest.New(),
-		}
-		newResource, err = New(resourceConfig)
-		if err != nil {
-			t.Fatalf("expected '%#v' got '%#v'", nil, err)
-		}
-
 		for i, tc := range testCases {
+			resourceConfig := Config{
+				AzureConfig:      fakeclient.NewAzureConfig(),
+				InstallationName: tc.InstallationName,
+				Logger:           microloggertest.New(),
+			}
+			newResource, err = New(resourceConfig)
+			if err != nil {
+				t.Fatalf("expected '%#v' got '%#v'", nil, err)
+			}
+
 			result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
 			if err != nil {
 				t.Fatalf("case %d expected '%v' got '%#v'", i+1, nil, err)
@@ -160,8 +166,9 @@ func Test_Resource_ResourceGroup_newCreateChange(t *testing.T) {
 	var newResource *Resource
 	{
 		resourceConfig := Config{
-			AzureConfig: fakeclient.NewAzureConfig(),
-			Logger:      microloggertest.New(),
+			AzureConfig:      fakeclient.NewAzureConfig(),
+			InstallationName: "test-install",
+			Logger:           microloggertest.New(),
 		}
 		newResource, err = New(resourceConfig)
 		if err != nil {
@@ -230,8 +237,9 @@ func Test_Resource_ResourceGroup_newDeleteChange(t *testing.T) {
 	var newResource *Resource
 	{
 		resourceConfig := Config{
-			AzureConfig: fakeclient.NewAzureConfig(),
-			Logger:      microloggertest.New(),
+			AzureConfig:      fakeclient.NewAzureConfig(),
+			InstallationName: "test-install",
+			Logger:           microloggertest.New(),
 		}
 		newResource, err = New(resourceConfig)
 		if err != nil {

--- a/service/azureconfig/v1/resource_set.go
+++ b/service/azureconfig/v1/resource_set.go
@@ -32,8 +32,9 @@ type ResourceSetConfig struct {
 	K8sExtClient apiextensionsclient.Interface
 	Logger       micrologger.Logger
 
-	AzureConfig client.AzureConfig
-	ProjectName string
+	AzureConfig      client.AzureConfig
+	InstallationName string
+	ProjectName      string
 	// TemplateVersion is a git branch name to use to get Azure Resource
 	// Manager templates from.
 	TemplateVersion string
@@ -107,8 +108,9 @@ func NewResourceSet(config ResourceSetConfig) (*framework.ResourceSet, error) {
 	var resourceGroupResource framework.Resource
 	{
 		c := resourcegroup.Config{
-			AzureConfig: config.AzureConfig,
-			Logger:      config.Logger,
+			AzureConfig:      config.AzureConfig,
+			InstallationName: config.InstallationName,
+			Logger:           config.Logger,
 		}
 
 		ops, err := resourcegroup.New(c)

--- a/service/service.go
+++ b/service/service.go
@@ -122,13 +122,14 @@ func New(config Config) (*Service, error) {
 	var azureConfigFramework *framework.Framework
 	{
 		c := azureconfig.FrameworkConfig{
-			G8sClient:       g8sClient,
-			K8sClient:       k8sClient,
-			K8sExtClient:    k8sExtClient,
-			Logger:          config.Logger,
-			AzureConfig:     azureConfig,
-			ProjectName:     "azure-operator",
-			TemplateVersion: config.Viper.GetString(config.Flag.Service.Azure.Template.URI.Version),
+			G8sClient:        g8sClient,
+			K8sClient:        k8sClient,
+			K8sExtClient:     k8sExtClient,
+			Logger:           config.Logger,
+			AzureConfig:      azureConfig,
+			InstallationName: config.Viper.GetString(config.Flag.Service.Installation.Name),
+			ProjectName:      "azure-operator",
+			TemplateVersion:  config.Viper.GetString(config.Flag.Service.Azure.Template.URI.Version),
 		}
 
 		azureConfigFramework, err = azureconfig.NewFramework(c)


### PR DESCRIPTION
Towards giantswarm/giantswarm#2775

Adds the tags below to each Resource Group for cost tracking.

```
GiantSwarmCluster: "rue77"
GiantSwarmOrganization: "giantswarm"
GiantSwarmInstallation: "gollum"
```

Replaces the previous tags.

```
ClusterID: "rue77"
CustomerID: "giantswarm"
```