### PR TITLE
Adds service resource

### DIFF
--- a/helm/azure-operator-chart/templates/rbac.yaml
+++ b/helm/azure-operator-chart/templates/rbac.yaml
@@ -35,9 +35,7 @@ rules:
       - endpoints
       - services
     verbs:
-      - create
-      - list
-      - watch
+      - "*"
   - apiGroups:
       - ""
     resources:

--- a/service/azureconfig/v1/resource/service/create.go
+++ b/service/azureconfig/v1/resource/service/create.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"context"
+
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/azure-operator/service/azureconfig/v1/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	serviceToCreate, err := toService(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if serviceToCreate != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes service")
+
+		namespace := key.ClusterNamespace(customObject)
+		_, err = r.k8sClient.CoreV1().Services(namespace).Create(serviceToCreate)
+		if apierrors.IsAlreadyExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes service: created")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes service: already created")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentService, err := toService(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredService, err := toService(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var serviceToCreate *apiv1.Service
+	if currentService == nil || desiredService.Name != currentService.Name {
+		serviceToCreate = desiredService
+	}
+
+	return serviceToCreate, nil
+}

--- a/service/azureconfig/v1/resource/service/create_test.go
+++ b/service/azureconfig/v1/resource/service/create_test.go
@@ -1,0 +1,119 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_Resource_Service_newCreateChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description     string
+		obj             interface{}
+		cur             interface{}
+		des             interface{}
+		expectedService *apiv1.Service
+	}{
+		{
+			description: "current state matches desired state, desired state is empty",
+			obj: &v1alpha1.AzureConfig{
+				Spec: v1alpha1.AzureConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: nil,
+		},
+
+		{
+			description: "current state is empty, return desired state",
+			obj: &v1alpha1.AzureConfig{
+				Spec: v1alpha1.AzureConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newCreateChange(context.TODO(), tc.obj, tc.cur, tc.des)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			if tc.expectedService == nil {
+				if tc.expectedService != result {
+					t.Errorf("expected '%v' got '%v'", tc.expectedService, result)
+				}
+			} else {
+				serviceToCreate, ok := result.(*apiv1.Service)
+				if !ok {
+					t.Errorf("case expected '%T', got '%T'", serviceToCreate, result)
+				}
+				if tc.expectedService.Name != serviceToCreate.Name {
+					t.Errorf("expected %s, got %s", tc.expectedService.Name, serviceToCreate.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/azureconfig/v1/resource/service/current.go
+++ b/service/azureconfig/v1/resource/service/current.go
@@ -1,0 +1,41 @@
+package service
+
+import (
+	"context"
+
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/azure-operator/service/azureconfig/v1/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the master service in the Kubernetes API")
+
+	namespace := key.ClusterNamespace(customObject)
+
+	// Lookup the current state of the service.
+	var service *apiv1.Service
+	{
+		manifest, err := r.k8sClient.CoreV1().Services(namespace).Get(masterServiceName, apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the master service in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the master service in the Kubernetes API")
+			service = manifest
+		}
+	}
+
+	return service, nil
+}

--- a/service/azureconfig/v1/resource/service/delete.go
+++ b/service/azureconfig/v1/resource/service/delete.go
@@ -1,0 +1,77 @@
+package service
+
+import (
+	"context"
+
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+
+	"github.com/giantswarm/azure-operator/service/azureconfig/v1/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	serviceToDelete, err := toService(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if serviceToDelete != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes service")
+
+		namespace := key.ClusterNamespace(customObject)
+		err := r.k8sClient.CoreV1().Services(namespace).Delete(serviceToDelete.Name, &apismetav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes service: deleted")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Kubernetes service: already deleted")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentService, err := toService(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredService, err := toService(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the service has to be deleted")
+
+	var serviceToDelete *apiv1.Service
+	if currentService != nil && desiredService.Name == currentService.Name {
+		serviceToDelete = desiredService
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found out if the service has to be deleted")
+
+	return serviceToDelete, nil
+}

--- a/service/azureconfig/v1/resource/service/delete_test.go
+++ b/service/azureconfig/v1/resource/service/delete_test.go
@@ -1,0 +1,139 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_Resource_Service_newDeleteChange(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description     string
+		obj             interface{}
+		cur             interface{}
+		des             interface{}
+		expectedService *apiv1.Service
+	}{
+		{
+			description: "current state matches desired state, return desired state",
+			obj: &v1alpha1.AzureConfig{
+				Spec: v1alpha1.AzureConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+		},
+		{
+			description: "current state is empty, no change",
+			obj: &v1alpha1.AzureConfig{
+				Spec: v1alpha1.AzureConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: nil,
+		},
+		{
+			description: "current and desired states are different, no change",
+			obj: &v1alpha1.AzureConfig{
+				Spec: v1alpha1.AzureConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			cur: nil,
+			des: &apiv1.Service{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "master",
+				},
+			},
+			expectedService: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.newDeleteChange(context.TODO(), tc.obj, tc.cur, tc.des)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			if tc.expectedService == nil {
+				if tc.expectedService != result {
+					t.Errorf("expected '%v' got '%v'", tc.expectedService, result)
+				}
+			} else {
+				serviceToDelete, ok := result.(*apiv1.Service)
+				if !ok {
+					t.Fatalf("case expected '%T', got '%T'", serviceToDelete, result)
+				}
+				if tc.expectedService.Name != serviceToDelete.Name {
+					t.Errorf("expected %s, got %s", tc.expectedService.Name, serviceToDelete.Name)
+				}
+			}
+		})
+	}
+}

--- a/service/azureconfig/v1/resource/service/desired.go
+++ b/service/azureconfig/v1/resource/service/desired.go
@@ -1,0 +1,46 @@
+package service
+
+import (
+	"context"
+
+	"k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/azure-operator/service/azureconfig/v1/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	service := &v1.Service{
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:      "master",
+			Namespace: key.ClusterID(customObject),
+			Labels: map[string]string{
+				"app":      "master",
+				"cluster":  key.ClusterID(customObject),
+				"customer": key.ClusterCustomer(customObject),
+			},
+			Annotations: map[string]string{
+				"giantswarm.io/prometheus-cluster": key.ClusterID(customObject),
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Protocol:   v1.ProtocolTCP,
+					Port:       httpsPort,
+					TargetPort: intstr.FromInt(httpsPort),
+				},
+			},
+		},
+	}
+
+	return service, nil
+}

--- a/service/azureconfig/v1/resource/service/desired.go
+++ b/service/azureconfig/v1/resource/service/desired.go
@@ -23,9 +23,11 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			Name:      "master",
 			Namespace: key.ClusterID(customObject),
 			Labels: map[string]string{
-				"app":      "master",
-				"cluster":  key.ClusterID(customObject),
-				"customer": key.ClusterCustomer(customObject),
+				"app":                        "master",
+				"cluster":                    key.ClusterID(customObject),
+				"customer":                   key.ClusterCustomer(customObject),
+				"giantswarm.io/cluster":      key.ClusterID(customObject),
+				"giantswarm.io/organization": key.ClusterCustomer(customObject),
 			},
 			Annotations: map[string]string{
 				"giantswarm.io/prometheus-cluster": key.ClusterID(customObject),

--- a/service/azureconfig/v1/resource/service/desired_test.go
+++ b/service/azureconfig/v1/resource/service/desired_test.go
@@ -1,0 +1,82 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+func Test_Resource_Service_GetDesiredState(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		description        string
+		obj                interface{}
+		expectedNamespace  string
+		expectedName       string
+		expectedPort       int
+		expectedTargetPort string
+	}{
+		{
+			description: "Get service from custom object",
+			obj: &v1alpha1.AzureConfig{
+				Spec: v1alpha1.AzureConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			expectedNamespace:  "al9qy",
+			expectedName:       "master",
+			expectedPort:       443,
+			expectedTargetPort: "443",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		c := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(c)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := newResource.GetDesiredState(context.TODO(), tc.obj)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			desiredService, ok := result.(*apiv1.Service)
+			if !ok {
+				t.Errorf("case expected '%T', got '%T'", desiredService, result)
+			}
+
+			if tc.expectedNamespace != desiredService.ObjectMeta.Namespace {
+				t.Errorf("expected namespace %q got %q", tc.expectedNamespace, desiredService.ObjectMeta.Namespace)
+			}
+
+			if tc.expectedName != desiredService.ObjectMeta.Name {
+				t.Errorf("expected name %q got %q", tc.expectedName, desiredService.ObjectMeta.Name)
+			}
+
+			if int32(tc.expectedPort) != desiredService.Spec.Ports[0].Port {
+				t.Errorf("expected port %q got %q", int32(tc.expectedPort), desiredService.Spec.Ports[0].Port)
+			}
+
+			if intstr.FromInt(tc.expectedPort) != desiredService.Spec.Ports[0].TargetPort {
+				t.Errorf("expected target port %q got %q", intstr.FromInt(tc.expectedPort), desiredService.Spec.Ports[0].TargetPort)
+			}
+		})
+	}
+}

--- a/service/azureconfig/v1/resource/service/error.go
+++ b/service/azureconfig/v1/resource/service/error.go
@@ -1,0 +1,24 @@
+package service
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/azureconfig/v1/resource/service/resource.go
+++ b/service/azureconfig/v1/resource/service/resource.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "servicev1"
+
+	httpsPort         = 443
+	masterServiceName = "master"
+)
+
+type Config struct {
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toService(v interface{}) (*apiv1.Service, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	service, ok := v.(*apiv1.Service)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &apiv1.Service{}, v)
+	}
+
+	return service, nil
+}

--- a/service/azureconfig/v1/resource/service/update.go
+++ b/service/azureconfig/v1/resource/service/update.go
@@ -1,0 +1,35 @@
+package service
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+// Service resources are not updated.
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/azureconfig/v1/resource_set.go
+++ b/service/azureconfig/v1/resource_set.go
@@ -23,6 +23,7 @@ import (
 	"github.com/giantswarm/azure-operator/service/azureconfig/v1/resource/dnsrecord"
 	"github.com/giantswarm/azure-operator/service/azureconfig/v1/resource/namespace"
 	"github.com/giantswarm/azure-operator/service/azureconfig/v1/resource/resourcegroup"
+	"github.com/giantswarm/azure-operator/service/azureconfig/v1/resource/service"
 	"github.com/giantswarm/azure-operator/service/azureconfig/v1/resource/vnetpeering"
 )
 
@@ -194,6 +195,24 @@ func NewResourceSet(config ResourceSetConfig) (*framework.ResourceSet, error) {
 		}
 	}
 
+	var serviceResource framework.Resource
+	{
+		c := service.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		ops, err := service.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		serviceResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var vnetPeeringResource framework.Resource
 	{
 		c := vnetpeering.Config{
@@ -216,6 +235,7 @@ func NewResourceSet(config ResourceSetConfig) (*framework.ResourceSet, error) {
 
 	resources := []framework.Resource{
 		namespaceResource,
+		serviceResource,
 		resourceGroupResource,
 		deploymentResource,
 		dnsrecordResource,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2372

e.g:
```
$ kubectl get -n=heu7i svc master -o yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    giantswarm.io/prometheus-cluster: heu7i
  creationTimestamp: 2018-04-09T10:36:24Z
  labels:
    app: master
    cluster: heu7i
    customer: giantswarm
  name: master
  namespace: heu7i
  resourceVersion: "2921913"
  selfLink: /api/v1/namespaces/heu7i/services/master
  uid: da1d0187-3be1-11e8-af51-000d3a2870da
spec:
  clusterIP: 172.31.0.105
  ports:
  - port: 443
    protocol: TCP
    targetPort: 443
  sessionAffinity: None
  type: ClusterIP
status:
  loadBalancer: {}
```