### PR TITLE
Fix Azure disk mounts

### DIFF
--- a/service/controller/v3/cloudconfig/master_extension.go
+++ b/service/controller/v3/cloudconfig/master_extension.go
@@ -162,11 +162,7 @@ func (me *masterExtension) renderIngressLBFile() (k8scloudconfig.FileAsset, erro
 }
 
 func (me *masterExtension) renderEtcdMountUnit() (k8scloudconfig.UnitAsset, error) {
-	params := diskParams{
-		DiskName: "sdc",
-	}
-
-	asset, err := renderEtcdMountUnit(params)
+	asset, err := renderEtcdMountUnit()
 	if err != nil {
 		return k8scloudconfig.UnitAsset{}, microerror.Mask(err)
 	}
@@ -176,7 +172,7 @@ func (me *masterExtension) renderEtcdMountUnit() (k8scloudconfig.UnitAsset, erro
 
 func (me *masterExtension) renderEtcdDiskFormatUnit() (k8scloudconfig.UnitAsset, error) {
 	params := diskParams{
-		DiskName: "sdc",
+		LUNID: "0",
 	}
 
 	asset, err := renderEtcdDiskFormatUnit(params)
@@ -188,11 +184,7 @@ func (me *masterExtension) renderEtcdDiskFormatUnit() (k8scloudconfig.UnitAsset,
 }
 
 func (me *masterExtension) renderDockerMountUnit() (k8scloudconfig.UnitAsset, error) {
-	params := diskParams{
-		DiskName: "sdd",
-	}
-
-	asset, err := renderDockerMountUnit(params)
+	asset, err := renderDockerMountUnit()
 	if err != nil {
 		return k8scloudconfig.UnitAsset{}, microerror.Mask(err)
 	}
@@ -202,7 +194,7 @@ func (me *masterExtension) renderDockerMountUnit() (k8scloudconfig.UnitAsset, er
 
 func (me *masterExtension) renderDockerDiskFormatUnit() (k8scloudconfig.UnitAsset, error) {
 	params := diskParams{
-		DiskName: "sdd",
+		LUNID: "1",
 	}
 
 	asset, err := renderDockerDiskFormatUnit(params)

--- a/service/controller/v3/cloudconfig/render.go
+++ b/service/controller/v3/cloudconfig/render.go
@@ -123,7 +123,9 @@ func renderIngressLBFile(params ingressLBFileParams) (k8scloudconfig.FileAsset, 
 	return file, nil
 }
 
-func renderEtcdMountUnit(params diskParams) (k8scloudconfig.UnitAsset, error) {
+func renderEtcdMountUnit() (k8scloudconfig.UnitAsset, error) {
+	params := struct{}{}
+
 	unitMeta := k8scloudconfig.UnitMetadata{
 		AssetContent: etcdMountUnitTemplate,
 		Name:         etcdMountUnitName,
@@ -165,7 +167,9 @@ func renderEtcdDiskFormatUnit(params diskParams) (k8scloudconfig.UnitAsset, erro
 	return asset, nil
 }
 
-func renderDockerMountUnit(params diskParams) (k8scloudconfig.UnitAsset, error) {
+func renderDockerMountUnit() (k8scloudconfig.UnitAsset, error) {
+	params := struct{}{}
+
 	unitMeta := k8scloudconfig.UnitMetadata{
 		AssetContent: dockerMountUnitTemplate,
 		Name:         dockerMountUnitName,

--- a/service/controller/v3/cloudconfig/render_test.go
+++ b/service/controller/v3/cloudconfig/render_test.go
@@ -39,7 +39,7 @@ func Test_render(t *testing.T) {
 		},
 		{
 			Name: "renderEtcdMountUnit",
-			Fn:   func() error { _, err := renderEtcdMountUnit(diskParams{}); return err },
+			Fn:   func() error { _, err := renderEtcdMountUnit(); return err },
 		},
 		{
 			Name: "renderEtcdDiskFormatUnit",
@@ -47,7 +47,7 @@ func Test_render(t *testing.T) {
 		},
 		{
 			Name: "renderDockerMountUnit",
-			Fn:   func() error { _, err := renderDockerMountUnit(diskParams{}); return err },
+			Fn:   func() error { _, err := renderDockerMountUnit(); return err },
 		},
 		{
 			Name: "renderDockerDiskFormatUnit",

--- a/service/controller/v3/cloudconfig/template.go
+++ b/service/controller/v3/cloudconfig/template.go
@@ -589,7 +589,7 @@ After=format-etcd-disk.service
 Before=etcd3.service
 
 [Mount]
-What=/dev/{{ .DiskName }}
+What=/dev/disk/by-label/etcd
 Where=/var/lib/etcd
 Type=ext4
 
@@ -599,14 +599,14 @@ WantedBy=multi-user.target
 	etcdDiskFormatUnitName     = "format-etcd-disk.service"
 	etcdDiskFormatUnitTemplate = `[Unit]
 Description=Formats the disk drive
-Requires=dev-{{ .DiskName }}.device
-After=dev-{{ .DiskName }}.device
+Requires=dev-disk-azure-scsi1-lun{{ .LUNID }}.device
+After=dev-disk-azure-scsi1-lun{{ .LUNID }}.device
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 Environment="LABEL=etcd"
-Environment="DEV=/dev/{{ .DiskName }}"
+Environment="DEV=/dev/disk/azure/scsi1/lun{{ .LUNID }}"
 # Do not wipe the disk if it's already being used, so the etcd data is persistent across reboot.
 ExecStart=-/bin/bash -c "if ! findfs LABEL=$LABEL > /tmp/label.$LABEL; then wipefs -a -f $DEV && mkfs.ext4 -T news -F -L $LABEL $DEV && echo wiped; fi"
 
@@ -621,7 +621,7 @@ After=format-docker-disk.service
 Before=docker.service
 
 [Mount]
-What=/dev/{{ .DiskName }}
+What=/dev/disk/by-label/docker
 Where=/var/lib/docker
 Type=xfs
 
@@ -631,16 +631,15 @@ WantedBy=multi-user.target
 	dockerDiskFormatUnitName     = "format-docker-disk.service"
 	dockerDiskFormatUnitTemplate = `[Unit]
 Description=Formats the disk drive
-Requires=dev-{{ .DiskName }}.device
-After=dev-{{ .DiskName }}.device
+Requires=dev-disk-azure-scsi1-lun{{ .LUNID }}.device
+After=dev-disk-azure-scsi1-lun{{ .LUNID }}.device
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 Environment="LABEL=docker"
-Environment="DEV=/dev/{{ .DiskName }}"
-# Do not wipe the disk if it's already being used.
-ExecStart=-/bin/bash -c "if ! findfs LABEL=$LABEL > /tmp/label.$LABEL; then wipefs -a -f $DEV && mkfs.xfs -L $LABEL $DEV && echo formatted; fi"
+Environment="DEV=/dev/disk/azure/scsi1/lun{{ .LUNID }}"
+ExecStart=-/bin/bash -c "wipefs -a -f $DEV && mkfs.xfs -L $LABEL $DEV"
 
 [Install]
 WantedBy=multi-user.target

--- a/service/controller/v3/cloudconfig/types.go
+++ b/service/controller/v3/cloudconfig/types.go
@@ -57,7 +57,7 @@ func newCloudProviderConfFileParams(azure setting.Azure, azureConfig client.Azur
 }
 
 type diskParams struct {
-	DiskName string
+	LUNID string
 }
 
 type ingressLBFileParams struct {

--- a/service/controller/v3/cloudconfig/worker_extension.go
+++ b/service/controller/v3/cloudconfig/worker_extension.go
@@ -91,11 +91,7 @@ func (we *workerExtension) renderCloudProviderConfFile() (k8scloudconfig.FileAss
 }
 
 func (we *workerExtension) renderDockerMountUnit() (k8scloudconfig.UnitAsset, error) {
-	params := diskParams{
-		DiskName: "sdc",
-	}
-
-	asset, err := renderDockerMountUnit(params)
+	asset, err := renderDockerMountUnit()
 	if err != nil {
 		return k8scloudconfig.UnitAsset{}, microerror.Mask(err)
 	}
@@ -105,7 +101,7 @@ func (we *workerExtension) renderDockerMountUnit() (k8scloudconfig.UnitAsset, er
 
 func (we *workerExtension) renderDockerDiskFormatUnit() (k8scloudconfig.UnitAsset, error) {
 	params := diskParams{
-		DiskName: "sdc",
+		LUNID: "0",
 	}
 
 	asset, err := renderDockerDiskFormatUnit(params)

--- a/service/controller/v3/version_bundle.go
+++ b/service/controller/v3/version_bundle.go
@@ -22,6 +22,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Added support for etcd monitoring.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "azure-operator",
+				Description: "Fixed Azure disk mounting.",
+				Kind:        versionbundle.KindChanged,
+			},
 		},
 		Components: []versionbundle.Component{
 			{


### PR DESCRIPTION
Fixes: https://github.com/giantswarm/giantswarm/issues/3847
Fixes: https://github.com/giantswarm/azure-operator/issues/113

In Azure you can set LUN ID, when attaching disk to VM. CoreOS supplied with special udev rules for Azure that create symlinks in `/dev/disk/azure/scsi1/lunX`, where `X` is the lun that was specified while attaching.