### PR TITLE
adds new instance resource and wires it

### DIFF
--- a/service/controller/v2/resource/instance/create.go
+++ b/service/controller/v2/resource/instance/create.go
@@ -1,0 +1,25 @@
+package instance
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/azure-operator/service/controller/v2/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("EnsureCreated called for cluster ID '%s'", key.ClusterID(customObject)))
+
+	// TODO list all instances
+	// TODO find the first instance not having the latest scale set model applied
+	// TODO trigger update for found instance
+
+	return nil
+}

--- a/service/controller/v2/resource/instance/delete.go
+++ b/service/controller/v2/resource/instance/delete.go
@@ -1,0 +1,9 @@
+package instance
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v2/resource/instance/error.go
+++ b/service/controller/v2/resource/instance/error.go
@@ -1,0 +1,19 @@
+package instance
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v2/resource/instance/resource.go
+++ b/service/controller/v2/resource/instance/resource.go
@@ -1,0 +1,53 @@
+package instance
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/azure-operator/client"
+	"github.com/giantswarm/azure-operator/service/controller/setting"
+)
+
+const (
+	Name = "instancev2"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+
+	Azure       setting.Azure
+	AzureConfig client.AzureConfig
+}
+
+type Resource struct {
+	logger micrologger.Logger
+
+	azure       setting.Azure
+	azureConfig client.AzureConfig
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if err := config.Azure.Validate(); err != nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Azure.%s", config, err)
+	}
+	if err := config.AzureConfig.Validate(); err != nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.AzureConfig.%s", config, err)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+
+		azure:       config.Azure,
+		azureConfig: config.AzureConfig,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v2/resource_set.go
+++ b/service/controller/v2/resource_set.go
@@ -20,6 +20,7 @@ import (
 	"github.com/giantswarm/azure-operator/service/controller/v2/resource/deployment"
 	"github.com/giantswarm/azure-operator/service/controller/v2/resource/dnsrecord"
 	"github.com/giantswarm/azure-operator/service/controller/v2/resource/endpoints"
+	"github.com/giantswarm/azure-operator/service/controller/v2/resource/instance"
 	"github.com/giantswarm/azure-operator/service/controller/v2/resource/namespace"
 	"github.com/giantswarm/azure-operator/service/controller/v2/resource/resourcegroup"
 	"github.com/giantswarm/azure-operator/service/controller/v2/resource/service"
@@ -180,6 +181,21 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
+	var instanceResource controller.Resource
+	{
+		c := instance.Config{
+			Logger: config.Logger,
+
+			Azure:       config.Azure,
+			AzureConfig: config.AzureConfig,
+		}
+
+		instanceResource, err = instance.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var namespaceResource controller.Resource
 	{
 		c := namespace.Config{
@@ -241,6 +257,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		serviceResource,
 		resourceGroupResource,
 		deploymentResource,
+		instanceResource,
 		endpointsResource,
 		dnsrecordResource,
 		vnetPeeringResource,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3272. The idea here is to have a new resource which manages the update mechanism as we want to implement it for Azure. 

> AFAIK we use the resource manager magic via the Azure API. Deployments are reconciled constantly. There is something like scale set models. Once the model is updated instances can be updated to use it. The currently used upgrade strategy is `manual` which means we have to trigger the instance update. We want to leverage this approach in order to have control over the draining. There is https://github.com/giantswarm/node-operator which we already integrated into the `aws-operator` and `kvm-operator`. During the reconciliation in the `azure-operator` we want to list all instances and check if they have to be updated. I am not sure yet how this check looks like. When we identify an instance has to be updated we drain the associated guest cluster node and once this is done we trigger the instance update in the Azure API. We repeat this process with each reconciliation loop until we upgraded all instances of the guest cluster. Later we might want to do this in batches for bigger clusters but this is some optimization aspect we can just add on top of it later on if necessary.

Also see https://gigantic.slack.com/archives/C6H0T6W1X/p1528118788000367. 