### PR TITLE
Disable reconciliation for worker network security group

### DIFF
--- a/service/controller/v2/arm_templates/main.json
+++ b/service/controller/v2/arm_templates/main.json
@@ -167,7 +167,8 @@
           "masterSubnetCidr": {"value": "[parameters('masterSubnetCidr')]"},
           "workerSubnetCidr": {"value": "[parameters('workerSubnetCidr')]"},
           "hostClusterCidr": {"value": "[parameters('hostClusterCidr')]"},
-          "kubernetesAPISecurePort": {"value": "[parameters('kubernetesAPISecurePort')]"}
+          "kubernetesAPISecurePort": {"value": "[parameters('kubernetesAPISecurePort')]"},
+          "initialProvisioning": {"value": "[parameters('initialProvisioning')]"}
         }
       }
     },

--- a/service/controller/v2/arm_templates/security_groups_setup.json
+++ b/service/controller/v2/arm_templates/security_groups_setup.json
@@ -18,6 +18,13 @@
         "provider": "F80D01C0-7AAC-4440-98F6-5061511962AD"
       }
     },
+    "initialProvisioning": {
+      "type": "string",
+      "defaultValue": "Yes",
+      "metadata": {
+        "description": "Whether the deployment is provisioned the very first time."
+      }
+    },
     "virtualNetworkCidr": {
       "type": "string"
     },
@@ -249,6 +256,7 @@
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('workerSecurityGroupName')]",
+      "condition": "[equals(parameters('initialProvisioning'), 'Yes')]",
       "apiVersion": "[parameters('networkSecurityGroupsAPIVersion')]",
       "location": "[resourceGroup().location]",
       "tags": {


### PR DESCRIPTION
Fixes: https://github.com/giantswarm/azure-operator/issues/242

Disable reconciliation for worker network security group to prevent wiping rules created by Kuberntes.

Similar to https://github.com/giantswarm/azure-operator/pull/239