### PR TITLE
add credential-default to helm chart

### DIFF
--- a/helm/azure-operator-chart/templates/credential-default.yaml
+++ b/helm/azure-operator-chart/templates/credential-default.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+labels:
+  app: credentiald
+  giantswarm.io/managed-by: credentiald
+  giantswarm.io/organization: giantswarm
+  giantswarm.io/service-type: system
+name: credential-default
+namespace: giantswarm
+data:
+  azure.azureoperator.clientid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.clientid }}
+  azure.azureoperator.clientsecret: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.clientsecret }}
+  azure.azureoperator.subscriptionid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.subscriptionid }}
+  azure.azureoperator.tenantid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.tenantid }}

--- a/helm/azure-operator-chart/templates/credential-default.yaml
+++ b/helm/azure-operator-chart/templates/credential-default.yaml
@@ -10,7 +10,7 @@ metadata:
   name: credential-default
   namespace: giantswarm
 data:
-  azure.azureoperator.clientid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.clientid | b64enc | quote }}
-  azure.azureoperator.clientsecret: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.clientsecret | b64enc | quote }}
-  azure.azureoperator.subscriptionid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.subscriptionid | b64enc | quote }}
-  azure.azureoperator.tenantid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.tenantid | b64enc | quote}}
+  azure.azureoperator.clientid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.clientid | b64enc }}
+  azure.azureoperator.clientsecret: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.clientsecret | b64enc }}
+  azure.azureoperator.subscriptionid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.subscriptionid | b64enc }}
+  azure.azureoperator.tenantid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.tenantid | b64enc }}

--- a/helm/azure-operator-chart/templates/credential-default.yaml
+++ b/helm/azure-operator-chart/templates/credential-default.yaml
@@ -6,10 +6,11 @@ labels:
   giantswarm.io/managed-by: credentiald
   giantswarm.io/organization: giantswarm
   giantswarm.io/service-type: system
-name: credential-default
-namespace: giantswarm
+metadata:
+  name: credential-default
+  namespace: giantswarm
 data:
-  azure.azureoperator.clientid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.clientid }}
-  azure.azureoperator.clientsecret: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.clientsecret }}
-  azure.azureoperator.subscriptionid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.subscriptionid }}
-  azure.azureoperator.tenantid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.tenantid }}
+  azure.azureoperator.clientid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.clientid | b64enc | quote }}
+  azure.azureoperator.clientsecret: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.clientsecret | b64enc | quote }}
+  azure.azureoperator.subscriptionid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.subscriptionid | b64enc | quote }}
+  azure.azureoperator.tenantid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.tenantid | b64enc | quote}}

--- a/helm/azure-operator-chart/templates/credential-default.yaml
+++ b/helm/azure-operator-chart/templates/credential-default.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Secret
 type: Opaque
-labels:
-  app: credentiald
-  giantswarm.io/managed-by: credentiald
-  giantswarm.io/organization: giantswarm
-  giantswarm.io/service-type: system
 metadata:
   name: credential-default
   namespace: giantswarm
+  labels:
+    app: credentiald
+    giantswarm.io/managed-by: credentiald
+    giantswarm.io/organization: giantswarm
+    giantswarm.io/service-type: system
 data:
   azure.azureoperator.clientid: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.clientid | b64enc }}
   azure.azureoperator.clientsecret: {{ .Values.Installation.V1.Secret.AzureOperator.CredentialDefault.clientsecret | b64enc }}

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -15,7 +15,6 @@ import (
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/azure-operator/integration/env"
-	"github.com/giantswarm/azure-operator/integration/template"
 )
 
 const (

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -76,13 +76,19 @@ func Resources(config Config) error {
 			},
 			Secret: chartvalues.AzureOperatorConfigSecret{
 				AzureOperator: chartvalues.AzureOperatorConfigSecretAzureOperator{
+					CredentialDefault: chartvalues.AzureOperatorConfigSecretAzureOperatorCredentialDefault{
+						ClientID:       env.AzureClientID(),
+						ClientSecret:   env.AzureClientSecret(),
+						SubscriptionID: env.AzureSubscriptionID(),
+						TenantID:       env.AzureTenantID(),
+					},
 					SecretYaml: chartvalues.AzureOperatorConfigSecretAzureOperatorSecretYaml{
 						Service: chartvalues.AzureOperatorConfigSecretAzureOperatorSecretYamlService{
 							Azure: chartvalues.AzureOperatorConfigSecretAzureOperatorSecretYamlServiceAzure{
-								ClientID:      env.AzureClientID(),
-								ClientSecret:  env.AzureClientSecret(),
-								SubsciptionID: env.AzureSubscriptionID(),
-								TenantID:      env.AzureTenantID(),
+								ClientID:       env.AzureClientID(),
+								ClientSecret:   env.AzureClientSecret(),
+								SubscriptionID: env.AzureSubscriptionID(),
+								TenantID:       env.AzureTenantID(),
 								Template: chartvalues.AzureOperatorConfigSecretAzureOperatorSecretYamlServiceAzureTemplate{
 									URI: chartvalues.AzureOperatorConfigSecretAzureOperatorSecretYamlServiceAzureTemplateURI{
 										Version: env.CircleSHA(),


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/3815

Add `credential-default` which is now required by azure-operator to operate tenant cluster.