### PR TITLE
Use latest alpine as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.7
 
 RUN apk add --no-cache ca-certificates
 


### PR DESCRIPTION
Uses the latest alpine as discussed with Tim.
https://github.com/giantswarm/e2e-app/pull/3#discussion_r174731859

I'd like us to use the latest version in our operators.