### PR TITLE
manage ingress load balancer by kubernetes

### DIFF
--- a/service/controller/v2/arm_templates/main.json
+++ b/service/controller/v2/arm_templates/main.json
@@ -53,12 +53,6 @@
     "kubernetesAPISecurePort": {
       "type": "int"
     },
-    "kubernetesIngressSecurePort": {
-      "type": "int"
-    },
-    "kubernetesIngressInsecurePort": {
-      "type": "int"
-    },
     "masterNodes": {
       "type": "array"
     },
@@ -166,9 +160,7 @@
           "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
           "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},
           "hostClusterCidr": {"value": "[parameters('hostClusterCidr')]"},
-          "kubernetesAPISecurePort": {"value": "[parameters('kubernetesAPISecurePort')]"},
-          "kubernetesIngressSecurePort": {"value": "[parameters('kubernetesIngressSecurePort')]"},
-          "kubernetesIngressInsecurePort": {"value": "[parameters('kubernetesIngressInsecurePort')]"}
+          "kubernetesAPISecurePort": {"value": "[parameters('kubernetesAPISecurePort')]"}
         }
       }
     },
@@ -287,35 +279,6 @@
     },
     {
       "apiVersion": "2016-09-01",
-      "name": "ingress_load_balancer_setup",
-      "type": "Microsoft.Resources/deployments",
-      "properties": {
-        "mode": "incremental",
-        "templateLink": {
-          "uri": "[variables('publicLoadBalancerTemplateURI')]",
-          "contentVersion": "1.0.0.0"
-        },
-        "parameters": {
-          "clusterID": {"value": "[parameters('clusterID')]"},
-          "GiantSwarmTags": {"value": "[parameters('GiantSwarmTags')]"},
-          "prefix": {"value": "Ingress"},
-          "ports": {"value":
-            [
-              {
-                "frontend": 80,
-                "backend": 30010
-              },
-              {
-                "frontend": 443,
-                "backend": 30011
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "apiVersion": "2016-09-01",
       "name": "kubernetes_api_dns_setup",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -347,24 +310,6 @@
           "GiantSwarmTags": {"value": "[parameters('GiantSwarmTags')]"},
           "prefix": { "value": "etcd" },
           "ipAddress": { "value": "[reference('etcd_load_balancer_setup').outputs.ipAddress.value]" }
-        }
-      }
-    },
-    {
-      "apiVersion": "2016-09-01",
-      "name": "kubernetes_ingress_dns_setup",
-      "type": "Microsoft.Resources/deployments",
-      "properties": {
-        "mode": "incremental",
-        "templateLink": {
-          "uri": "[variables('dnsASetupTemplateURI')]",
-          "contentVersion": "1.0.0.0"
-        },
-        "parameters": {
-          "dnsZone": { "value": "[concat(parameters('clusterID'), '.k8s.', parameters('dnsZones').ingress.name)]" },
-          "GiantSwarmTags": {"value": "[parameters('GiantSwarmTags')]"},
-          "prefix": { "value": "ingress" },
-          "ipAddress": { "value": "[reference('ingress_load_balancer_setup').outputs.ipAddress.value]" }
         }
       }
     },
@@ -442,7 +387,7 @@
           "vmssOsImageSKU": {"value": "[parameters('workerNodes')[0].osImage.sku]"},
           "vmssOsImageVersion": {"value": "[parameters('workerNodes')[0].osImage.version]"},
           "vmssVmCustomData": {"value": "[parameters('workerCloudConfigData')]"},
-          "vmssLbBackendPools": {"value": [{"id": "[reference('ingress_load_balancer_setup').outputs.backendPoolId.value]"}]},
+          "vmssLbBackendPools": {"value": []},
           "vmssVnetSubnetId": {"value": "[reference('virtual_network_setup').outputs.workerSubnetID.value]"}
         }
       }

--- a/service/controller/v2/arm_templates/security_groups_setup.json
+++ b/service/controller/v2/arm_templates/security_groups_setup.json
@@ -35,12 +35,6 @@
     },
     "kubernetesAPISecurePort": {
       "type": "int"
-    },
-    "kubernetesIngressSecurePort": {
-      "type": "int"
-    },
-    "kubernetesIngressInsecurePort": {
-      "type": "int"
     }
   },
   "variables": {
@@ -330,34 +324,6 @@
               "access": "Allow",
               "direction": "Inbound",
               "priority": "4000"
-            }
-          },
-          {
-            "name": "ingressSecurePortRule",
-            "properties": {
-              "description": "Allow anyone to reach the ingress controller secure port.",
-              "protocol": "tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "[string(parameters('kubernetesIngressSecurePort'))]",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
-              "access": "Allow",
-              "direction": "Inbound",
-              "priority": "3900"
-            }
-          },
-          {
-            "name": "ingressInsecurePortRule",
-            "properties": {
-              "description": "Allow anyone to reach the ingress controller insecure port.",
-              "protocol": "tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "[string(parameters('kubernetesIngressInsecurePort'))]",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "[parameters('workerSubnetCidr')]",
-              "access": "Allow",
-              "direction": "Inbound",
-              "priority": "3800"
             }
           },
           {

--- a/service/controller/v2/cloudconfig/render.go
+++ b/service/controller/v2/cloudconfig/render.go
@@ -102,6 +102,27 @@ func renderDefaultStorageClassFile() (k8scloudconfig.FileAsset, error) {
 	return file, nil
 }
 
+func renderIngressLBFile(params ingressLBFileParams) (k8scloudconfig.FileAsset, error) {
+	fileMeta := k8scloudconfig.FileMetadata{
+		AssetContent: ingressLBFileTemplate,
+		Path:         ingressLBFileName,
+		Owner:        ingressLBFileOwner,
+		Permissions:  ingressLBFilePermission,
+	}
+
+	content, err := k8scloudconfig.RenderAssetContent(fileMeta.AssetContent, params)
+	if err != nil {
+		return k8scloudconfig.FileAsset{}, microerror.Mask(err)
+	}
+
+	file := k8scloudconfig.FileAsset{
+		Metadata: fileMeta,
+		Content:  content,
+	}
+
+	return file, nil
+}
+
 func renderEtcdMountUnit(params diskParams) (k8scloudconfig.UnitAsset, error) {
 	unitMeta := k8scloudconfig.UnitMetadata{
 		AssetContent: etcdMountUnitTemplate,
@@ -169,6 +190,29 @@ func renderDockerDiskFormatUnit(params diskParams) (k8scloudconfig.UnitAsset, er
 	unitMeta := k8scloudconfig.UnitMetadata{
 		AssetContent: dockerDiskFormatUnitTemplate,
 		Name:         dockerDiskFormatUnitName,
+		Enable:       true,
+		Command:      "start",
+	}
+
+	content, err := k8scloudconfig.RenderAssetContent(unitMeta.AssetContent, params)
+	if err != nil {
+		return k8scloudconfig.UnitAsset{}, microerror.Mask(err)
+	}
+
+	asset := k8scloudconfig.UnitAsset{
+		Metadata: unitMeta,
+		Content:  content,
+	}
+
+	return asset, nil
+}
+
+func renderIngressLBUnit() (k8scloudconfig.UnitAsset, error) {
+	params := struct{}{}
+
+	unitMeta := k8scloudconfig.UnitMetadata{
+		AssetContent: ingressLBUnitTemplate,
+		Name:         ingressLBUnitName,
 		Enable:       true,
 		Command:      "start",
 	}

--- a/service/controller/v2/cloudconfig/render_test.go
+++ b/service/controller/v2/cloudconfig/render_test.go
@@ -34,6 +34,10 @@ func Test_render(t *testing.T) {
 			Fn:   func() error { _, err := renderDefaultStorageClassFile(); return err },
 		},
 		{
+			Name: "renderIngressLBFile",
+			Fn:   func() error { _, err := renderIngressLBFile(ingressLBFileParams{}); return err },
+		},
+		{
 			Name: "renderEtcdMountUnit",
 			Fn:   func() error { _, err := renderEtcdMountUnit(diskParams{}); return err },
 		},
@@ -48,6 +52,10 @@ func Test_render(t *testing.T) {
 		{
 			Name: "renderDockerDiskFormatUnit",
 			Fn:   func() error { _, err := renderDockerDiskFormatUnit(diskParams{}); return err },
+		},
+		{
+			Name: "renderIngressLBUnit",
+			Fn:   func() error { _, err := renderIngressLBUnit(); return err },
 		},
 	}
 

--- a/service/controller/v2/cloudconfig/types.go
+++ b/service/controller/v2/cloudconfig/types.go
@@ -53,3 +53,13 @@ func newCloudProviderConfFileParams(azure setting.Azure, azureConfig client.Azur
 type diskParams struct {
 	DiskName string
 }
+
+type ingressLBFileParams struct {
+	ClusterDNSDomain string
+}
+
+func newIngressLBFileParams(obj providerv1alpha1.AzureConfig) ingressLBFileParams {
+	return ingressLBFileParams{
+		ClusterDNSDomain: key.DNSZonePrefixIngress(obj),
+	}
+}

--- a/service/controller/v2/resource/deployment/deployment.go
+++ b/service/controller/v2/resource/deployment/deployment.go
@@ -65,8 +65,6 @@ func (r Resource) newMainDeployment(obj providerv1alpha1.AzureConfig) (deploymen
 		"hostClusterResourceGroupName":  r.azure.HostCluster.ResourceGroup,
 		"hostClusterVirtualNetworkName": r.azure.HostCluster.VirtualNetwork,
 		"kubernetesAPISecurePort":       obj.Spec.Cluster.Kubernetes.API.SecurePort,
-		"kubernetesIngressSecurePort":   obj.Spec.Cluster.Kubernetes.IngressController.SecurePort,
-		"kubernetesIngressInsecurePort": obj.Spec.Cluster.Kubernetes.IngressController.InsecurePort,
 		"masterCloudConfigData":         masterCloudConfig,
 		"workerCloudConfigData":         workerCloudConfig,
 		"templatesBaseURI":              baseTemplateURI(r.templateVersion),

--- a/service/controller/v2/version_bundle.go
+++ b/service/controller/v2/version_bundle.go
@@ -42,6 +42,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Added basic support for worker updates.",
 				Kind:        versionbundle.KindChanged,
 			},
+			{
+				Component:   "azure-operator",
+				Description: "Ingress load balancer managed by Kubernetes.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{


### PR DESCRIPTION
Task: https://github.com/giantswarm/giantswarm/issues/3268

Idea is that we are managing ingress load balancer with Kubernetes itself. So in this change:
- remove ingress load balancer creation from ARM templates
- add systemd unit that creates kubernetes service type load balancer (with external-dns annotation to create DNS A record)