### PR TITLE
fixes build names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,12 @@ jobs:
 
 
 
-  e2eTestReady:
+  e2eTestMasterReady:
+    environment:
+      TEST_DIR: "integration/test/ready"
+    <<: *e2eTest
+
+  e2eTestPRReady:
     environment:
       TEST_DIR: "integration/test/ready"
     <<: *e2eTest


### PR DESCRIPTION
There was the hold target introduced in https://github.com/giantswarm/azure-operator/pull/207 but the build names are not aligned. This PR fixes this. 