### PR TITLE
Add germancloud support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -132,7 +132,7 @@
     "v_3_2_5",
     "v_3_3_0"
   ]
-  revision = "28e732970d7695a176209b8483142427327fe221"
+  revision = "0e1efc0ed01e5f23bfbce140e95b78b427a29328"
 
 [[projects]]
   branch = "master"

--- a/client/azure.go
+++ b/client/azure.go
@@ -218,5 +218,5 @@ func parseAzureEnvironment(cloudName string) (azure.Environment, error) {
 			return env, microerror.Maskf(err, "parsing Azure environment")
 		}
 	}
-	return env, err
+	return env, microerror.Maskf(err, "parsing Azure environment")
 }

--- a/client/azure.go
+++ b/client/azure.go
@@ -151,42 +151,54 @@ func ResponseWasNotFound(resp autorest.Response) bool {
 }
 
 func newDeploymentsClient(config *azureClientConfig) (*resources.DeploymentsClient, error) {
-	client := resources.NewDeploymentsClient(config.subscriptionID)
+	client := resources.NewDeploymentsClientWithBaseURI(
+		config.resourceManagerEndpoint,
+		config.subscriptionID)
 	client.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
 
 	return &client, nil
 }
 
 func newGroupsClient(config *azureClientConfig) (*resources.GroupsClient, error) {
-	client := resources.NewGroupsClient(config.subscriptionID)
+	client := resources.NewGroupsClientWithBaseURI(
+		config.resourceManagerEndpoint,
+		config.subscriptionID)
 	client.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
 
 	return &client, nil
 }
 
 func newDNSRecordSetsClient(config *azureClientConfig) (*dns.RecordSetsClient, error) {
-	client := dns.NewRecordSetsClient(config.subscriptionID)
+	client := dns.NewRecordSetsClientWithBaseURI(
+		config.resourceManagerEndpoint,
+		config.subscriptionID)
 	client.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
 
 	return &client, nil
 }
 
 func newDNSZonesClient(config *azureClientConfig) (*dns.ZonesClient, error) {
-	client := dns.NewZonesClient(config.subscriptionID)
+	client := dns.NewZonesClientWithBaseURI(
+		config.resourceManagerEndpoint,
+		config.subscriptionID)
 	client.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
 
 	return &client, nil
 }
 
 func newInterfacesClient(config *azureClientConfig) (*network.InterfacesClient, error) {
-	client := network.NewInterfacesClient(config.subscriptionID)
+	client := network.NewInterfacesClientWithBaseURI(
+		config.resourceManagerEndpoint,
+		config.subscriptionID)
 	client.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
 
 	return &client, nil
 }
 
 func newVnetPeeringClient(config *azureClientConfig) (*network.VirtualNetworkPeeringsClient, error) {
-	client := network.NewVirtualNetworkPeeringsClient(config.subscriptionID)
+	client := network.NewVirtualNetworkPeeringsClientWithBaseURI(
+		config.resourceManagerEndpoint,
+		config.subscriptionID)
 	client.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
 
 	return &client, nil

--- a/client/azure.go
+++ b/client/azure.go
@@ -151,54 +151,42 @@ func ResponseWasNotFound(resp autorest.Response) bool {
 }
 
 func newDeploymentsClient(config *azureClientConfig) (*resources.DeploymentsClient, error) {
-	client := resources.NewDeploymentsClientWithBaseURI(
-		config.resourceManagerEndpoint,
-		config.subscriptionID)
+	client := resources.NewDeploymentsClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	client.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
 
 	return &client, nil
 }
 
 func newGroupsClient(config *azureClientConfig) (*resources.GroupsClient, error) {
-	client := resources.NewGroupsClientWithBaseURI(
-		config.resourceManagerEndpoint,
-		config.subscriptionID)
+	client := resources.NewGroupsClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	client.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
 
 	return &client, nil
 }
 
 func newDNSRecordSetsClient(config *azureClientConfig) (*dns.RecordSetsClient, error) {
-	client := dns.NewRecordSetsClientWithBaseURI(
-		config.resourceManagerEndpoint,
-		config.subscriptionID)
+	client := dns.NewRecordSetsClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	client.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
 
 	return &client, nil
 }
 
 func newDNSZonesClient(config *azureClientConfig) (*dns.ZonesClient, error) {
-	client := dns.NewZonesClientWithBaseURI(
-		config.resourceManagerEndpoint,
-		config.subscriptionID)
+	client := dns.NewZonesClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	client.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
 
 	return &client, nil
 }
 
 func newInterfacesClient(config *azureClientConfig) (*network.InterfacesClient, error) {
-	client := network.NewInterfacesClientWithBaseURI(
-		config.resourceManagerEndpoint,
-		config.subscriptionID)
+	client := network.NewInterfacesClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	client.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
 
 	return &client, nil
 }
 
 func newVnetPeeringClient(config *azureClientConfig) (*network.VirtualNetworkPeeringsClient, error) {
-	client := network.NewVirtualNetworkPeeringsClientWithBaseURI(
-		config.resourceManagerEndpoint,
-		config.subscriptionID)
+	client := network.NewVirtualNetworkPeeringsClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	client.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
 
 	return &client, nil
@@ -210,7 +198,12 @@ func newServicePrincipalToken(config AzureConfig, env azure.Environment) (*adal.
 		return nil, microerror.Maskf(err, "creating OAuth config")
 	}
 
-	return adal.NewServicePrincipalToken(*oauthConfig, config.ClientID, config.ClientSecret, env.ServiceManagementEndpoint)
+	token, err := adal.NewServicePrincipalToken(*oauthConfig, config.ClientID, config.ClientSecret, env.ServiceManagementEndpoint)
+	if err != nil {
+		return nil, microerror.Maskf(err, "getting token")
+	}
+
+	return token, nil
 }
 
 // parseAzureEnvironment returns azure environment by name.

--- a/flag/service/azure/azure.go
+++ b/flag/service/azure/azure.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Azure struct {
+	Cloud          string
 	ClientID       string
 	ClientSecret   string
 	HostCluster    hostcluster.HostCluster

--- a/helm/azure-operator-chart/templates/configmap.yaml
+++ b/helm/azure-operator-chart/templates/configmap.yaml
@@ -10,6 +10,7 @@ data:
         address: 'http://0.0.0.0:8000'
     service:
       azure:
+        cloud: '{{ .Values.Installation.V1.Provider.Azure.Cloud }}'
         hostCluster:
           cidr: '{{ .Values.Installation.V1.Provider.Azure.HostCluster.CIDR }}'
           resourceGroup: '{{ .Values.Installation.V1.Provider.Azure.HostCluster.ResourceGroup }}'

--- a/integration/template/azure_operator_charts_values.go
+++ b/integration/template/azure_operator_charts_values.go
@@ -17,6 +17,7 @@ var AzureOperatorChartValues = `Installation:
     Name: ci-azure-operator
     Provider:
       Azure:
+        Cloud: AZUREPUBLICCLOUD
         HostCluster:
           CIDR: "10.0.0.0/16"
           ResourceGroup: "godsmack"

--- a/main.go
+++ b/main.go
@@ -119,6 +119,8 @@ func mainError() error {
 
 	daemonCommand.PersistentFlags().String(f.Service.Azure.ClientID, "", "ID of the Active Directory Service Principal.")
 	daemonCommand.PersistentFlags().String(f.Service.Azure.ClientSecret, "", "Secret of the Active Directory Service Principal.")
+	// The cloud environment identifier. Takes values from https://github.com/Azure/go-autorest/blob/ec5f4903f77ed9927ac95b19ab8e44ada64c1356/autorest/azure/environments.go#L13
+	daemonCommand.PersistentFlags().String(f.Service.Azure.Cloud, "AZUREPUBLICCLOUD", "Azure Cloud Environment identifier.")
 	daemonCommand.PersistentFlags().String(f.Service.Azure.HostCluster.CIDR, "", "CIDR of the host cluster virtual network used to create a peering.")
 	daemonCommand.PersistentFlags().String(f.Service.Azure.HostCluster.ResourceGroup, "", "Host cluster resource group name.")
 	daemonCommand.PersistentFlags().String(f.Service.Azure.HostCluster.VirtualNetwork, "", "Host cluster virtual network name.")

--- a/service/controller/setting/types.go
+++ b/service/controller/setting/types.go
@@ -3,11 +3,15 @@ package setting
 import "fmt"
 
 type Azure struct {
+	Cloud       string
 	HostCluster AzureHostCluster
 	Location    string
 }
 
 func (a Azure) Validate() error {
+	if a.Cloud == "" {
+		return fmt.Errorf("Location must not be empty")
+	}
 	if err := a.HostCluster.Validate(); err != nil {
 		return fmt.Errorf("HostCluster.%s", err)
 	}

--- a/service/controller/v1/resource/deployment/resource_test.go
+++ b/service/controller/v1/resource/deployment/resource_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 var testAzure = setting.Azure{
+	Cloud: "AZUREPUBLICCLOUD",
 	HostCluster: setting.AzureHostCluster{
 		CIDR:           "10.0.0.0/8",
 		ResourceGroup:  "test-group",

--- a/service/controller/v1/resource/resourcegroup/resource_test.go
+++ b/service/controller/v1/resource/resourcegroup/resource_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 var testAzure = setting.Azure{
+	Cloud: "AZUREPUBLICCLOUD",
 	HostCluster: setting.AzureHostCluster{
 		CIDR:           "10.0.0.0/8",
 		ResourceGroup:  "test-group",

--- a/service/controller/v1/version_bundle.go
+++ b/service/controller/v1/version_bundle.go
@@ -46,7 +46,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 		},
 		Dependencies: []versionbundle.Dependency{},
-		Deprecated:   true,
+		Deprecated:   false,
 		Name:         "azure-operator",
 		Time:         time.Date(2018, time.January, 7, 8, 35, 0, 0, time.UTC),
 		Version:      "0.1.0",

--- a/service/controller/v1/version_bundle.go
+++ b/service/controller/v1/version_bundle.go
@@ -46,7 +46,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 		},
 		Dependencies: []versionbundle.Dependency{},
-		Deprecated:   false,
+		Deprecated:   true,
 		Name:         "azure-operator",
 		Time:         time.Date(2018, time.January, 7, 8, 35, 0, 0, time.UTC),
 		Version:      "0.1.0",

--- a/service/controller/v2/cloudconfig/template.go
+++ b/service/controller/v2/cloudconfig/template.go
@@ -523,7 +523,7 @@ const (
 	cloudProviderConfFileName       = "/etc/kubernetes/config/azure.yaml"
 	cloudProviderConfFileOwner      = "root:root"
 	cloudProviderConfFilePermission = 0600
-	cloudProviderConfFileTemplate   = `cloud: AZUREPUBLICCLOUD
+	cloudProviderConfFileTemplate   = `cloud: {{ .Cloud }}
 tenantId: {{ .TenantID }}
 subscriptionId: {{ .SubscriptionID }}
 resourceGroup: {{ .ResourceGroup }}

--- a/service/controller/v2/cloudconfig/template.go
+++ b/service/controller/v2/cloudconfig/template.go
@@ -4,8 +4,8 @@ const (
 	calicoAzureFileName       = "/srv/calico-azure.yaml"
 	calicoAzureFileOwner      = "root:root"
 	calicoAzureFilePermission = 0600
-	calicoAzureFileTemplate   = `# Calico Version v3.0.1
-# https://docs.projectcalico.org/v3.0/releases#v3.0.1
+	calicoAzureFileTemplate   = `# Calico Version v3.0.5
+# https://docs.projectcalico.org/v3.0/releases#v3.0.5
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
@@ -91,11 +91,11 @@ subjects:
 
 ---
 
-# Calico Version v3.0.1
-# https://docs.projectcalico.org/v3.0/releases#v3.0.1
+# Calico Version v3.0.5
+# https://docs.projectcalico.org/v3.0/releases#v3.0.5
 # This manifest includes the following component versions:
-#   calico/node:v3.0.1
-#   calico/cni:v2.0.0
+#   calico/node:v3.0.5
+#   calico/cni:v2.0.4
 
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap
@@ -200,7 +200,7 @@ spec:
       hostNetwork: true
       serviceAccountName: calico-node
       containers:
-      - image: quay.io/calico/typha:v0.6.0
+      - image: quay.io/calico/typha:v0.6.3
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -290,7 +290,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: quay.io/calico/node:v3.0.1
+          image: quay.io/calico/node:v3.0.5
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -365,7 +365,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: quay.io/calico/cni:v2.0.0
+          image: quay.io/calico/cni:v2.0.4
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.

--- a/service/controller/v2/cloudconfig/types.go
+++ b/service/controller/v2/cloudconfig/types.go
@@ -23,6 +23,7 @@ func newCalicoAzureFileParams(obj providerv1alpha1.AzureConfig) calicoAzureFileP
 type cloudProviderConfFileVMType string
 
 type cloudProviderConfFileParams struct {
+	Cloud               string
 	Location            string
 	PrimaryScaleSetName string
 	ResourceGroup       string
@@ -36,6 +37,7 @@ type cloudProviderConfFileParams struct {
 
 func newCloudProviderConfFileParams(azure setting.Azure, azureConfig client.AzureConfig, obj providerv1alpha1.AzureConfig) cloudProviderConfFileParams {
 	return cloudProviderConfFileParams{
+		Cloud:               azure.Cloud,
 		Location:            azure.Location,
 		PrimaryScaleSetName: key.WorkerVMSSName(obj),
 		ResourceGroup:       key.ResourceGroupName(obj),

--- a/service/controller/v2/resource/deployment/resource_test.go
+++ b/service/controller/v2/resource/deployment/resource_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 var testAzure = setting.Azure{
+	Cloud: "AZUREPUBLICCLOUD",
 	HostCluster: setting.AzureHostCluster{
 		CIDR:           "10.0.0.0/8",
 		ResourceGroup:  "test-group",

--- a/service/controller/v2/resource/resourcegroup/resource_test.go
+++ b/service/controller/v2/resource/resourcegroup/resource_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 var testAzure = setting.Azure{
+	Cloud: "AZUREPUBLICCLOUD",
 	HostCluster: setting.AzureHostCluster{
 		CIDR:           "10.0.0.0/8",
 		ResourceGroup:  "test-group",

--- a/service/controller/v2/version_bundle.go
+++ b/service/controller/v2/version_bundle.go
@@ -10,14 +10,14 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "azure-operator",
-				Description: "Added first release.",
-				Kind:        versionbundle.KindAdded,
+				Component:   "kubernetes",
+				Description: "updated to 1.10.2.",
+				Kind:        versionbundle.KindChanged,
 			},
 			{
-				Component:   "kubernetes",
-				Description: "Updated to 1.10.2.",
-				Kind:        versionbundle.KindChanged,
+				Component:   "cloudconfig",
+				Description: "Removed kube-state-metrics related components (will be managed by chart-operator).",
+				Kind:        versionbundle.KindRemoved,
 			},
 		},
 		Components: []versionbundle.Component{
@@ -53,8 +53,8 @@ func VersionBundle() versionbundle.Bundle {
 		Dependencies: []versionbundle.Dependency{},
 		Deprecated:   false,
 		Name:         "azure-operator",
-		Time:         time.Date(2018, time.January, 7, 8, 35, 0, 0, time.UTC),
+		Time:         time.Date(2018, time.May, 14, 12, 00, 0, 0, time.UTC),
 		Version:      "0.2.0",
-		WIP:          true,
+		WIP:          false,
 	}
 }

--- a/service/controller/v2/version_bundle.go
+++ b/service/controller/v2/version_bundle.go
@@ -24,6 +24,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Added German cloud support.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "cloudconfig",
+				Description: "Updated Calico to 3.0.5",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{
@@ -60,6 +65,6 @@ func VersionBundle() versionbundle.Bundle {
 		Name:         "azure-operator",
 		Time:         time.Date(2018, time.May, 14, 12, 00, 0, 0, time.UTC),
 		Version:      "0.2.0",
-		WIP:          false,
+		WIP:          true,
 	}
 }

--- a/service/controller/v2/version_bundle.go
+++ b/service/controller/v2/version_bundle.go
@@ -19,6 +19,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Removed kube-state-metrics related components (will be managed by chart-operator).",
 				Kind:        versionbundle.KindRemoved,
 			},
+			{
+				Component:   "azure-operator",
+				Description: "Added German cloud support.",
+				Kind:        versionbundle.KindAdded,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/service.go
+++ b/service/service.go
@@ -72,6 +72,7 @@ func New(config Config) (*Service, error) {
 	var err error
 
 	azure := setting.Azure{
+		Cloud: config.Viper.GetString(config.Flag.Service.Azure.Cloud),
 		HostCluster: setting.AzureHostCluster{
 			CIDR:           config.Viper.GetString(config.Flag.Service.Azure.HostCluster.CIDR),
 			ResourceGroup:  config.Viper.GetString(config.Flag.Service.Azure.HostCluster.ResourceGroup),
@@ -85,6 +86,7 @@ func New(config Config) (*Service, error) {
 
 		ClientID:       config.Viper.GetString(config.Flag.Service.Azure.ClientID),
 		ClientSecret:   config.Viper.GetString(config.Flag.Service.Azure.ClientSecret),
+		Cloud:          config.Viper.GetString(config.Flag.Service.Azure.Cloud),
 		SubscriptionID: config.Viper.GetString(config.Flag.Service.Azure.SubscriptionID),
 		TenantID:       config.Viper.GetString(config.Flag.Service.Azure.TenantID),
 	}

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_3_3_0/master_template.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_3_3_0/master_template.go
@@ -965,77 +965,6 @@ write_files:
           hostPID: true
           securityContext:
             runAsUser: 0
-- path: /srv/kube-state-metrics-svc.yaml
-  owner: root
-  permissions: 0644
-  content: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      name: kube-state-metrics
-      namespace: kube-system
-      labels:
-        app: kube-state-metrics
-      annotations:
-        prometheus.io/scrape: 'true'
-        prometheus.io/scheme: "http"
-    spec:
-      ports:
-      - port: 10301
-      selector:
-        app: kube-state-metrics
-- path: /srv/kube-state-metrics-sa.yaml
-  owner: root
-  permissions: 0644
-  content: |
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: kube-state-metrics
-      namespace: kube-system
-      labels:
-        app: kube-state-metrics
-- path: /srv/kube-state-metrics-dep.yaml
-  owner: root
-  permissions: 0644
-  content: |
-    apiVersion: extensions/v1beta1
-    kind: Deployment
-    metadata:
-      name: kube-state-metrics
-      namespace: kube-system
-      labels:
-        app: kube-state-metrics
-    spec:
-      replicas: 1
-      template:
-        metadata:
-          labels:
-            app: kube-state-metrics
-        spec:
-          containers:
-          - name: kube-state-metrics
-            image: quay.io/giantswarm/kube-state-metrics:v1.3.1
-            args:
-              - '--port=10301'
-            livenessProbe:
-              httpGet:
-                path: /
-                port: 10301
-              initialDelaySeconds: 5
-              timeoutSeconds: 5
-            readinessProbe:
-              httpGet:
-                path: /
-                port: 10301
-              initialDelaySeconds: 5
-              timeoutSeconds: 5
-            resources:
-              requests:
-                cpu: 50m
-                memory: 75Mi
-          serviceAccountName: kube-state-metrics
-          hostNetwork: true
 - path: /srv/rbac_bindings.yaml
   owner: root
   permissions: 0644
@@ -1177,21 +1106,6 @@ write_files:
     roleRef:
       kind: Role
       name: node-exporter
-      apiGroup: rbac.authorization.k8s.io
-    ---
-    kind: ClusterRoleBinding
-    apiVersion: rbac.authorization.k8s.io/v1beta1
-    metadata:
-      name: kube-state-metrics
-      labels:
-        app: kube-state-metrics
-    subjects:
-      - kind: ServiceAccount
-        name: kube-state-metrics
-        namespace: kube-system
-    roleRef:
-      kind: ClusterRole
-      name: kube-state-metrics
       apiGroup: rbac.authorization.k8s.io
 - path: /srv/rbac_roles.yaml
   owner: root
@@ -1345,72 +1259,6 @@ write_files:
       verbs:     ['use']
       resourceNames:
       - privileged
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      name: kube-state-metrics
-      labels:
-        app: kube-state-metrics
-    rules:
-      - apiGroups:
-          - ""
-        resources:
-          - nodes
-          - pods
-          - services
-          - resourcequotas
-          - replicationcontrollers
-          - limitranges
-          - persistentvolumeclaims
-          - persistentvolumes
-          - namespaces
-          - endpoints
-          - secrets
-          - configmaps
-        verbs:
-          - list
-          - watch
-      - apiGroups:
-          - extensions
-        resources:
-          - daemonsets
-          - deployments
-          - replicasets
-        verbs:
-          - list
-          - watch
-      - apiGroups:
-          - apps
-        resources:
-          - statefulsets
-        verbs:
-          - list
-          - watch
-      - apiGroups:
-          - batch
-        resources:
-          - cronjobs
-          - jobs
-        verbs:
-          - list
-          - watch
-      - apiGroups:
-          - extensions
-        resources:
-          - podsecuritypolicies
-        verbs:
-          - use
-        resourceNames:
-          - privileged
-      - apiGroups:
-          - autoscaling
-        attributeRestrictions: null
-        resources:
-          - horizontalpodautoscalers
-        verbs:
-          - list
-          - watch
 - path: /srv/psp_policies.yaml
   owner: root
   permissions: 0644
@@ -1697,9 +1545,6 @@ write_files:
       MANIFESTS="${MANIFESTS} node-exporter-svc.yaml"
       MANIFESTS="${MANIFESTS} node-exporter-sa.yaml"
       MANIFESTS="${MANIFESTS} node-exporter-ds.yaml"
-      MANIFESTS="${MANIFESTS} kube-state-metrics-svc.yaml"
-      MANIFESTS="${MANIFESTS} kube-state-metrics-sa.yaml"
-      MANIFESTS="${MANIFESTS} kube-state-metrics-dep.yaml"
 
       for manifest in $MANIFESTS
       do


### PR DESCRIPTION
There are multiple changes:
- added new configuration flag `--service.azure.cloud`
- added cloud support to azure client package (made it similar as done in Kubernetes)
- updated calico to 3.0.5 (as it was in changelog, but template was not updated)
- make `v2` active release and deprecate `v1`

Related: https://github.com/giantswarm/installations/pull/310
Related: https://github.com/giantswarm/k8scloudconfig/pull/368

Status: Tested in `tarantula` cluster creation started, but vmss fail to be created with "Internal server error" from Azure. Working on it.