### PR TITLE
v3, v3patch1, v4, v5: fix vmss instances paging

### DIFF
--- a/service/controller/v3/key/key.go
+++ b/service/controller/v3/key/key.go
@@ -2,6 +2,7 @@ package key
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/Azure/go-autorest/autorest/to"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
@@ -217,7 +218,8 @@ func WorkerSubnetName(customObject providerv1alpha1.AzureConfig) string {
 }
 
 func MasterInstanceName(customObject providerv1alpha1.AzureConfig, instanceID string) string {
-	return fmt.Sprintf("%s-master-%06s", ClusterID(customObject), instanceID)
+	idB36 := vmssInstanceIDBase36(instanceID)
+	return fmt.Sprintf("%s-master-%06s", ClusterID(customObject), idB36)
 }
 
 // MasterNICName returns name of the master NIC.
@@ -389,9 +391,27 @@ func VPNGatewayName(customObject providerv1alpha1.AzureConfig) string {
 }
 
 func WorkerInstanceName(customObject providerv1alpha1.AzureConfig, instanceID string) string {
-	return fmt.Sprintf("%s-worker-%06s", ClusterID(customObject), instanceID)
+	idB36 := vmssInstanceIDBase36(instanceID)
+	return fmt.Sprintf("%s-worker-%06s", ClusterID(customObject), idB36)
 }
 
 func WorkerVMSSName(customObject providerv1alpha1.AzureConfig) string {
 	return fmt.Sprintf("%s-worker", ClusterID(customObject))
+}
+
+func vmssInstanceIDBase36(instanceID string) string {
+	i, err := strconv.ParseUint(instanceID, 10, 64)
+	if err != nil {
+		// This must be an int according to the documentation linked below.
+		//
+		// We are panicking here to make the API nice. If this is not
+		// an int there is nothing we can really do and we need to
+		// redesign `instance` resource.
+		//
+		//	https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-instance-ids#scale-set-vm-computer-name
+		//
+		panic(fmt.Sprintf("expected VMSS instanceID to be a positive integer number but got %#q", instanceID))
+	}
+
+	return strconv.FormatUint(i, 36)
 }

--- a/service/controller/v3/resource/instance/create.go
+++ b/service/controller/v3/resource/instance/create.go
@@ -271,9 +271,20 @@ func (r *Resource) allInstances(ctx context.Context, customObject providerv1alph
 		return nil, microerror.Mask(err)
 	}
 
+	var instances []compute.VirtualMachineScaleSetVM
+
+	for result.NotDone() {
+		instances = append(instances, result.Values()...)
+
+		err := result.Next()
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found the scale set '%s'", deploymentNameFunc(customObject)))
 
-	return result.Values(), nil
+	return instances, nil
 }
 
 func (r *Resource) createDrainerConfig(ctx context.Context, customObject providerv1alpha1.AzureConfig, instance *compute.VirtualMachineScaleSetVM, instanceNameFunc func(customObject providerv1alpha1.AzureConfig, instanceID string) string) error {

--- a/service/controller/v3patch1/key/key.go
+++ b/service/controller/v3patch1/key/key.go
@@ -2,6 +2,7 @@ package key
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/Azure/go-autorest/autorest/to"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
@@ -217,7 +218,8 @@ func WorkerSubnetName(customObject providerv1alpha1.AzureConfig) string {
 }
 
 func MasterInstanceName(customObject providerv1alpha1.AzureConfig, instanceID string) string {
-	return fmt.Sprintf("%s-master-%06s", ClusterID(customObject), instanceID)
+	idB36 := vmssInstanceIDBase36(instanceID)
+	return fmt.Sprintf("%s-master-%06s", ClusterID(customObject), idB36)
 }
 
 // MasterNICName returns name of the master NIC.
@@ -389,9 +391,27 @@ func VPNGatewayName(customObject providerv1alpha1.AzureConfig) string {
 }
 
 func WorkerInstanceName(customObject providerv1alpha1.AzureConfig, instanceID string) string {
-	return fmt.Sprintf("%s-worker-%06s", ClusterID(customObject), instanceID)
+	idB36 := vmssInstanceIDBase36(instanceID)
+	return fmt.Sprintf("%s-worker-%06s", ClusterID(customObject), idB36)
 }
 
 func WorkerVMSSName(customObject providerv1alpha1.AzureConfig) string {
 	return fmt.Sprintf("%s-worker", ClusterID(customObject))
+}
+
+func vmssInstanceIDBase36(instanceID string) string {
+	i, err := strconv.ParseUint(instanceID, 10, 64)
+	if err != nil {
+		// This must be an int according to the documentation linked below.
+		//
+		// We are panicking here to make the API nice. If this is not
+		// an int there is nothing we can really do and we need to
+		// redesign `instance` resource.
+		//
+		//	https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-instance-ids#scale-set-vm-computer-name
+		//
+		panic(fmt.Sprintf("expected VMSS instanceID to be a positive integer number but got %#q", instanceID))
+	}
+
+	return strconv.FormatUint(i, 36)
 }

--- a/service/controller/v3patch1/resource/instance/create.go
+++ b/service/controller/v3patch1/resource/instance/create.go
@@ -271,9 +271,20 @@ func (r *Resource) allInstances(ctx context.Context, customObject providerv1alph
 		return nil, microerror.Mask(err)
 	}
 
+	var instances []compute.VirtualMachineScaleSetVM
+
+	for result.NotDone() {
+		instances = append(instances, result.Values()...)
+
+		err := result.Next()
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found the scale set '%s'", deploymentNameFunc(customObject)))
 
-	return result.Values(), nil
+	return instances, nil
 }
 
 func (r *Resource) createDrainerConfig(ctx context.Context, customObject providerv1alpha1.AzureConfig, instance *compute.VirtualMachineScaleSetVM, instanceNameFunc func(customObject providerv1alpha1.AzureConfig, instanceID string) string) error {

--- a/service/controller/v4/key/key.go
+++ b/service/controller/v4/key/key.go
@@ -2,6 +2,7 @@ package key
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/Azure/go-autorest/autorest/to"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
@@ -217,7 +218,8 @@ func WorkerSubnetName(customObject providerv1alpha1.AzureConfig) string {
 }
 
 func MasterInstanceName(customObject providerv1alpha1.AzureConfig, instanceID string) string {
-	return fmt.Sprintf("%s-master-%06s", ClusterID(customObject), instanceID)
+	idB36 := vmssInstanceIDBase36(instanceID)
+	return fmt.Sprintf("%s-master-%06s", ClusterID(customObject), idB36)
 }
 
 // MasterNICName returns name of the master NIC.
@@ -389,9 +391,27 @@ func VPNGatewayName(customObject providerv1alpha1.AzureConfig) string {
 }
 
 func WorkerInstanceName(customObject providerv1alpha1.AzureConfig, instanceID string) string {
-	return fmt.Sprintf("%s-worker-%06s", ClusterID(customObject), instanceID)
+	idB36 := vmssInstanceIDBase36(instanceID)
+	return fmt.Sprintf("%s-worker-%06s", ClusterID(customObject), idB36)
 }
 
 func WorkerVMSSName(customObject providerv1alpha1.AzureConfig) string {
 	return fmt.Sprintf("%s-worker", ClusterID(customObject))
+}
+
+func vmssInstanceIDBase36(instanceID string) string {
+	i, err := strconv.ParseUint(instanceID, 10, 64)
+	if err != nil {
+		// This must be an int according to the documentation linked below.
+		//
+		// We are panicking here to make the API nice. If this is not
+		// an int there is nothing we can really do and we need to
+		// redesign `instance` resource.
+		//
+		//	https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-instance-ids#scale-set-vm-computer-name
+		//
+		panic(fmt.Sprintf("expected VMSS instanceID to be a positive integer number but got %#q", instanceID))
+	}
+
+	return strconv.FormatUint(i, 36)
 }

--- a/service/controller/v4/resource/instance/create.go
+++ b/service/controller/v4/resource/instance/create.go
@@ -273,9 +273,20 @@ func (r *Resource) allInstances(ctx context.Context, customObject providerv1alph
 		return nil, microerror.Mask(err)
 	}
 
+	var instances []compute.VirtualMachineScaleSetVM
+
+	for result.NotDone() {
+		instances = append(instances, result.Values()...)
+
+		err := result.Next()
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found the scale set '%s'", deploymentNameFunc(customObject)))
 
-	return result.Values(), nil
+	return instances, nil
 }
 
 func (r *Resource) createDrainerConfig(ctx context.Context, customObject providerv1alpha1.AzureConfig, instance *compute.VirtualMachineScaleSetVM, instanceNameFunc func(customObject providerv1alpha1.AzureConfig, instanceID string) string) error {

--- a/service/controller/v5/key/key.go
+++ b/service/controller/v5/key/key.go
@@ -413,6 +413,11 @@ func WorkerVMSSName(customObject providerv1alpha1.AzureConfig) string {
 func vmssInstanceIDBase36(instanceID string) string {
 	i, err := strconv.ParseUint(instanceID, 10, 64)
 	if err != nil {
+		// TODO Avoid panic call below if feasible.
+		//
+		//	See https://github.com/giantswarm/giantswarm/issues/4674
+		//
+
 		// This must be an int according to the documentation linked below.
 		//
 		// We are panicking here to make the API nice. If this is not

--- a/service/controller/v5/key/key.go
+++ b/service/controller/v5/key/key.go
@@ -2,6 +2,7 @@ package key
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/Azure/go-autorest/autorest/to"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
@@ -223,7 +224,8 @@ func WorkerSubnetName(customObject providerv1alpha1.AzureConfig) string {
 }
 
 func MasterInstanceName(customObject providerv1alpha1.AzureConfig, instanceID string) string {
-	return fmt.Sprintf("%s-master-%06s", ClusterID(customObject), instanceID)
+	idB36 := vmssInstanceIDBase36(instanceID)
+	return fmt.Sprintf("%s-master-%06s", ClusterID(customObject), idB36)
 }
 
 // MasterNICName returns name of the master NIC.
@@ -400,9 +402,27 @@ func VPNGatewayName(customObject providerv1alpha1.AzureConfig) string {
 }
 
 func WorkerInstanceName(customObject providerv1alpha1.AzureConfig, instanceID string) string {
-	return fmt.Sprintf("%s-worker-%06s", ClusterID(customObject), instanceID)
+	idB36 := vmssInstanceIDBase36(instanceID)
+	return fmt.Sprintf("%s-worker-%06s", ClusterID(customObject), idB36)
 }
 
 func WorkerVMSSName(customObject providerv1alpha1.AzureConfig) string {
 	return fmt.Sprintf("%s-worker", ClusterID(customObject))
+}
+
+func vmssInstanceIDBase36(instanceID string) string {
+	i, err := strconv.ParseUint(instanceID, 10, 64)
+	if err != nil {
+		// This must be an int according to the documentation linked below.
+		//
+		// We are panicking here to make the API nice. If this is not
+		// an int there is nothing we can really do and we need to
+		// redesign `instance` resource.
+		//
+		//	https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-instance-ids#scale-set-vm-computer-name
+		//
+		panic(fmt.Sprintf("expected VMSS instanceID to be a positive integer number but got %#q", instanceID))
+	}
+
+	return strconv.FormatUint(i, 36)
 }

--- a/service/controller/v5/resource/instance/create.go
+++ b/service/controller/v5/resource/instance/create.go
@@ -273,9 +273,20 @@ func (r *Resource) allInstances(ctx context.Context, customObject providerv1alph
 		return nil, microerror.Mask(err)
 	}
 
+	var instances []compute.VirtualMachineScaleSetVM
+
+	for result.NotDone() {
+		instances = append(instances, result.Values()...)
+
+		err := result.Next()
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found the scale set '%s'", deploymentNameFunc(customObject)))
 
-	return result.Values(), nil
+	return instances, nil
 }
 
 func (r *Resource) createDrainerConfig(ctx context.Context, customObject providerv1alpha1.AzureConfig, instance *compute.VirtualMachineScaleSetVM, instanceNameFunc func(customObject providerv1alpha1.AzureConfig, instanceID string) string) error {


### PR DESCRIPTION
This effectively blocked us from making upgrades on clusters with more
that 10 workers.

It also fixes a problem with instance names that have ID > 10. Apparently base 36 is used to create those names. For more details see https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-instance-ids#scale-set-vm-computer-name.