### PR TITLE
Adds prometheus scrape annotation

### DIFF
--- a/helm/azure-operator-chart/templates/service.yaml
+++ b/helm/azure-operator-chart/templates/service.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: giantswarm
   labels:
     app: azure-operator
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: NodePort
   ports:


### PR DESCRIPTION
Noticed this earlier, so with the annotation, we now scrape azure-operator, e.g: `go_memstats_alloc_bytes{app="azure-operator"}` on `godsmack` now gives me:


Element | Value
-- | --
go_memstats_alloc_bytes{app="azure-operator",cluster_id="godsmack",cluster_type="host",instance="10.0.133.26:8000",job="host-cluster-godsmack-workload",namespace="giantswarm"} | 5071384


