### PR TITLE
sets informer settings explicitly to default values

### DIFF
--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"time"
-
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	gsclient "github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
@@ -84,8 +82,8 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 			Logger:  config.Logger,
 			Watcher: config.G8sClient.ProviderV1alpha1().AzureConfigs(""),
 
-			//ResyncPeriod: informer.DefaultResyncPeriod,
-			ResyncPeriod: 1 * time.Minute,
+			RateWait:     informer.DefaultRateWait,
+			ResyncPeriod: informer.DefaultResyncPeriod,
 		}
 
 		newInformer, err = informer.New(c)


### PR DESCRIPTION
That is a left over from testing. It does not hurt but using the default values again is just fine. 