### PR TITLE
Opens required ports for monitoring

### DIFF
--- a/service/azureconfig/v1/arm_templates/security_groups_setup.json
+++ b/service/azureconfig/v1/arm_templates/security_groups_setup.json
@@ -48,7 +48,12 @@
     "masterSecurityGroupID": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('masterSecurityGroupName'))]",
 
     "workerSecurityGroupName": "[concat(parameters('clusterID'), '-WorkerSecurityGroup')]",
-    "workerSecurityGroupID": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('workerSecurityGroupName'))]"
+    "workerSecurityGroupID": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('workerSecurityGroupName'))]",
+
+    "cadvisorPort": "4194",
+    "kubeletPort": "10250",
+    "nodeExporterPort": "10300",
+    "kubeStateMetricsPort": "10301"
   },
   "resources": [
     {
@@ -157,6 +162,48 @@
               "access": "Allow",
               "direction": "Inbound",
               "priority": "3700"
+            }
+          },
+          {
+            "name": "allowCadvisor",
+            "properties": {
+              "description": "Allow host cluster Prometheus to reach Cadvisors.",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "[variables('cadvisorPort')]",
+              "sourceAddressPrefix": "[parameters('hostClusterCidr')]",
+              "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
+              "access": "Allow",
+              "direction": "Inbound",
+              "priority": "3500"
+            }
+          },
+          {
+            "name": "allowKubelet",
+            "properties": {
+              "description": "Allow host cluster Prometheus to reach Kubelets.",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "[variables('kubeletPort')]",
+              "sourceAddressPrefix": "[parameters('hostClusterCidr')]",
+              "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
+              "access": "Allow",
+              "direction": "Inbound",
+              "priority": "3501"
+            }
+          },
+          {
+            "name": "allowNodeExporter",
+            "properties": {
+              "description": "Allow host cluster Prometheus to reach node-exporters.",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "[variables('nodeExporterPort')]",
+              "sourceAddressPrefix": "[parameters('hostClusterCidr')]",
+              "destinationAddressPrefix": "[parameters('masterSubnetCidr')]",
+              "access": "Allow",
+              "direction": "Inbound",
+              "priority": "3502"
             }
           }
         ]
@@ -296,6 +343,62 @@
               "access": "Allow",
               "direction": "Inbound",
               "priority": "3600"
+            }
+          },
+          {
+            "name": "allowCadvisor",
+            "properties": {
+              "description": "Allow host cluster Prometheus to reach Cadvisors.",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "[variables('cadvisorPort')]",
+              "sourceAddressPrefix": "[parameters('hostClusterCidr')]",
+              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
+              "access": "Allow",
+              "direction": "Inbound",
+              "priority": "3500"
+            }
+          },
+          {
+            "name": "allowKubelet",
+            "properties": {
+              "description": "Allow host cluster Prometheus to reach Kubelets.",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "[variables('kubeletPort')]",
+              "sourceAddressPrefix": "[parameters('hostClusterCidr')]",
+              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
+              "access": "Allow",
+              "direction": "Inbound",
+              "priority": "3501"
+            }
+          },
+          {
+            "name": "allowNodeExporter",
+            "properties": {
+              "description": "Allow host cluster Prometheus to reach node-exporters.",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "[variables('nodeExporterPort')]",
+              "sourceAddressPrefix": "[parameters('hostClusterCidr')]",
+              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
+              "access": "Allow",
+              "direction": "Inbound",
+              "priority": "3502"
+            }
+          },
+          {
+            "name": "allowKubeStateMetrics",
+            "properties": {
+              "description": "Allow host cluster Prometheus to reach kube-state-metrics.",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "[variables('kubeStateMetricsPort')]",
+              "sourceAddressPrefix": "[parameters('hostClusterCidr')]",
+              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
+              "access": "Allow",
+              "direction": "Inbound",
+              "priority": "3503"
             }
           }
         ]


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2372

Master:
<img width="1812" alt="screen shot 2018-04-05 at 12 28 23" src="https://user-images.githubusercontent.com/297653/38363527-e6ab0358-38cc-11e8-8ce1-fe4ea1a343a6.png">
Worker:
<img width="1822" alt="screen shot 2018-04-05 at 12 28 36" src="https://user-images.githubusercontent.com/297653/38363528-e6c18254-38cc-11e8-932c-c08a40e3a613.png">

and when i submit the namespace, service and endpoint, monitoring targets come up correctly in prometheus bam bam

<img width="1781" alt="screen shot 2018-04-05 at 13 03 33" src="https://user-images.githubusercontent.com/297653/38364763-c59ff9a2-38d1-11e8-877a-93819107c1ab.png">
