### PR TITLE
rename *AzureConfig to *AzureClientSetConfig

### DIFF
--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -123,13 +123,13 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 
-			Azure:            config.Azure,
-			HostAzureConfig:  config.AzureConfig,
-			InstallationName: config.InstallationName,
-			ProjectName:      config.ProjectName,
-			OIDC:             config.OIDC,
-			SSOPublicKey:     config.SSOPublicKey,
-			TemplateVersion:  config.TemplateVersion,
+			Azure: config.Azure,
+			HostAzureClientSetConfig: config.AzureConfig,
+			InstallationName:         config.InstallationName,
+			ProjectName:              config.ProjectName,
+			OIDC:                     config.OIDC,
+			SSOPublicKey:             config.SSOPublicKey,
+			TemplateVersion:          config.TemplateVersion,
 		}
 
 		v3ResourceSet, err = v3.NewResourceSet(c)

--- a/service/controller/v3/resource/dnsrecord/resource.go
+++ b/service/controller/v3/resource/dnsrecord/resource.go
@@ -17,27 +17,27 @@ const (
 )
 
 type Config struct {
-	HostAzureConfig client.AzureClientSetConfig
-	Logger          micrologger.Logger
+	HostAzureClientSetConfig client.AzureClientSetConfig
+	Logger                   micrologger.Logger
 }
 
 // Resource manages Azure resource groups.
 type Resource struct {
-	hostAzureConfig client.AzureClientSetConfig
-	logger          micrologger.Logger
+	hostAzureClientSetConfig client.AzureClientSetConfig
+	logger                   micrologger.Logger
 }
 
 func New(config Config) (*Resource, error) {
-	if err := config.HostAzureConfig.Validate(); err != nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.HostAzureConfig.%s", err)
+	if err := config.HostAzureClientSetConfig.Validate(); err != nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.HostAzureClientSetConfig.%s", err)
 	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
 	}
 
 	r := &Resource{
-		hostAzureConfig: config.HostAzureConfig,
-		logger:          config.Logger,
+		hostAzureClientSetConfig: config.HostAzureClientSetConfig,
+		logger: config.Logger,
 	}
 
 	return r, nil
@@ -49,7 +49,7 @@ func (r *Resource) Name() string {
 }
 
 func (r *Resource) getDNSRecordSetsHostClient() (*dns.RecordSetsClient, error) {
-	azureClients, err := client.NewAzureClientSet(r.hostAzureConfig)
+	azureClients, err := client.NewAzureClientSet(r.hostAzureClientSetConfig)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/v3/resource/vpngateway/clients.go
+++ b/service/controller/v3/resource/vpngateway/clients.go
@@ -69,7 +69,7 @@ func (r *Resource) getGuestVirtualNetworkGatewayConnection(ctx context.Context, 
 // getHostVirtualNetworkGatewaysClient return a client to interact with
 // VirtualNetworkGateways on host cluster.
 func (r *Resource) getHostVirtualNetworkGatewaysClient(ctx context.Context) (*network.VirtualNetworkGatewaysClient, error) {
-	azureClients, err := client.NewAzureClientSet(r.hostAzureConfig)
+	azureClients, err := client.NewAzureClientSet(r.hostAzureClientSetConfig)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -91,7 +91,7 @@ func (r *Resource) getGuestVirtualNetworkGatewaysClient(ctx context.Context) (*n
 // getHostVirtualNetworkGatewayConnectionsClient return a client to interact with
 // VirtualNetworkGatewayConnections on host cluster.
 func (r *Resource) getHostVirtualNetworkGatewayConnectionsClient(ctx context.Context) (*network.VirtualNetworkGatewayConnectionsClient, error) {
-	azureClients, err := client.NewAzureClientSet(r.hostAzureConfig)
+	azureClients, err := client.NewAzureClientSet(r.hostAzureClientSetConfig)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/v3/resource/vpngateway/resource.go
+++ b/service/controller/v3/resource/vpngateway/resource.go
@@ -16,16 +16,16 @@ const (
 type Config struct {
 	Logger micrologger.Logger
 
-	Azure           setting.Azure
-	HostAzureConfig client.AzureClientSetConfig
+	Azure                    setting.Azure
+	HostAzureClientSetConfig client.AzureClientSetConfig
 }
 
 // Resource manages Azure virtual network peering.
 type Resource struct {
 	logger micrologger.Logger
 
-	azure           setting.Azure
-	hostAzureConfig client.AzureClientSetConfig
+	azure                    setting.Azure
+	hostAzureClientSetConfig client.AzureClientSetConfig
 }
 
 func New(config Config) (*Resource, error) {
@@ -33,8 +33,8 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
-	if err := config.HostAzureConfig.Validate(); err != nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.HostAzureConfig.%s", config, err)
+	if err := config.HostAzureClientSetConfig.Validate(); err != nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostAzureClientSetConfig.%s", config, err)
 	}
 	if err := config.Azure.Validate(); err != nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Azure.%s", config, err)
@@ -43,8 +43,8 @@ func New(config Config) (*Resource, error) {
 	r := &Resource{
 		logger: config.Logger,
 
-		azure:           config.Azure,
-		hostAzureConfig: config.HostAzureConfig,
+		azure: config.Azure,
+		hostAzureClientSetConfig: config.HostAzureClientSetConfig,
 	}
 
 	return r, nil

--- a/service/controller/v3/resource_set.go
+++ b/service/controller/v3/resource_set.go
@@ -39,12 +39,12 @@ type ResourceSetConfig struct {
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
 
-	Azure            setting.Azure
-	HostAzureConfig  client.AzureClientSetConfig
-	InstallationName string
-	ProjectName      string
-	OIDC             setting.OIDC
-	SSOPublicKey     string
+	Azure                    setting.Azure
+	HostAzureClientSetConfig client.AzureClientSetConfig
+	InstallationName         string
+	ProjectName              string
+	OIDC                     setting.OIDC
+	SSOPublicKey             string
 	// TemplateVersion is a git branch name to use to get Azure Resource
 	// Manager templates from.
 	TemplateVersion string
@@ -162,7 +162,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := dnsrecord.Config{
 			Logger: config.Logger,
 
-			HostAzureConfig: config.HostAzureConfig,
+			HostAzureClientSetConfig: config.HostAzureClientSetConfig,
 		}
 
 		ops, err := dnsrecord.New(c)
@@ -250,8 +250,8 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		c := vpngateway.Config{
 			Logger: config.Logger,
 
-			Azure:           config.Azure,
-			HostAzureConfig: config.HostAzureConfig,
+			Azure: config.Azure,
+			HostAzureClientSetConfig: config.HostAzureClientSetConfig,
 		}
 
 		ops, err := vpngateway.New(c)
@@ -325,12 +325,12 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			return nil, microerror.Mask(err)
 		}
 
-		guestAzureConfig, err := credential.GetAzureConfig(config.K8sClient, obj)
+		guestAzureClientSetConfig, err := credential.GetAzureConfig(config.K8sClient, obj)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 
-		azureClients, err := client.NewAzureClientSet(*guestAzureConfig)
+		azureClients, err := client.NewAzureClientSet(*guestAzureClientSetConfig)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -343,7 +343,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 				RandomkeysSearcher: randomkeysSearcher,
 
 				Azure:        config.Azure,
-				AzureConfig:  *guestAzureConfig,
+				AzureConfig:  *guestAzureClientSetConfig,
 				AzureNetwork: *subnets,
 				OIDC:         config.OIDC,
 				SSOPublicKey: config.SSOPublicKey,


### PR DESCRIPTION
Follow up on: https://github.com/giantswarm/azure-operator/pull/289#discussion_r202932843

Rename misleading `AzureConfig` to `AzureClientSetConfig`.