### PR TITLE
correct --service.azure.location error message

### DIFF
--- a/service/azureconfig/setting/types.go
+++ b/service/azureconfig/setting/types.go
@@ -12,7 +12,7 @@ func (a Azure) Validate() error {
 		return fmt.Errorf("HostCluster.%s", err)
 	}
 	if a.Location == "" {
-		return fmt.Errorf("CIDR must not be empty")
+		return fmt.Errorf("Location must not be empty")
 	}
 
 	return nil


### PR DESCRIPTION
The error message when `--service.azure.location error message` is empty was incorrectly showing:
```
panic: [{[...]/azureconfig/framework.go:59: azureconfig.FrameworkConfig.Azure.CIDR must not be empty} {invalid config}]
```

I corrected this to show
```
panic: [{[...]/azureconfig/framework.go:59: azureconfig.FrameworkConfig.Azure.Location must not be empty} {invalid config}]
```