### PR TITLE
service-reconcilation-minor-bugfix

### DIFF
--- a/service/controller/v3/resource/service/update.go
+++ b/service/controller/v3/resource/service/update.go
@@ -64,6 +64,10 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 		// Make a copy and set the resource version so the service can be updated.
 		serviceToUpdate := desiredService.DeepCopy()
 		if currentService != nil {
+			if currentService.Spec.ClusterIP == "" {
+				// cluster IP is yet not set that means the service is not ready, cancelling
+				return nil, nil
+			}
 			serviceToUpdate.ObjectMeta.ResourceVersion = currentService.ObjectMeta.ResourceVersion
 			serviceToUpdate.Spec.ClusterIP = currentService.Spec.ClusterIP
 		}

--- a/service/controller/v3/resource/service/update.go
+++ b/service/controller/v3/resource/service/update.go
@@ -64,10 +64,6 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 		// Make a copy and set the resource version so the service can be updated.
 		serviceToUpdate := desiredService.DeepCopy()
 		if currentService != nil {
-			if currentService.Spec.ClusterIP == "" {
-				// cluster IP is yet not set that means the service is not ready, cancelling
-				return nil, nil
-			}
 			serviceToUpdate.ObjectMeta.ResourceVersion = currentService.ObjectMeta.ResourceVersion
 			serviceToUpdate.Spec.ClusterIP = currentService.Spec.ClusterIP
 		}

--- a/service/controller/v3/resource/service/update.go
+++ b/service/controller/v3/resource/service/update.go
@@ -14,7 +14,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		return microerror.Mask(err)
 	}
 
-	if serviceToUpdate != nil {
+	if serviceToUpdate != nil && serviceToUpdate.Spec.ClusterIP != "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "updating services")
 
 		_, err := r.k8sClient.CoreV1().Services(serviceToUpdate.Namespace).Update(serviceToUpdate)


### PR DESCRIPTION
found a small race condition with reconciliation fo service resource
If the `current service` is read from the early stage then it has no `spec.clusterIP` value and then if we tried to update the service with no `spec.clusterIP` it will throw errors as that value is immutable.