### PR TITLE
v1: cancel endpoints & service deletion

### DIFF
--- a/service/controller/v1/resource/deployment/resource.go
+++ b/service/controller/v1/resource/deployment/resource.go
@@ -87,6 +87,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	// Deleting the resource group will take care about cleaning
 	// deployments.
 	if key.IsDeleted(customObject) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling deployment deletion: deleted with the resource group")
 		resourcecanceledcontext.SetCanceled(ctx)
 		return nil, nil
 	}

--- a/service/controller/v1/resource/endpoints/current.go
+++ b/service/controller/v1/resource/endpoints/current.go
@@ -20,6 +20,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	// Deleting the K8s namespace will take care of cleaning the endpoints.
 	if key.IsDeleted(customObject) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling endpoints deletion: deleted with the namespace")
 		resourcecanceledcontext.SetCanceled(ctx)
 		return nil, nil
 	}

--- a/service/controller/v1/resource/service/current.go
+++ b/service/controller/v1/resource/service/current.go
@@ -21,6 +21,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	// Deleting the K8s namespace will take care of cleaning the service.
 	if key.IsDeleted(customObject) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling service deletion: deleted with the namespace")
 		resourcecanceledcontext.SetCanceled(ctx)
 		return nil, nil
 	}

--- a/service/controller/v1/resource/service/current.go
+++ b/service/controller/v1/resource/service/current.go
@@ -8,6 +8,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 
 	"github.com/giantswarm/azure-operator/service/controller/v1/key"
 )
@@ -16,6 +17,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	customObject, err := key.ToCustomObject(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
+	}
+
+	// Deleting the K8s namespace will take care of cleaning the service.
+	if key.IsDeleted(customObject) {
+		resourcecanceledcontext.SetCanceled(ctx)
+		return nil, nil
 	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the master service in the Kubernetes API")


### PR DESCRIPTION
They are deleted with the namespace. Endpoints does failing Azure API
calls on deletion so this change is necessary.