### PR TITLE
Remove under construction message

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@
 
 The azure-operator manages Kubernetes clusters running in Giantnetes on Azure.
 
-The azure-operator is still under development. See our [aws-operator](https://github.com/giantswarm/aws-operator)
-for launching Giantnetes clusters on AWS.
-
 ## Getting Project
 
 Clone the git repository: https://github.com/giantswarm/azure-operator.git


### PR DESCRIPTION
Message is out of date and doesn't need to link to AWS.