### PR TITLE
Fix typo in changelog

### DIFF
--- a/service/controller/v2/version_bundle.go
+++ b/service/controller/v2/version_bundle.go
@@ -19,7 +19,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "cloudconfig",
-				Description: "Updated Calico to 3.1.3",
+				Description: "Updated Calico to 3.0.8",
 				Kind:        versionbundle.KindChanged,
 			},
 			{
@@ -81,7 +81,7 @@ func VersionBundle() versionbundle.Bundle {
 		Components: []versionbundle.Component{
 			{
 				Name:    "calico",
-				Version: "3.1.3",
+				Version: "3.0.8",
 			},
 			{
 				Name:    "containerlinux",


### PR DESCRIPTION
We use calico 3.0.8 finally, but i forgot to update changelog.