### PR TITLE
fix: Microsoft.Network/networkInterfaces/<cluster name>-Master-1-NIC not found

### DIFF
--- a/service/controller/v1/key/key.go
+++ b/service/controller/v1/key/key.go
@@ -139,6 +139,10 @@ func WorkerSubnetName(customObject providerv1alpha1.AzureConfig) string {
 	return fmt.Sprintf("%s-%s-%s", ClusterID(customObject), virtualNetworkSuffix, workerSubnetSuffix)
 }
 
+func MasterVMSSName(customObject providerv1alpha1.AzureConfig) string {
+	return fmt.Sprintf("%s-master", ClusterID(customObject))
+}
+
 func WorkerVMSSName(customObject providerv1alpha1.AzureConfig) string {
 	return "worker-vmss"
 }

--- a/service/controller/v1/key/key.go
+++ b/service/controller/v1/key/key.go
@@ -144,7 +144,7 @@ func MasterVMSSName(customObject providerv1alpha1.AzureConfig) string {
 }
 
 func WorkerVMSSName(customObject providerv1alpha1.AzureConfig) string {
-	return "worker-vmss"
+	return fmt.Sprintf("%s-worker", ClusterID(customObject))
 }
 
 // MasterNICName returns name of the master NIC.

--- a/service/controller/v1/resource/endpoints/desired.go
+++ b/service/controller/v1/resource/endpoints/desired.go
@@ -17,7 +17,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
-	masterNICPrivateIP, err := r.getMasterNICPrivateIP(key.ClusterID(customObject), key.MasterNICName(customObject))
+	masterNICPrivateIPs, err := r.getMasterNICPrivateIPs(key.ClusterID(customObject), key.MasterVMSSName(customObject))
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -35,20 +35,21 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 				"giantswarm.io/managed-by":   "azure-operator",
 			},
 		},
-		Subsets: []v1.EndpointSubset{
-			{
-				Addresses: []v1.EndpointAddress{
-					{
-						IP: masterNICPrivateIP,
-					},
-				},
-				Ports: []v1.EndpointPort{
-					{
-						Port: httpsPort,
-					},
+	}
+
+	for _, ip := range masterNICPrivateIPs {
+		endpoints.Subsets = append(endpoints.Subsets, v1.EndpointSubset{
+			Addresses: []v1.EndpointAddress{
+				{
+					IP: ip,
 				},
 			},
-		},
+			Ports: []v1.EndpointPort{
+				{
+					Port: httpsPort,
+				},
+			},
+		})
 	}
 
 	return endpoints, nil


### PR DESCRIPTION
After migration to vmss, the endpoint resource broke because it try to read get the Network Interface Controller using the old method `interfacesClient.Get`.

We now need to retrieve the network interface from the vmss using `interfacesClient.ListVirtualMachineScaleSetNetworkInterfaces`. This PR implement this method.


the encountered error is
```
W 18-04-24 10:40:30 /apis/provider.giantswarm.io/v1alpha1/namespaces/default/azureconfigs/dfi0y retrying due to error | operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:96 | function=GetDesiredState | resource=endpointsv1 | underlyingResource=endpointsv1
    /go/src/github.com/giantswarm/azure-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/crud_resource_ops_wrapper.go:89:
    /go/src/github.com/giantswarm/azure-operator/service/controller/v1/resource/endpoints/desired.go:22:
    /go/src/github.com/giantswarm/azure-operator/service/controller/v1/resource/endpoints/nic.go:30:
    network.InterfacesClient#Get: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceNotFound" Message="The Resource 'Microsoft.Network/networkInterfaces/dfi0y-Master-1-NIC' under resource group 'dfi0y' was not found."
```