### PR TITLE
Add resource limits for install-cni container and make it initContainer.

### DIFF
--- a/service/controller/v5/cloudconfig/template.go
+++ b/service/controller/v5/cloudconfig/template.go
@@ -6,6 +6,7 @@ const (
 	calicoAzureFilePermission = 0600
 	calicoAzureFileTemplate   = `# Extra changes:
 #  - Added "nodename_file_optional" set to true (can be removed on the next upgrade).
+#    Tracked here: https://github.com/giantswarm/giantswarm/issues/4113
 #  - Added resource limits to calico-node.
 #  - Added resource limits to install-cni.
 #  - Made install-cni initContainer.

--- a/service/controller/v5/cloudconfig/template.go
+++ b/service/controller/v5/cloudconfig/template.go
@@ -5,8 +5,10 @@ const (
 	calicoAzureFileOwner      = "root:root"
 	calicoAzureFilePermission = 0600
 	calicoAzureFileTemplate   = `# Extra changes:
-#  - added "nodename_file_optional" set to true (can be removed on the next upgrade)
-#  - added resource limits
+#  - Added "nodename_file_optional" set to true (can be removed on the next upgrade).
+#  - Added resource limits to calico-node.
+#  - Added resource limits to install-cni.
+#  - Made install-cni initContainer.
 #
 # Calico Version v3.2.3
 # https://docs.projectcalico.org/v3.2/releases#v3.2.3
@@ -294,6 +296,7 @@ spec:
             - mountPath: /var/lib/calico
               name: var-lib-calico
               readOnly: false
+      initContainers:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
@@ -314,6 +317,16 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: cni_network_config
+            # Prevents the container from sleeping forever.
+            - name: SLEEP
+              value: "false"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
           volumeMounts:
             - mountPath: /host/opt/cni/bin
               name: cni-bin-dir

--- a/service/controller/v5/version_bundle.go
+++ b/service/controller/v5/version_bundle.go
@@ -14,7 +14,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "cloudconfig",
-				Description: "Updated Calico manifest with resource limits.",
+				Description: "Updated Calico manifest with resource limits to get QoS policy guaranteed.",
 				Kind:        versionbundle.KindChanged,
 			},
 			{


### PR DESCRIPTION
Part of: https://github.com/giantswarm/giantswarm/issues/4159

Makes calico QoS policy guaranteed.