### PR TITLE
does not cancel resource on deletion when resources should be removed

### DIFF
--- a/service/controller/v2/resource/vnetpeering/current.go
+++ b/service/controller/v2/resource/vnetpeering/current.go
@@ -26,7 +26,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	// guest cluster creation. If we would not check for the virtual network
 	// existence the client calls of CreateOrUpdate would fail with not found
 	// errors.
-	{
+	if !key.IsDeleted(customObject) {
 		c, err := r.getVirtualNetworksClient()
 		if err != nil {
 			return network.VirtualNetworkPeering{}, microerror.Mask(err)


### PR DESCRIPTION
During testing I figured out there is a problem with cluster deletion. Right now the vnet peerings are not deleted. This PR fixes the problem. I tested this successfully on `godsmack`. 