### PR TITLE
simplifies error masking of errors that are only dispatched

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,12 @@ jobs:
 
 
 
-  e2eTestReady:
+  e2eTestMasterReady:
+    environment:
+      TEST_DIR: "integration/test/ready"
+    <<: *e2eTest
+
+  e2eTestPRReady:
     environment:
       TEST_DIR: "integration/test/ready"
     <<: *e2eTest

--- a/service/controller/v2/cloudconfig/cloud_config.go
+++ b/service/controller/v2/cloudconfig/cloud_config.go
@@ -196,7 +196,7 @@ func newCloudConfig(template string, params k8scloudconfig.Params) (string, erro
 
 	compressed, err := gzipBase64(cloudConfig.String())
 	if err != nil {
-		return "", microerror.Maskf(err, "compressing cloud-config")
+		return "", microerror.Mask(err)
 	}
 
 	// cloud-config is compressed so we fit the tight 85kB limit of
@@ -221,15 +221,15 @@ func gzipBase64(s string) (string, error) {
 
 	w, err := gzip.NewWriterLevel(buf, gzip.BestCompression)
 	if err != nil {
-		return "", microerror.Maskf(err, "creating gzip stream")
+		return "", microerror.Mask(err)
 	}
 	_, err = io.WriteString(w, s)
 	if err != nil {
-		return "", microerror.Maskf(err, "writing to gzip stream")
+		return "", microerror.Mask(err)
 	}
 	err = w.Close()
 	if err != nil {
-		return "", microerror.Maskf(err, "closing gzip stream")
+		return "", microerror.Mask(err)
 	}
 
 	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil

--- a/service/controller/v2/cloudconfig/master_extension.go
+++ b/service/controller/v2/cloudconfig/master_extension.go
@@ -22,22 +22,22 @@ type masterExtension struct {
 func (me *masterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 	calicoAzureFile, err := me.renderCalicoAzureFile()
 	if err != nil {
-		return nil, microerror.Maskf(err, "renderCalicoAzureFile")
+		return nil, microerror.Mask(err)
 	}
 
 	certificateFiles, err := me.renderCertificatesFiles()
 	if err != nil {
-		return nil, microerror.Maskf(err, "renderCertificatesFiles")
+		return nil, microerror.Mask(err)
 	}
 
 	cloudProviderConfFile, err := me.renderCloudProviderConfFile()
 	if err != nil {
-		return nil, microerror.Maskf(err, "renderCloudProviderConfFile")
+		return nil, microerror.Mask(err)
 	}
 
 	defaultStorageClassFile, err := me.renderDefaultStorageClassFile()
 	if err != nil {
-		return nil, microerror.Maskf(err, "renderDefaultStorageClassFile")
+		return nil, microerror.Mask(err)
 	}
 
 	files := []k8scloudconfig.FileAsset{
@@ -55,25 +55,25 @@ func (me *masterExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
 	// Unit to format etcd disk.
 	formatEtcdUnit, err := me.renderEtcdDiskFormatUnit()
 	if err != nil {
-		return nil, microerror.Maskf(err, "renderEtcdDiskFormatUnit")
+		return nil, microerror.Mask(err)
 	}
 
 	// Unit to mount etcd disk.
 	mountEtcdUnit, err := me.renderEtcdMountUnit()
 	if err != nil {
-		return nil, microerror.Maskf(err, "renderEtcdMountUnit")
+		return nil, microerror.Mask(err)
 	}
 
 	// Unit to format docker disk.
 	formatDockerUnit, err := me.renderDockerDiskFormatUnit()
 	if err != nil {
-		return nil, microerror.Maskf(err, "renderDockerDiskFormatUnit")
+		return nil, microerror.Mask(err)
 	}
 
 	// Unit to mount docker disk.
 	mountDockerUnit, err := me.renderDockerMountUnit()
 	if err != nil {
-		return nil, microerror.Maskf(err, "renderDockerMountUnit")
+		return nil, microerror.Mask(err)
 	}
 
 	units := []k8scloudconfig.UnitAsset{

--- a/service/controller/v2/cloudconfig/worker_extension.go
+++ b/service/controller/v2/cloudconfig/worker_extension.go
@@ -22,12 +22,12 @@ type workerExtension struct {
 func (we *workerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 	certificateFiles, err := we.renderCertificatesFiles()
 	if err != nil {
-		return nil, microerror.Maskf(err, "renderCertificatesFiles")
+		return nil, microerror.Mask(err)
 	}
 
 	cloudProviderConfFile, err := we.renderCloudProviderConfFile()
 	if err != nil {
-		return nil, microerror.Maskf(err, "renderCloudProviderConfFile")
+		return nil, microerror.Mask(err)
 	}
 
 	files := []k8scloudconfig.FileAsset{
@@ -43,13 +43,13 @@ func (we *workerExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
 	// Unit to format docker disk.
 	formatDockerUnit, err := we.renderDockerDiskFormatUnit()
 	if err != nil {
-		return nil, microerror.Maskf(err, "renderDockerDiskFormatUnit")
+		return nil, microerror.Mask(err)
 	}
 
 	// Unit to mount docker disk.
 	mountDockerUnit, err := we.renderDockerMountUnit()
 	if err != nil {
-		return nil, microerror.Maskf(err, "renderDockerMountUnit")
+		return nil, microerror.Mask(err)
 	}
 
 	units := []k8scloudconfig.UnitAsset{

--- a/service/controller/v2/resource/deployment/network.go
+++ b/service/controller/v2/resource/deployment/network.go
@@ -12,7 +12,7 @@ func secondHalf(cidr string) (string, error) {
 	{
 		_, n, err := net.ParseCIDR(cidr)
 		if err != nil {
-			return "", microerror.Maskf(err, "parsing cidr=%q", cidr)
+			return "", microerror.Mask(err)
 		}
 		network = *n
 	}

--- a/service/controller/v2/resource/deployment/resource.go
+++ b/service/controller/v2/resource/deployment/resource.go
@@ -178,7 +178,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createState inter
 		resourceGroupName := key.ClusterID(customObject)
 		deploymentsClient, err := r.getDeploymentsClient()
 		if err != nil {
-			return microerror.Maskf(err, "creating Azure deployments")
+			return microerror.Mask(err)
 		}
 
 		for _, deploy := range deploymentsToCreate {

--- a/service/controller/v2/resource/dnsrecord/create.go
+++ b/service/controller/v2/resource/dnsrecord/create.go
@@ -13,12 +13,12 @@ import (
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, change interface{}) error {
 	o, err := key.ToCustomObject(obj)
 	if err != nil {
-		return microerror.Maskf(err, "creating DNS records in host cluster")
+		return microerror.Mask(err)
 	}
 
 	c, err := toDNSRecords(change)
 	if err != nil {
-		return microerror.Maskf(err, "creating DNS records in host cluster")
+		return microerror.Mask(err)
 	}
 
 	return r.applyCreateChange(ctx, o, c)

--- a/service/controller/v2/resource/dnsrecord/current.go
+++ b/service/controller/v2/resource/dnsrecord/current.go
@@ -14,7 +14,7 @@ import (
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
 	o, err := key.ToCustomObject(obj)
 	if err != nil {
-		return nil, microerror.Maskf(err, "GetCurrentState")
+		return nil, microerror.Mask(err)
 	}
 
 	return r.getCurrentState(ctx, o)
@@ -23,7 +23,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 func (r *Resource) getCurrentState(ctx context.Context, obj providerv1alpha1.AzureConfig) (dnsRecords, error) {
 	recordSetsClient, err := r.getDNSRecordSetsClient()
 	if err != nil {
-		return nil, microerror.Maskf(err, "GetCurrentState")
+		return nil, microerror.Mask(err)
 	}
 
 	current := newPartialDNSRecords(obj)
@@ -33,7 +33,7 @@ func (r *Resource) getCurrentState(ctx context.Context, obj providerv1alpha1.Azu
 		if client.ResponseWasNotFound(resp.Response) {
 			continue
 		} else if err != nil {
-			return nil, microerror.Maskf(err, "GetCurrentState: getting record=%#v", record)
+			return nil, microerror.Mask(err)
 		}
 
 		var nameServers []string

--- a/service/controller/v2/resource/dnsrecord/delete.go
+++ b/service/controller/v2/resource/dnsrecord/delete.go
@@ -16,11 +16,11 @@ import (
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, change interface{}) error {
 	o, err := key.ToCustomObject(obj)
 	if err != nil {
-		return microerror.Maskf(err, "deleting host cluster DNS records")
+		return microerror.Mask(err)
 	}
 	c, err := toDNSRecords(change)
 	if err != nil {
-		return microerror.Maskf(err, "deleting host cluster DNS records")
+		return microerror.Mask(err)
 	}
 
 	return r.applyDeleteChange(ctx, o, c)
@@ -36,7 +36,7 @@ func (r *Resource) applyDeleteChange(ctx context.Context, obj providerv1alpha1.A
 
 	recordSetsClient, err := r.getDNSRecordSetsClient()
 	if err != nil {
-		return microerror.Maskf(err, "deleting host cluster DNS records")
+		return microerror.Mask(err)
 	}
 
 	for _, record := range change {
@@ -44,7 +44,7 @@ func (r *Resource) applyDeleteChange(ctx context.Context, obj providerv1alpha1.A
 
 		_, err := recordSetsClient.Delete(ctx, record.ZoneRG, record.Zone, record.RelativeName, dns.NS, "")
 		if err != nil {
-			return microerror.Maskf(err, fmt.Sprintf("deleting host cluster DNS record=%#v", record))
+			return microerror.Mask(err)
 		}
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting host cluster DNS record=%#v: deleted", record))
@@ -59,15 +59,15 @@ func (r *Resource) applyDeleteChange(ctx context.Context, obj providerv1alpha1.A
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
 	o, err := key.ToCustomObject(obj)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewDeletePatch")
+		return nil, microerror.Mask(err)
 	}
 	c, err := toDNSRecords(currentState)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewDeletePatch")
+		return nil, microerror.Mask(err)
 	}
 	d, err := toDNSRecords(desiredState)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewDeletePatch")
+		return nil, microerror.Mask(err)
 	}
 
 	return r.newDeletePatch(ctx, o, c, d)
@@ -78,7 +78,7 @@ func (r *Resource) newDeletePatch(ctx context.Context, obj providerv1alpha1.Azur
 
 	deleteChange, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewDeletePatch")
+		return nil, microerror.Mask(err)
 	}
 
 	patch.SetDeleteChange(deleteChange)

--- a/service/controller/v2/resource/dnsrecord/desired.go
+++ b/service/controller/v2/resource/dnsrecord/desired.go
@@ -14,7 +14,7 @@ import (
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
 	o, err := key.ToCustomObject(obj)
 	if err != nil {
-		return nil, microerror.Maskf(err, "GetDesiredState")
+		return nil, microerror.Mask(err)
 	}
 
 	return r.getDesiredState(ctx, o)
@@ -23,7 +23,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 func (r *Resource) getDesiredState(ctx context.Context, obj providerv1alpha1.AzureConfig) (dnsRecords, error) {
 	zonesClient, err := r.getDNSZonesClient()
 	if err != nil {
-		return nil, microerror.Maskf(err, "GetDesiredState")
+		return nil, microerror.Mask(err)
 	}
 
 	desired := newPartialDNSRecords(obj)
@@ -34,7 +34,7 @@ func (r *Resource) getDesiredState(ctx context.Context, obj providerv1alpha1.Azu
 		if client.ResponseWasNotFound(resp.Response) {
 			return dnsRecords{}, nil
 		} else if err != nil {
-			return nil, microerror.Maskf(err, "GetDesiredState: getting zone=%q", zone)
+			return nil, microerror.Mask(err)
 		}
 
 		var nameServers []string

--- a/service/controller/v2/resource/dnsrecord/resource.go
+++ b/service/controller/v2/resource/dnsrecord/resource.go
@@ -48,7 +48,7 @@ func (r *Resource) Name() string {
 func (r *Resource) getDNSRecordSetsClient() (*dns.RecordSetsClient, error) {
 	azureClients, err := client.NewAzureClientSet(r.azureConfig)
 	if err != nil {
-		return nil, microerror.Maskf(err, "creating Azure DNS record sets client")
+		return nil, microerror.Mask(err)
 	}
 
 	return azureClients.DNSRecordSetsClient, nil
@@ -57,7 +57,7 @@ func (r *Resource) getDNSRecordSetsClient() (*dns.RecordSetsClient, error) {
 func (r *Resource) getDNSZonesClient() (*dns.ZonesClient, error) {
 	azureClients, err := client.NewAzureClientSet(r.azureConfig)
 	if err != nil {
-		return nil, microerror.Maskf(err, "creating Azure DNS zones client")
+		return nil, microerror.Mask(err)
 	}
 
 	return azureClients.DNSZonesClient, nil

--- a/service/controller/v2/resource/dnsrecord/update.go
+++ b/service/controller/v2/resource/dnsrecord/update.go
@@ -16,12 +16,12 @@ import (
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, change interface{}) error {
 	o, err := key.ToCustomObject(obj)
 	if err != nil {
-		return microerror.Maskf(err, "ensuring host cluster DNS records")
+		return microerror.Mask(err)
 	}
 
 	c, err := toDNSRecords(change)
 	if err != nil {
-		return microerror.Maskf(err, "ensuring host cluster DNS records")
+		return microerror.Mask(err)
 	}
 
 	return r.applyUpdateChange(ctx, o, c)
@@ -32,7 +32,7 @@ func (r *Resource) applyUpdateChange(ctx context.Context, obj providerv1alpha1.A
 
 	recordSetsClient, err := r.getDNSRecordSetsClient()
 	if err != nil {
-		return microerror.Maskf(err, "ensuring host cluster DNS records")
+		return microerror.Mask(err)
 	}
 
 	if len(change) == 0 {
@@ -57,7 +57,7 @@ func (r *Resource) applyUpdateChange(ctx context.Context, obj providerv1alpha1.A
 
 		_, err := recordSetsClient.CreateOrUpdate(ctx, record.ZoneRG, record.Zone, record.RelativeName, dns.NS, params, "", "")
 		if err != nil {
-			return microerror.Maskf(err, fmt.Sprintf("ensuring host cluster DNS record=%#v", record))
+			return microerror.Mask(err)
 		}
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("ensuring host cluster DNS record=%#v: ensured", record))
@@ -72,15 +72,15 @@ func (r *Resource) applyUpdateChange(ctx context.Context, obj providerv1alpha1.A
 func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
 	o, err := key.ToCustomObject(obj)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewUpdatePatch")
+		return nil, microerror.Mask(err)
 	}
 	c, err := toDNSRecords(currentState)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewUpdatePatch")
+		return nil, microerror.Mask(err)
 	}
 	d, err := toDNSRecords(desiredState)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewUpdatePatch")
+		return nil, microerror.Mask(err)
 	}
 
 	return r.newUpdatePatch(ctx, o, c, d)
@@ -91,7 +91,7 @@ func (r *Resource) newUpdatePatch(ctx context.Context, obj providerv1alpha1.Azur
 
 	updateChange, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewUpdatePatch")
+		return nil, microerror.Mask(err)
 	}
 
 	patch.SetUpdateChange(updateChange)

--- a/service/controller/v2/resource/resourcegroup/resource.go
+++ b/service/controller/v2/resource/resourcegroup/resource.go
@@ -148,12 +148,12 @@ func (r *Resource) Name() string {
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createState interface{}) error {
 	_, err := key.ToCustomObject(obj)
 	if err != nil {
-		return microerror.Maskf(err, "creating Azure resource group")
+		return microerror.Mask(err)
 	}
 
 	resourceGroupToCreate, err := toGroup(createState)
 	if err != nil {
-		return microerror.Maskf(err, "creating Azure resource group")
+		return microerror.Mask(err)
 	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "creating Azure resource group")
@@ -161,7 +161,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createState inter
 	if resourceGroupToCreate.Name != "" {
 		groupsClient, err := r.getGroupsClient()
 		if err != nil {
-			return microerror.Maskf(err, "creating Azure resource group")
+			return microerror.Mask(err)
 		}
 
 		resourceGroup := azureresource.Group{
@@ -187,11 +187,11 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createState inter
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteState interface{}) error {
 	_, err := key.ToCustomObject(obj)
 	if err != nil {
-		return microerror.Maskf(err, "deleting Azure resource group")
+		return microerror.Mask(err)
 	}
 	resourceGroupToDelete, err := toGroup(deleteState)
 	if err != nil {
-		return microerror.Maskf(err, "deleting Azure resource group")
+		return microerror.Mask(err)
 	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting Azure resource group")
@@ -199,7 +199,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteState inter
 	if resourceGroupToDelete.Name != "" {
 		groupsClient, err := r.getGroupsClient()
 		if err != nil {
-			return microerror.Maskf(err, "deleting Azure resource group")
+			return microerror.Mask(err)
 		}
 
 		// Delete the resource group which also deletes all resources it

--- a/service/controller/v2/resource/vnetpeering/current.go
+++ b/service/controller/v2/resource/vnetpeering/current.go
@@ -15,12 +15,12 @@ import (
 func (r Resource) GetCurrentState(ctx context.Context, azureConfig interface{}) (interface{}, error) {
 	a, err := key.ToCustomObject(azureConfig)
 	if err != nil {
-		return network.VirtualNetworkPeering{}, microerror.Maskf(err, "GetCurrentState")
+		return network.VirtualNetworkPeering{}, microerror.Mask(err)
 	}
 
 	vnetPeering, err := r.getCurrentState(ctx, a)
 	if err != nil {
-		return network.VirtualNetworkPeering{}, microerror.Maskf(err, "GetCurrentState")
+		return network.VirtualNetworkPeering{}, microerror.Mask(err)
 	}
 
 	return vnetPeering, nil
@@ -29,7 +29,7 @@ func (r Resource) GetCurrentState(ctx context.Context, azureConfig interface{}) 
 func (r Resource) getCurrentState(ctx context.Context, azureConfig providerv1alpha1.AzureConfig) (network.VirtualNetworkPeering, error) {
 	vnetPeeringClient, err := r.getVnetPeeringClient()
 	if err != nil {
-		return network.VirtualNetworkPeering{}, microerror.Maskf(err, "getCurrentState")
+		return network.VirtualNetworkPeering{}, microerror.Mask(err)
 	}
 
 	vnetPeering, err := vnetPeeringClient.Get(ctx, r.azure.HostCluster.ResourceGroup, r.azure.HostCluster.ResourceGroup, key.ResourceGroupName(azureConfig))

--- a/service/controller/v2/resource/vnetpeering/delete.go
+++ b/service/controller/v2/resource/vnetpeering/delete.go
@@ -16,20 +16,20 @@ import (
 func (r Resource) NewDeletePatch(ctx context.Context, azureConfig, current, desired interface{}) (*controller.Patch, error) {
 	a, err := key.ToCustomObject(azureConfig)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewDeletePatch")
+		return nil, microerror.Mask(err)
 	}
 	c, err := toVnetPeering(current)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewDeletePatch")
+		return nil, microerror.Mask(err)
 	}
 	d, err := toVnetPeering(desired)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewDeletePatch")
+		return nil, microerror.Mask(err)
 	}
 
 	patch, err := r.newDeletePatch(ctx, a, c, d)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewDeletePatch")
+		return nil, microerror.Mask(err)
 	}
 
 	return patch, nil
@@ -46,16 +46,16 @@ func (r Resource) newDeletePatch(ctx context.Context, azureConfig providerv1alph
 func (r Resource) ApplyDeleteChange(ctx context.Context, azureConfig, change interface{}) error {
 	a, err := key.ToCustomObject(azureConfig)
 	if err != nil {
-		return microerror.Maskf(err, "ApplyDeleteChange")
+		return microerror.Mask(err)
 	}
 	c, err := toVnetPeering(change)
 	if err != nil {
-		return microerror.Maskf(err, "ApplyDeleteChange")
+		return microerror.Mask(err)
 	}
 
 	err = r.applyDeleteChange(ctx, a, c)
 	if err != nil {
-		return microerror.Maskf(err, "ApplyDeleteChange")
+		return microerror.Mask(err)
 	}
 
 	return nil
@@ -66,12 +66,12 @@ func (r Resource) applyDeleteChange(ctx context.Context, azureConfig providerv1a
 
 	vnetPeeringClient, err := r.getVnetPeeringClient()
 	if err != nil {
-		return microerror.Maskf(err, "deleting host vnet peering")
+		return microerror.Mask(err)
 	}
 
 	respFuture, err := vnetPeeringClient.Delete(ctx, r.azure.HostCluster.ResourceGroup, r.azure.HostCluster.ResourceGroup, *change.Name)
 	if err != nil {
-		return microerror.Maskf(err, "deleting host vnet peering")
+		return microerror.Mask(err)
 	}
 
 	res, err := vnetPeeringClient.DeleteResponder(respFuture.Response())
@@ -80,7 +80,7 @@ func (r Resource) applyDeleteChange(ctx context.Context, azureConfig providerv1a
 		return nil
 	}
 	if err != nil {
-		return microerror.Maskf(err, "deleting host vnet peering")
+		return microerror.Mask(err)
 	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting host vnet peering: deleted")

--- a/service/controller/v2/resource/vnetpeering/desired.go
+++ b/service/controller/v2/resource/vnetpeering/desired.go
@@ -16,12 +16,12 @@ import (
 func (r Resource) GetDesiredState(ctx context.Context, azureConfig interface{}) (interface{}, error) {
 	a, err := key.ToCustomObject(azureConfig)
 	if err != nil {
-		return network.VirtualNetworkPeering{}, microerror.Maskf(err, "GetDesiredState")
+		return network.VirtualNetworkPeering{}, microerror.Mask(err)
 	}
 
 	vnetPeering, err := r.getDesiredState(ctx, a)
 	if err != nil {
-		return network.VirtualNetworkPeering{}, microerror.Maskf(err, "GetDesiredState")
+		return network.VirtualNetworkPeering{}, microerror.Mask(err)
 	}
 
 	return vnetPeering, nil

--- a/service/controller/v2/resource/vnetpeering/resource.go
+++ b/service/controller/v2/resource/vnetpeering/resource.go
@@ -59,7 +59,7 @@ func (r Resource) Name() string {
 func (r Resource) getVnetPeeringClient() (*network.VirtualNetworkPeeringsClient, error) {
 	azureClients, err := client.NewAzureClientSet(r.azureConfig)
 	if err != nil {
-		return nil, microerror.Maskf(err, "creating Azure virtual network peering client")
+		return nil, microerror.Mask(err)
 	}
 
 	return azureClients.VnetPeeringClient, nil

--- a/service/controller/v2/resource/vnetpeering/update.go
+++ b/service/controller/v2/resource/vnetpeering/update.go
@@ -15,20 +15,20 @@ import (
 func (r Resource) NewUpdatePatch(ctx context.Context, azureConfig, current, desired interface{}) (*controller.Patch, error) {
 	a, err := key.ToCustomObject(azureConfig)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewUpdatePatch")
+		return nil, microerror.Mask(err)
 	}
 	c, err := toVnetPeering(current)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewUpdatePatch")
+		return nil, microerror.Mask(err)
 	}
 	d, err := toVnetPeering(desired)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewUpdatePatch")
+		return nil, microerror.Mask(err)
 	}
 
 	patch, err := r.newUpdatePatch(ctx, a, c, d)
 	if err != nil {
-		return nil, microerror.Maskf(err, "NewUpdatePatch")
+		return nil, microerror.Mask(err)
 	}
 
 	return patch, nil
@@ -39,7 +39,7 @@ func (r Resource) newUpdatePatch(ctx context.Context, azureConfig providerv1alph
 
 	change, err := r.newUpdateChange(ctx, azureConfig, current, desired)
 	if err != nil {
-		return nil, microerror.Maskf(err, "newUpdatePatch")
+		return nil, microerror.Mask(err)
 	}
 
 	patch.SetUpdateChange(change)
@@ -93,16 +93,16 @@ func needUpdate(current, desired network.VirtualNetworkPeering) bool {
 func (r Resource) ApplyUpdateChange(ctx context.Context, azureConfig, change interface{}) error {
 	a, err := key.ToCustomObject(azureConfig)
 	if err != nil {
-		return microerror.Maskf(err, "ApplyUpdateChange")
+		return microerror.Mask(err)
 	}
 	c, err := toVnetPeering(change)
 	if err != nil {
-		return microerror.Maskf(err, "ApplyUpdateChange")
+		return microerror.Mask(err)
 	}
 
 	err = r.applyUpdateChange(ctx, a, c)
 	if err != nil {
-		return microerror.Maskf(err, "ApplyUpdateChange")
+		return microerror.Mask(err)
 	}
 
 	return nil
@@ -113,7 +113,7 @@ func (r *Resource) applyUpdateChange(ctx context.Context, azureConfig providerv1
 
 	vnetPeeringClient, err := r.getVnetPeeringClient()
 	if err != nil {
-		return microerror.Maskf(err, "ensure host vnet peering")
+		return microerror.Mask(err)
 	}
 
 	if isVNetPeeringEmpty(change) {
@@ -123,7 +123,7 @@ func (r *Resource) applyUpdateChange(ctx context.Context, azureConfig providerv1
 
 	_, err = vnetPeeringClient.CreateOrUpdate(ctx, r.azure.HostCluster.ResourceGroup, r.azure.HostCluster.VirtualNetwork, *change.Name, change)
 	if err != nil {
-		return microerror.Maskf(err, "ensure host vnet peering %#v", change)
+		return microerror.Mask(err)
 	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "ensure host vnet peering: created")

--- a/service/controller/v2/resource_set.go
+++ b/service/controller/v2/resource_set.go
@@ -80,7 +80,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 
 		certsSearcher, err = certs.NewSearcher(c)
 		if err != nil {
-			return nil, microerror.Maskf(err, "certs.NewSearcher")
+			return nil, microerror.Mask(err)
 		}
 	}
 
@@ -93,7 +93,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 
 		randomkeysSearcher, err = randomkeys.NewSearcher(c)
 		if err != nil {
-			return nil, microerror.Maskf(err, "randomkeys.NewSearcher")
+			return nil, microerror.Mask(err)
 		}
 	}
 
@@ -110,7 +110,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 
 		cloudConfig, err = cloudconfig.New(c)
 		if err != nil {
-			return nil, microerror.Maskf(err, "cloudconfig.New")
+			return nil, microerror.Mask(err)
 		}
 	}
 


### PR DESCRIPTION
This PR tries to ease the error masking. In case errors are only received and dispatched it does not yield to a lot of benefit to annotate them. IMO the contrary is the case. The stack should be as pure and clean as possible. In almost all cases only the creator of an error is able to annotate really relevant information. Any other information is more or less useless garbage we carry for nothing. The trace is the important part which is way easier to scan in case it stays clean. When you debug you follow the execution flow by hard line numbers. In case of serious problems you have to get into the code and read and understand it. No annotation of dispatched errors can help here. Annotations almost always only make sense when an error is created at the root of its origin. 