### PR TITLE
re-use vnetpeering resource

### DIFF
--- a/service/controller/v3/resource/vnetpeering/create.go
+++ b/service/controller/v3/resource/vnetpeering/create.go
@@ -1,0 +1,10 @@
+package vnetpeering
+
+import (
+	"context"
+)
+
+// ApplyCreateChange is noop. Creation goes through ApplyUpdateChange.
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	return nil
+}

--- a/service/controller/v3/resource/vnetpeering/current.go
+++ b/service/controller/v3/resource/vnetpeering/current.go
@@ -1,0 +1,87 @@
+package vnetpeering
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+
+	"github.com/giantswarm/azure-operator/client"
+	"github.com/giantswarm/azure-operator/service/controller/v3/key"
+)
+
+// GetCurrentState retrieve the current host cluster virtual network peering
+// resource from azure.
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return network.VirtualNetworkPeering{}, microerror.Mask(err)
+	}
+
+	// In order to make vnet peering work we need a virtual network which we can
+	// use to peer. In case there is no virtual network yet we cancel the resource
+	// and try again on the next resync period. This is a classical scenario on
+	// guest cluster creation. If we would not check for the virtual network
+	// existence the client calls of CreateOrUpdate would fail with not found
+	// errors.
+	if !key.IsDeleted(customObject) {
+		c, err := r.getVirtualNetworksClient()
+		if err != nil {
+			return network.VirtualNetworkPeering{}, microerror.Mask(err)
+		}
+
+		g := key.ResourceGroupName(customObject)
+		n := key.VnetName(customObject)
+		e := ""
+		v, err := c.Get(ctx, g, n, e)
+		if IsVirtualNetworkNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the virtual network in the Azure API")
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object")
+
+			return network.VirtualNetworkPeering{}, nil
+		} else if err != nil {
+			return network.VirtualNetworkPeering{}, microerror.Mask(err)
+		} else {
+			s := *v.ProvisioningState
+
+			if !key.IsFinalProvisioningState(s) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("virtual network is in state '%s'", s))
+				resourcecanceledcontext.SetCanceled(ctx)
+				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object")
+
+				return network.VirtualNetworkPeering{}, nil
+			}
+		}
+	}
+
+	// Look for the current state of the vnet peering. It is a valid operation to
+	// not find any state. This indicates we want to create the vnet peering in
+	// the following steps.
+	var vnetPeering network.VirtualNetworkPeering
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the vnet peerings in the Azure API")
+
+		c, err := r.getVnetPeeringClient()
+		if err != nil {
+			return network.VirtualNetworkPeering{}, microerror.Mask(err)
+		}
+
+		g := r.azure.HostCluster.ResourceGroup
+		n := key.ResourceGroupName(customObject)
+		vnetPeering, err = c.Get(ctx, g, g, n)
+		if client.ResponseWasNotFound(vnetPeering.Response) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the vnet peerings in the Azure API")
+
+			return network.VirtualNetworkPeering{}, nil
+		} else if err != nil {
+			return network.VirtualNetworkPeering{}, microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found the vnet peerings in the Azure API")
+	}
+
+	return vnetPeering, nil
+}

--- a/service/controller/v3/resource/vnetpeering/delete.go
+++ b/service/controller/v3/resource/vnetpeering/delete.go
@@ -1,0 +1,87 @@
+package vnetpeering
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network"
+	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+
+	"github.com/giantswarm/azure-operator/client"
+	"github.com/giantswarm/azure-operator/service/controller/v3/key"
+)
+
+// NewDeletePatch provide a controller.Patch holding the network.VirtualNetworkPeering to be deleted.
+func (r *Resource) NewDeletePatch(ctx context.Context, azureConfig, current, desired interface{}) (*controller.Patch, error) {
+	a, err := key.ToCustomObject(azureConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	c, err := toVnetPeering(current)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	d, err := toVnetPeering(desired)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch, err := r.newDeletePatch(ctx, a, c, d)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return patch, nil
+}
+
+// newDeletePatch use desired as delete patch since it is mostly static and more likely to be present than current.
+func (r *Resource) newDeletePatch(ctx context.Context, azureConfig providerv1alpha1.AzureConfig, current, desired network.VirtualNetworkPeering) (*controller.Patch, error) {
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(desired)
+	return patch, nil
+}
+
+// ApplyDeleteChange perform deletion of the change virtual network peering against azure.
+func (r *Resource) ApplyDeleteChange(ctx context.Context, azureConfig, change interface{}) error {
+	a, err := key.ToCustomObject(azureConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	c, err := toVnetPeering(change)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.applyDeleteChange(ctx, a, c)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) applyDeleteChange(ctx context.Context, azureConfig providerv1alpha1.AzureConfig, change network.VirtualNetworkPeering) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting host vnet peering")
+
+	vnetPeeringClient, err := r.getVnetPeeringClient()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	respFuture, err := vnetPeeringClient.Delete(ctx, r.azure.HostCluster.ResourceGroup, r.azure.HostCluster.ResourceGroup, *change.Name)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	res, err := vnetPeeringClient.DeleteResponder(respFuture.Response())
+	if client.ResponseWasNotFound(res) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find host vnet peering")
+	} else if err != nil {
+		return microerror.Mask(err)
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted host vnet peering")
+	}
+
+	return nil
+}

--- a/service/controller/v3/resource/vnetpeering/desired.go
+++ b/service/controller/v3/resource/vnetpeering/desired.go
@@ -1,0 +1,40 @@
+package vnetpeering
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/azure-operator/service/controller/v3/key"
+)
+
+// GetDesiredState return desired peering for host cluster virtual network.
+// Peering resource is named after guest cluster's resource group and targeting its virtual network.
+func (r *Resource) GetDesiredState(ctx context.Context, azureConfig interface{}) (interface{}, error) {
+	a, err := key.ToCustomObject(azureConfig)
+	if err != nil {
+		return network.VirtualNetworkPeering{}, microerror.Mask(err)
+	}
+
+	vnetPeering, err := r.getDesiredState(ctx, a)
+	if err != nil {
+		return network.VirtualNetworkPeering{}, microerror.Mask(err)
+	}
+
+	return vnetPeering, nil
+}
+
+func (r *Resource) getDesiredState(ctx context.Context, azureConfig providerv1alpha1.AzureConfig) (network.VirtualNetworkPeering, error) {
+	return network.VirtualNetworkPeering{
+		Name: to.StringPtr(key.ResourceGroupName(azureConfig)),
+		VirtualNetworkPeeringPropertiesFormat: &network.VirtualNetworkPeeringPropertiesFormat{
+			AllowVirtualNetworkAccess: to.BoolPtr(true),
+			RemoteVirtualNetwork: &network.SubResource{
+				ID: to.StringPtr(key.VNetID(azureConfig, r.azureConfig.SubscriptionID)),
+			},
+		},
+	}, nil
+}

--- a/service/controller/v3/resource/vnetpeering/error.go
+++ b/service/controller/v3/resource/vnetpeering/error.go
@@ -1,0 +1,46 @@
+package vnetpeering
+
+import (
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var virtualNetworkNotFoundError = microerror.New("virtual network not found")
+
+// IsVirtualNetworkNotFound asserts virtualNetworkNotFoundError.
+func IsVirtualNetworkNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if c == virtualNetworkNotFoundError {
+		return true
+	}
+
+	{
+		dErr, ok := c.(autorest.DetailedError)
+		if ok {
+			if dErr.StatusCode == 404 {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v3/resource/vnetpeering/helper.go
+++ b/service/controller/v3/resource/vnetpeering/helper.go
@@ -1,0 +1,27 @@
+package vnetpeering
+
+import (
+	"github.com/giantswarm/microerror"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network"
+)
+
+// toVnePeering convert v to network.VirtualNetworkPeering.
+// If v is nil and empty network.VirtualNetworkPeering is returned.
+func toVnetPeering(v interface{}) (network.VirtualNetworkPeering, error) {
+	if v == nil {
+		return network.VirtualNetworkPeering{}, nil
+	}
+
+	vnetPeering, ok := v.(network.VirtualNetworkPeering)
+	if !ok {
+		return network.VirtualNetworkPeering{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", network.VirtualNetworkPeering{}, v)
+	}
+
+	return vnetPeering, nil
+}
+
+// isVNetPeeringEmpty check whether peering correspond to network.VirtualNetworkPeering zero value.
+func isVNetPeeringEmpty(peering network.VirtualNetworkPeering) bool {
+	return peering == network.VirtualNetworkPeering{}
+}

--- a/service/controller/v3/resource/vnetpeering/resource.go
+++ b/service/controller/v3/resource/vnetpeering/resource.go
@@ -1,0 +1,78 @@
+package vnetpeering
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/azure-operator/client"
+	"github.com/giantswarm/azure-operator/service/controller/setting"
+)
+
+const (
+	Name = "vnetpeeringv3"
+)
+
+// Config is the configuration required by Resource.
+type Config struct {
+	Logger micrologger.Logger
+
+	Azure       setting.Azure
+	AzureConfig client.AzureClientSetConfig
+}
+
+// Resource manages Azure virtual network peering.
+type Resource struct {
+	logger micrologger.Logger
+
+	azure       setting.Azure
+	azureConfig client.AzureClientSetConfig
+}
+
+func New(config Config) (*Resource, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if err := config.AzureConfig.Validate(); err != nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.AzureConfig.%s", config, err)
+	}
+	if err := config.Azure.Validate(); err != nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Azure.%s", config, err)
+	}
+
+	r := &Resource{
+		logger: config.Logger,
+
+		azure:       config.Azure,
+		azureConfig: config.AzureConfig,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+// getVirtualNetworksClient return an azure client to interact with
+// VirtualNetworks resources.
+func (r *Resource) getVirtualNetworksClient() (*network.VirtualNetworksClient, error) {
+	azureClients, err := client.NewAzureClientSet(r.azureConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return azureClients.VirtualNetworkClient, nil
+}
+
+// getVnetPeeringClient return an azure client to interact with
+// VirtualNetworkPeering resources.
+func (r *Resource) getVnetPeeringClient() (*network.VirtualNetworkPeeringsClient, error) {
+	azureClients, err := client.NewAzureClientSet(r.azureConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return azureClients.VnetPeeringClient, nil
+}

--- a/service/controller/v3/resource/vnetpeering/update.go
+++ b/service/controller/v3/resource/vnetpeering/update.go
@@ -1,0 +1,133 @@
+package vnetpeering
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network"
+	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+
+	"github.com/giantswarm/azure-operator/service/controller/v3/key"
+)
+
+// NewUpdatePatch provide a controller.Patch holding the needed network.VirtualNetworkPeering update to have current comply with desired.
+func (r *Resource) NewUpdatePatch(ctx context.Context, azureConfig, current, desired interface{}) (*controller.Patch, error) {
+	a, err := key.ToCustomObject(azureConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	c, err := toVnetPeering(current)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	d, err := toVnetPeering(desired)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch, err := r.newUpdatePatch(ctx, a, c, d)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdatePatch(ctx context.Context, azureConfig providerv1alpha1.AzureConfig, current, desired network.VirtualNetworkPeering) (*controller.Patch, error) {
+	patch := controller.NewPatch()
+
+	change, err := r.newUpdateChange(ctx, azureConfig, current, desired)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch.SetUpdateChange(change)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, azureConfig providerv1alpha1.AzureConfig, current, desired network.VirtualNetworkPeering) (network.VirtualNetworkPeering, error) {
+	var change network.VirtualNetworkPeering
+
+	if needUpdate(current, desired) {
+		change = desired
+	}
+
+	return change, nil
+}
+
+// needUpdate determine if current needs to be updated in order to comply with
+// desired. Following properties are compared and must be present in desired.
+//
+//     Name
+//     VirtualNetworkPeeringPropertiesFormat.AllowVirtualNetworkAccess
+//     VirtualNetworkPeeringPropertiesFormat.RemoteVirtualNetwork.ID
+//
+func needUpdate(current, desired network.VirtualNetworkPeering) bool {
+	if current.Name == nil || *current.Name != *desired.Name {
+		return true
+	}
+
+	if current.VirtualNetworkPeeringPropertiesFormat == nil {
+		return true
+	}
+
+	if current.VirtualNetworkPeeringPropertiesFormat.AllowVirtualNetworkAccess == nil ||
+		*current.VirtualNetworkPeeringPropertiesFormat.AllowVirtualNetworkAccess != *desired.VirtualNetworkPeeringPropertiesFormat.AllowVirtualNetworkAccess {
+		return true
+	}
+
+	if current.VirtualNetworkPeeringPropertiesFormat.RemoteVirtualNetwork == nil ||
+		current.VirtualNetworkPeeringPropertiesFormat.RemoteVirtualNetwork.ID == nil ||
+		*current.VirtualNetworkPeeringPropertiesFormat.RemoteVirtualNetwork.ID != *desired.VirtualNetworkPeeringPropertiesFormat.RemoteVirtualNetwork.ID {
+		return true
+	}
+
+	if current.VirtualNetworkPeeringPropertiesFormat.PeeringState == network.Disconnected {
+		return true
+	}
+
+	return false
+}
+
+// ApplyUpdateChange perform the host cluster virtual network peering update against azure.
+func (r *Resource) ApplyUpdateChange(ctx context.Context, azureConfig, change interface{}) error {
+	a, err := key.ToCustomObject(azureConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	c, err := toVnetPeering(change)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.applyUpdateChange(ctx, a, c)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) applyUpdateChange(ctx context.Context, azureConfig providerv1alpha1.AzureConfig, change network.VirtualNetworkPeering) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensure host vnet peering")
+
+	vnetPeeringClient, err := r.getVnetPeeringClient()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if isVNetPeeringEmpty(change) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "ensure host vnet peering: already ensured")
+		return nil
+	}
+
+	_, err = vnetPeeringClient.CreateOrUpdate(ctx, r.azure.HostCluster.ResourceGroup, r.azure.HostCluster.VirtualNetwork, *change.Name, change)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensure host vnet peering: created")
+	return nil
+}

--- a/service/controller/v3/resource/vnetpeering/update_test.go
+++ b/service/controller/v3/resource/vnetpeering/update_test.go
@@ -1,0 +1,163 @@
+package vnetpeering
+
+import (
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+func TestNeedUpdate(t *testing.T) {
+	testCases := []struct {
+		name     string
+		current  network.VirtualNetworkPeering
+		desired  network.VirtualNetworkPeering
+		expected bool
+	}{
+		{
+			"case 0: need an update when current state is empty",
+			network.VirtualNetworkPeering{},
+			network.VirtualNetworkPeering{
+				Name: to.StringPtr("some Name"),
+				VirtualNetworkPeeringPropertiesFormat: &network.VirtualNetworkPeeringPropertiesFormat{
+					AllowVirtualNetworkAccess: to.BoolPtr(true),
+					RemoteVirtualNetwork: &network.SubResource{
+						ID: to.StringPtr("some ID"),
+					},
+				},
+			},
+			true,
+		},
+		{
+			"case 1: current state with additional values does not need update",
+			network.VirtualNetworkPeering{
+				Name: to.StringPtr("some Name"),
+				VirtualNetworkPeeringPropertiesFormat: &network.VirtualNetworkPeeringPropertiesFormat{
+					AllowVirtualNetworkAccess: to.BoolPtr(true),
+					AllowForwardedTraffic:     to.BoolPtr(false),
+					AllowGatewayTransit:       to.BoolPtr(false),
+					UseRemoteGateways:         to.BoolPtr(false),
+					RemoteVirtualNetwork: &network.SubResource{
+						ID: to.StringPtr("some ID"),
+					},
+					RemoteAddressSpace: &network.AddressSpace{
+						AddressPrefixes: &[]string{
+							"10.0.0.0/16",
+						},
+					},
+					PeeringState:      network.Connected,
+					ProvisioningState: to.StringPtr("some provisioning state"),
+				},
+			},
+			network.VirtualNetworkPeering{
+				Name: to.StringPtr("some Name"),
+				VirtualNetworkPeeringPropertiesFormat: &network.VirtualNetworkPeeringPropertiesFormat{
+					AllowVirtualNetworkAccess: to.BoolPtr(true),
+					RemoteVirtualNetwork: &network.SubResource{
+						ID: to.StringPtr("some ID"),
+					},
+				},
+			},
+			false,
+		},
+		{
+			"case 2: need an update when RemoteVirtualNetwork.ID property change",
+			network.VirtualNetworkPeering{
+				Name: to.StringPtr("some Name"),
+				VirtualNetworkPeeringPropertiesFormat: &network.VirtualNetworkPeeringPropertiesFormat{
+					AllowVirtualNetworkAccess: to.BoolPtr(true),
+					RemoteVirtualNetwork: &network.SubResource{
+						ID: to.StringPtr("some other ID"),
+					},
+				},
+			},
+			network.VirtualNetworkPeering{
+				Name: to.StringPtr("some Name"),
+				VirtualNetworkPeeringPropertiesFormat: &network.VirtualNetworkPeeringPropertiesFormat{
+					AllowVirtualNetworkAccess: to.BoolPtr(true),
+					RemoteVirtualNetwork: &network.SubResource{
+						ID: to.StringPtr("some ID"),
+					},
+				},
+			},
+			true,
+		},
+		{
+			"case 3: need an update when AllowVirtualNetworkAccess property change",
+			network.VirtualNetworkPeering{
+				Name: to.StringPtr("some Name"),
+				VirtualNetworkPeeringPropertiesFormat: &network.VirtualNetworkPeeringPropertiesFormat{
+					AllowVirtualNetworkAccess: to.BoolPtr(false),
+					RemoteVirtualNetwork: &network.SubResource{
+						ID: to.StringPtr("some ID"),
+					},
+				},
+			},
+			network.VirtualNetworkPeering{
+				Name: to.StringPtr("some Name"),
+				VirtualNetworkPeeringPropertiesFormat: &network.VirtualNetworkPeeringPropertiesFormat{
+					AllowVirtualNetworkAccess: to.BoolPtr(true),
+					RemoteVirtualNetwork: &network.SubResource{
+						ID: to.StringPtr("some ID"),
+					},
+				},
+			},
+			true,
+		},
+		{
+			"case 4: need an update when Name property change",
+			network.VirtualNetworkPeering{
+				Name: to.StringPtr("some Name"),
+				VirtualNetworkPeeringPropertiesFormat: &network.VirtualNetworkPeeringPropertiesFormat{
+					AllowVirtualNetworkAccess: to.BoolPtr(true),
+					RemoteVirtualNetwork: &network.SubResource{
+						ID: to.StringPtr("some ID"),
+					},
+				},
+			},
+			network.VirtualNetworkPeering{
+				Name: to.StringPtr("some other Name"),
+				VirtualNetworkPeeringPropertiesFormat: &network.VirtualNetworkPeeringPropertiesFormat{
+					AllowVirtualNetworkAccess: to.BoolPtr(true),
+					RemoteVirtualNetwork: &network.SubResource{
+						ID: to.StringPtr("some ID"),
+					},
+				},
+			},
+			true,
+		},
+		{
+			"case 5: need an update when PeeringState is disconnected",
+			network.VirtualNetworkPeering{
+				Name: to.StringPtr("some Name"),
+				VirtualNetworkPeeringPropertiesFormat: &network.VirtualNetworkPeeringPropertiesFormat{
+					AllowVirtualNetworkAccess: to.BoolPtr(true),
+					RemoteVirtualNetwork: &network.SubResource{
+						ID: to.StringPtr("some ID"),
+					},
+					PeeringState: network.Disconnected,
+				},
+			},
+			network.VirtualNetworkPeering{
+				Name: to.StringPtr("some Name"),
+				VirtualNetworkPeeringPropertiesFormat: &network.VirtualNetworkPeeringPropertiesFormat{
+					AllowVirtualNetworkAccess: to.BoolPtr(true),
+					RemoteVirtualNetwork: &network.SubResource{
+						ID: to.StringPtr("some ID"),
+					},
+				},
+			},
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok := needUpdate(tc.current, tc.desired)
+
+			if ok != tc.expected {
+				t.Fatalf("ok == %v, want %v", ok, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Towards: #284 

Re-use the previously gone vnetpeering resource as a base for cleaning up orphaned vnetpeering.