### PR TITLE
Fix ingress dns domain for load balancer

### DIFF
--- a/service/controller/v2/cloudconfig/types.go
+++ b/service/controller/v2/cloudconfig/types.go
@@ -60,6 +60,6 @@ type ingressLBFileParams struct {
 
 func newIngressLBFileParams(obj providerv1alpha1.AzureConfig) ingressLBFileParams {
 	return ingressLBFileParams{
-		ClusterDNSDomain: key.DNSZonePrefixIngress(obj),
+		ClusterDNSDomain: key.ClusterDNSDomain(obj),
 	}
 }

--- a/service/controller/v2/key/key.go
+++ b/service/controller/v2/key/key.go
@@ -44,6 +44,11 @@ func ClusterCustomer(customObject providerv1alpha1.AzureConfig) string {
 	return customObject.Spec.Cluster.Customer.ID
 }
 
+// ClusterDNSDomain returns cluster DNS domain.
+func ClusterDNSDomain(customObject providerv1alpha1.AzureConfig) string {
+	return fmt.Sprintf("%s.%s", DNSZonePrefixAPI(customObject), DNSZoneAPI(customObject))
+}
+
 // ClusterID returns the unique ID for this cluster.
 func ClusterID(customObject providerv1alpha1.AzureConfig) string {
 	return customObject.Spec.Cluster.ID

--- a/service/controller/v2/key/key_test.go
+++ b/service/controller/v2/key/key_test.go
@@ -162,6 +162,89 @@ func Test_Functions_for_AzureResourceKeys(t *testing.T) {
 	}
 }
 
+func Test_Functions_for_DNSKeys(t *testing.T) {
+	clusterID := "eggs2"
+	baseDomainName := "domain.tld"
+	resourceGroupName := clusterID
+
+	testCases := []struct {
+		Func           func(providerv1alpha1.AzureConfig) string
+		ExpectedResult string
+	}{
+		{
+			Func:           ClusterDNSDomain,
+			ExpectedResult: fmt.Sprintf("%s.k8s.%s", clusterID, baseDomainName),
+		},
+		{
+			Func:           DNSZoneAPI,
+			ExpectedResult: baseDomainName,
+		},
+		{
+			Func:           DNSZoneEtcd,
+			ExpectedResult: baseDomainName,
+		},
+		{
+			Func:           DNSZoneIngress,
+			ExpectedResult: baseDomainName,
+		},
+		{
+			Func:           DNSZonePrefixAPI,
+			ExpectedResult: fmt.Sprintf("%s.k8s", clusterID),
+		},
+		{
+			Func:           DNSZonePrefixEtcd,
+			ExpectedResult: fmt.Sprintf("%s.k8s", clusterID),
+		},
+		{
+			Func:           DNSZonePrefixIngress,
+			ExpectedResult: fmt.Sprintf("%s.k8s", clusterID),
+		},
+		{
+			Func:           DNSZoneResourceGroupAPI,
+			ExpectedResult: resourceGroupName,
+		},
+		{
+			Func:           DNSZoneResourceGroupEtcd,
+			ExpectedResult: resourceGroupName,
+		},
+		{
+			Func:           DNSZoneResourceGroupIngress,
+			ExpectedResult: resourceGroupName,
+		},
+	}
+
+	customObject := providerv1alpha1.AzureConfig{
+		Spec: providerv1alpha1.AzureConfigSpec{
+			Azure: providerv1alpha1.AzureConfigSpecAzure{
+				DNSZones: providerv1alpha1.AzureConfigSpecAzureDNSZones{
+					API: providerv1alpha1.AzureConfigSpecAzureDNSZonesDNSZone{
+						ResourceGroup: resourceGroupName,
+						Name:          baseDomainName,
+					},
+					Etcd: providerv1alpha1.AzureConfigSpecAzureDNSZonesDNSZone{
+						ResourceGroup: resourceGroupName,
+						Name:          baseDomainName,
+					},
+					Ingress: providerv1alpha1.AzureConfigSpecAzureDNSZonesDNSZone{
+						ResourceGroup: resourceGroupName,
+						Name:          baseDomainName,
+					},
+				},
+			},
+			Cluster: providerv1alpha1.Cluster{
+				ID: clusterID,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		actualRes := tc.Func(customObject)
+		if actualRes != tc.ExpectedResult {
+			t.Fatalf("Expected %s but was %s", tc.ExpectedResult, actualRes)
+		}
+	}
+}
+
 func Test_MasterNICName(t *testing.T) {
 	expectedMasterNICName := "3p5j2-Master-1-NIC"
 


### PR DESCRIPTION
I need full cluster domain for my ingress load balancer. But for some reason i've used DNSZonePrefixIngress that returns only `xxxxx.k8s`, but i need full `xxxxx.k8s.gollum.westeurope.gigantic.io`. So added new function that provides cluster doman.