### PR TITLE
Update certs dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -108,7 +108,7 @@
     ".",
     "certstest"
   ]
-  revision = "7be474c80bf0e824b1e575d21fb699686c0a9e4d"
+  revision = "c087c8dd2a0a56cdebb4f41275de1ac448071a9c"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
This update fixes problem with old clusters that don't have
calico-etcd-client certs.