### PR TITLE
Prevent routes removal while reconciliation

### DIFF
--- a/service/controller/v2/arm_templates/main.json
+++ b/service/controller/v2/arm_templates/main.json
@@ -16,7 +16,7 @@
     },
     "initial_provisioning": {
       "type": "string",
-      "defaultValue": "Yes"
+      "defaultValue": "Yes",
       "metadata": {
         "description": "Whether the deployment is provisioned the very first time."
       }

--- a/service/controller/v2/arm_templates/main.json
+++ b/service/controller/v2/arm_templates/main.json
@@ -174,7 +174,6 @@
     {
       "apiVersion": "2016-09-01",
       "name": "route_table_setup",
-      "condition": "[equals(parameters('initialProvisioning'), 'Yes')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "incremental",
@@ -184,14 +183,14 @@
         },
         "parameters": {
           "clusterID": {"value": "[parameters('clusterID')]"},
-          "GiantSwarmTags": {"value": "[parameters('GiantSwarmTags')]"}
+          "GiantSwarmTags": {"value": "[parameters('GiantSwarmTags')]"},
+          "initialProvisioning": {"value": "[parameters('initialProvisioning')]"}
         }
       }
     },
     {
       "apiVersion": "2016-09-01",
       "name": "virtual_network_setup",
-      "condition": "[equals(parameters('initialProvisioning'), 'Yes')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
         "route_table_setup"
@@ -217,7 +216,6 @@
     {
       "apiVersion": "2016-09-01",
       "name": "peering",
-      "condition": "[equals(parameters('initialProvisioning'), 'Yes')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
           "virtual_network_setup"

--- a/service/controller/v2/arm_templates/main.json
+++ b/service/controller/v2/arm_templates/main.json
@@ -14,7 +14,7 @@
         "provider": "F80D01C0-7AAC-4440-98F6-5061511962AD"
       }
     },
-    "initial_provisioning": {
+    "initialProvisioning": {
       "type": "string",
       "defaultValue": "Yes",
       "metadata": {
@@ -174,7 +174,7 @@
     {
       "apiVersion": "2016-09-01",
       "name": "route_table_setup",
-      "condition": "[equals(parameters('initial_provisioning'), 'Yes')]",
+      "condition": "[equals(parameters('initialProvisioning'), 'Yes')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "incremental",
@@ -191,7 +191,7 @@
     {
       "apiVersion": "2016-09-01",
       "name": "virtual_network_setup",
-      "condition": "[equals(parameters('initial_provisioning'), 'Yes')]",
+      "condition": "[equals(parameters('initialProvisioning'), 'Yes')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
         "route_table_setup"
@@ -217,7 +217,7 @@
     {
       "apiVersion": "2016-09-01",
       "name": "peering",
-      "condition": "[equals(parameters('initial_provisioning'), 'Yes')]",
+      "condition": "[equals(parameters('initialProvisioning'), 'Yes')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
           "virtual_network_setup"

--- a/service/controller/v2/arm_templates/main.json
+++ b/service/controller/v2/arm_templates/main.json
@@ -167,6 +167,7 @@
     {
       "apiVersion": "2016-09-01",
       "name": "route_table_setup",
+      "condition": "[equals(parameters('initial_provisioning'), 'Yes')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "incremental",
@@ -183,6 +184,7 @@
     {
       "apiVersion": "2016-09-01",
       "name": "virtual_network_setup",
+      "condition": "[equals(parameters('initial_provisioning'), 'Yes')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
         "route_table_setup"
@@ -208,6 +210,7 @@
     {
       "apiVersion": "2016-09-01",
       "name": "peering",
+      "condition": "[equals(parameters('initial_provisioning'), 'Yes')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
           "virtual_network_setup"

--- a/service/controller/v2/arm_templates/main.json
+++ b/service/controller/v2/arm_templates/main.json
@@ -14,6 +14,13 @@
         "provider": "F80D01C0-7AAC-4440-98F6-5061511962AD"
       }
     },
+    "initial_provisioning": {
+      "type": "string",
+      "defaultValue": "Yes"
+      "metadata": {
+        "description": "Whether the deployment is provisioned the very first time."
+      }
+    },
     "virtualNetworkName": {
       "type": "string",
       "metadata": {

--- a/service/controller/v2/arm_templates/route_table_setup.json
+++ b/service/controller/v2/arm_templates/route_table_setup.json
@@ -11,6 +11,13 @@
         "provider": "F80D01C0-7AAC-4440-98F6-5061511962AD"
       }
     },
+    "initialProvisioning": {
+      "type": "string",
+      "defaultValue": "Yes",
+      "metadata": {
+        "description": "Whether the deployment is provisioned the very first time."
+      }
+    },
     "routeTablesAPIVersion": {
       "type": "string",
       "defaultValue": "2016-09-01",
@@ -27,6 +34,7 @@
     {
       "type": "Microsoft.Network/routeTables",
       "name": "[variables('name')]",
+      "condition": "[equals(parameters('initialProvisioning'), 'Yes')]",
       "apiVersion": "[parameters('routeTablesAPIVersion')]",
       "location": "[resourceGroup().location]",
       "tags": {

--- a/service/controller/v2/resource/deployment/deployment.go
+++ b/service/controller/v2/resource/deployment/deployment.go
@@ -85,12 +85,11 @@ func (r Resource) newDeployment(obj providerv1alpha1.AzureConfig, overwrites map
 	return d, nil
 }
 
-// convertParameters merges the input maps and converts teh result into the
+// convertParameters merges the input maps and converts the result into the
 // structure used by the Azure API. Note that the order of inputs is relevant.
 // Default parameters should be given first. Data of the following maps will
 // overwrite eventual data of preceeding maps. This mechanism is used for e.g.
-// setting the initialProvisioning parameter accordingly to the cluster's
-// state.
+// setting the initialProvisioning parameter accordingly to the cluster's state.
 func convertParameters(list ...map[string]interface{}) map[string]interface{} {
 	allParams := map[string]interface{}{}
 

--- a/service/controller/v2/resource/deployment/deployment.go
+++ b/service/controller/v2/resource/deployment/deployment.go
@@ -1,6 +1,8 @@
 package deployment
 
 import (
+	azureresource "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-02-01/resources"
+	"github.com/Azure/go-autorest/autorest/to"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
@@ -8,7 +10,6 @@ import (
 )
 
 const (
-	mainDeploymentName     = "cluster-main-template"
 	templateContentVersion = "1.0.0.0"
 )
 
@@ -18,7 +19,7 @@ func getDeploymentNames() []string {
 	}
 }
 
-func (r Resource) newMainDeployment(obj providerv1alpha1.AzureConfig) (deployment, error) {
+func (r Resource) newDeployment(obj providerv1alpha1.AzureConfig, overwrites map[string]interface{}) (azureresource.Deployment, error) {
 	var masterNodes []node
 	for _, m := range obj.Spec.Azure.Masters {
 		n := node{
@@ -43,15 +44,15 @@ func (r Resource) newMainDeployment(obj providerv1alpha1.AzureConfig) (deploymen
 
 	masterCloudConfig, err := r.cloudConfig.NewMasterCloudConfig(obj)
 	if err != nil {
-		return deployment{}, microerror.Mask(err)
+		return azureresource.Deployment{}, microerror.Mask(err)
 	}
 
 	workerCloudConfig, err := r.cloudConfig.NewWorkerCloudConfig(obj)
 	if err != nil {
-		return deployment{}, microerror.Mask(err)
+		return azureresource.Deployment{}, microerror.Mask(err)
 	}
 
-	params := map[string]interface{}{
+	defaultParams := map[string]interface{}{
 		"clusterID":                     key.ClusterID(obj),
 		"virtualNetworkName":            key.VnetName(obj),
 		"virtualNetworkCidr":            key.VnetCIDR(obj),
@@ -70,27 +71,38 @@ func (r Resource) newMainDeployment(obj providerv1alpha1.AzureConfig) (deploymen
 		"templatesBaseURI":              baseTemplateURI(r.templateVersion),
 	}
 
-	d := deployment{
-		Name:                   mainDeploymentName,
-		Parameters:             convertParameters(params),
-		ResourceGroup:          key.ClusterID(obj),
-		TemplateURI:            templateURI(r.templateVersion, mainTemplate),
-		TemplateContentVersion: templateContentVersion,
+	d := azureresource.Deployment{
+		Properties: &azureresource.DeploymentProperties{
+			Mode:       azureresource.Incremental,
+			Parameters: convertParameters(defaultParams, overwrites),
+			TemplateLink: &azureresource.TemplateLink{
+				URI:            to.StringPtr(templateURI(r.templateVersion, mainTemplate)),
+				ContentVersion: to.StringPtr(templateContentVersion),
+			},
+		},
 	}
 
 	return d, nil
 }
 
-// convertParameters converts the map into the structure used by the Azure API.
-func convertParameters(inputs map[string]interface{}) map[string]interface{} {
-	params := make(map[string]interface{}, len(inputs))
-	for key, val := range inputs {
-		params[key] = struct {
-			Value interface{}
-		}{
-			Value: val,
+// convertParameters merges the input maps and converts teh result into the
+// structure used by the Azure API. Note that the order of inputs is relevant.
+// Default parameters should be given first. Data of the following maps will
+// overwrite eventual data of preceeding maps. This mechanism is used for e.g.
+// setting the initial_provisioning parameter accordingly to the cluster's
+// state.
+func convertParameters(list ...map[string]interface{}) map[string]interface{} {
+	allParams := map[string]interface{}{}
+
+	for _, l := range list {
+		for key, val := range l {
+			allParams[key] = struct {
+				Value interface{}
+			}{
+				Value: val,
+			}
 		}
 	}
 
-	return params
+	return allParams
 }

--- a/service/controller/v2/resource/deployment/deployment.go
+++ b/service/controller/v2/resource/deployment/deployment.go
@@ -89,7 +89,7 @@ func (r Resource) newDeployment(obj providerv1alpha1.AzureConfig, overwrites map
 // structure used by the Azure API. Note that the order of inputs is relevant.
 // Default parameters should be given first. Data of the following maps will
 // overwrite eventual data of preceeding maps. This mechanism is used for e.g.
-// setting the initial_provisioning parameter accordingly to the cluster's
+// setting the initialProvisioning parameter accordingly to the cluster's
 // state.
 func convertParameters(list ...map[string]interface{}) map[string]interface{} {
 	allParams := map[string]interface{}{}

--- a/service/controller/v2/resource/deployment/resource.go
+++ b/service/controller/v2/resource/deployment/resource.go
@@ -91,7 +91,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	d, err := deploymentsClient.Get(ctx, key.ClusterID(customObject), mainDeploymentName)
 	if IsNotFound(err) {
 		params := map[string]interface{}{
-			"initial_provisioning": "Yes",
+			"initialProvisioning": "Yes",
 		}
 		deployment, err = r.newDeployment(customObject, params)
 		if err != nil {
@@ -110,7 +110,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 
 		params := map[string]interface{}{
-			"initial_provisioning": "No",
+			"initialProvisioning": "No",
 		}
 		deployment, err = r.newDeployment(customObject, params)
 		if err != nil {

--- a/service/controller/v2/resource/deployment/resource.go
+++ b/service/controller/v2/resource/deployment/resource.go
@@ -147,16 +147,3 @@ func (r *Resource) getDeploymentsClient() (*azureresource.DeploymentsClient, err
 
 	return azureClients.DeploymentsClient, nil
 }
-
-func toDeployments(v interface{}) ([]deployment, error) {
-	if v == nil {
-		return []deployment{}, nil
-	}
-
-	deployments, ok := v.([]deployment)
-	if !ok {
-		return []deployment{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []deployment{}, v)
-	}
-
-	return deployments, nil
-}

--- a/service/controller/v2/resource/deployment/resource.go
+++ b/service/controller/v2/resource/deployment/resource.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	azureresource "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-02-01/resources"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 
@@ -18,6 +17,10 @@ import (
 const (
 	// Name is the identifier of the resource.
 	Name = "deploymentv2"
+)
+
+const (
+	mainDeploymentName = "cluster-main-template"
 )
 
 type Config struct {
@@ -83,25 +86,17 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring deployment")
 
-	resourceGroupName := key.ClusterID(customObject)
-	mainDeployment, err := r.newMainDeployment(customObject)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	newDeployment := azureresource.Deployment{
-		Properties: &azureresource.DeploymentProperties{
-			Mode:       azureresource.Incremental,
-			Parameters: &mainDeployment.Parameters,
-			TemplateLink: &azureresource.TemplateLink{
-				URI:            to.StringPtr(mainDeployment.TemplateURI),
-				ContentVersion: to.StringPtr(mainDeployment.TemplateContentVersion),
-			},
-		},
-	}
+	var deployment azureresource.Deployment
 
-	d, err := deploymentsClient.Get(ctx, resourceGroupName, mainDeployment.Name)
+	d, err := deploymentsClient.Get(ctx, key.ClusterID(customObject), mainDeploymentName)
 	if IsNotFound(err) {
-		// fall through
+		params := map[string]interface{}{
+			"initial_provisioning": "Yes",
+		}
+		deployment, err = r.newDeployment(customObject, params)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	} else if err != nil {
 		return microerror.Mask(err)
 	} else {
@@ -113,9 +108,17 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 			return nil
 		}
+
+		params := map[string]interface{}{
+			"initial_provisioning": "No",
+		}
+		deployment, err = r.newDeployment(customObject, params)
+		if err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
-	_, err = deploymentsClient.CreateOrUpdate(ctx, resourceGroupName, mainDeployment.Name, newDeployment)
+	_, err = deploymentsClient.CreateOrUpdate(ctx, key.ClusterID(customObject), mainDeploymentName, deployment)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -143,47 +146,6 @@ func (r *Resource) getDeploymentsClient() (*azureresource.DeploymentsClient, err
 	}
 
 	return azureClients.DeploymentsClient, nil
-}
-
-func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) ([]deployment, error) {
-	currentDeployments, err := toDeployments(currentState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-	desiredDeployments, err := toDeployments(desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	var deploymentsToCreate []deployment
-
-	for _, desiredDeployment := range desiredDeployments {
-		if !existsDeploymentByName(currentDeployments, desiredDeployment.Name) {
-			deploymentsToCreate = append(deploymentsToCreate, desiredDeployment)
-		}
-	}
-
-	return deploymentsToCreate, nil
-}
-
-func existsDeploymentByName(list []deployment, name string) bool {
-	for _, d := range list {
-		if d.Name == name {
-			return true
-		}
-	}
-
-	return false
-}
-
-func getDeploymentByName(list []deployment, name string) (deployment, error) {
-	for _, d := range list {
-		if d.Name == name {
-			return d, nil
-		}
-	}
-
-	return deployment{}, microerror.Maskf(notFoundError, name)
 }
 
 func toDeployments(v interface{}) ([]deployment, error) {

--- a/service/controller/v2/resource/deployment/types.go
+++ b/service/controller/v2/resource/deployment/types.go
@@ -1,18 +1,5 @@
 package deployment
 
-// deployment defines an Azure Deployment that deploys an ARM template.
-type deployment struct {
-	Parameters    map[string]interface{}
-	ResourceGroup string
-	TemplateURI   string
-
-	// TemplateContentVersion is a value to fill in
-	// github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-02-01/resources.TemplateLink.ContentVersion.
-	// For more information see contentVersion documentation
-	// https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authoring-templates.
-	TemplateContentVersion string
-}
-
 type node struct {
 	// AdminUsername is the vm administrator username
 	AdminUsername string `json:"adminUsername" yaml:"adminUsername"`

--- a/service/controller/v2/resource/deployment/types.go
+++ b/service/controller/v2/resource/deployment/types.go
@@ -2,7 +2,6 @@ package deployment
 
 // deployment defines an Azure Deployment that deploys an ARM template.
 type deployment struct {
-	Name          string
 	Parameters    map[string]interface{}
 	ResourceGroup string
 	TemplateURI   string


### PR DESCRIPTION
Related-to: https://github.com/giantswarm/azure-operator/issues/233

Tested in `godsmack`

This change fixes issue when routes created by Kubernetes controller manager are removed while ARM reconciliation. To avoid this we adding new paramter "initialProvisioning" and deploying route table only on first run. On reconciliation "initialProvisioning" set to "No", which disables route table reconciliation.