### PR TITLE
Adds resource group collector

### DIFF
--- a/helm/azure-operator-chart/templates/rbac.yaml
+++ b/helm/azure-operator-chart/templates/rbac.yaml
@@ -54,6 +54,7 @@ rules:
       - secrets
     verbs:
       - get
+      - list
       - watch
   - apiGroups:
       - ""

--- a/service/collector/client.go
+++ b/service/collector/client.go
@@ -1,0 +1,47 @@
+package collector
+
+import (
+	"github.com/giantswarm/azure-operator/client"
+	"github.com/giantswarm/azure-operator/service/credential"
+	"github.com/giantswarm/microerror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// kubernetesCredentialNamespace is the namespace in which we store credentials.
+	kubernetesCredentialNamespace = "giantswarm"
+
+	// kubernetesLabelSelector is the label selector we use to retrieve credentials.
+	kubernetesLabelSelector = "app=credentiald"
+)
+
+// getUniqueClientSets fetches all unique Azure clients.
+func getUniqueClientSets(k8sClient kubernetes.Interface, environmentName string) ([]*client.AzureClientSet, error) {
+	credentialList, err := k8sClient.CoreV1().Secrets(kubernetesCredentialNamespace).List(metav1.ListOptions{
+		LabelSelector: kubernetesLabelSelector,
+	})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	clientSets := []*client.AzureClientSet{}
+
+	for _, secret := range credentialList.Items {
+		config, err := credential.GetAzureConfig(k8sClient, secret.Name, secret.Namespace)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		config.Cloud = environmentName
+
+		clientSet, err := client.NewAzureClientSet(*config)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		clientSets = append(clientSets, clientSet)
+	}
+
+	return clientSets, nil
+}

--- a/service/collector/client.go
+++ b/service/collector/client.go
@@ -16,8 +16,8 @@ const (
 	credentialLabelSelector = "app=credentiald"
 )
 
-// getUniqueClientSets fetches all unique Azure clients.
-func getUniqueClientSets(k8sClient kubernetes.Interface, environmentName string) ([]*client.AzureClientSet, error) {
+// getClientSets fetches all unique Azure clients.
+func getClientSets(k8sClient kubernetes.Interface, environmentName string) ([]*client.AzureClientSet, error) {
 	credentialList, err := k8sClient.CoreV1().Secrets(credentialNamespace).List(metav1.ListOptions{
 		LabelSelector: credentialLabelSelector,
 	})

--- a/service/collector/client.go
+++ b/service/collector/client.go
@@ -9,17 +9,17 @@ import (
 )
 
 const (
-	// kubernetesCredentialNamespace is the namespace in which we store credentials.
-	kubernetesCredentialNamespace = "giantswarm"
+	// credentialNamespace is the namespace in which we store credentials.
+	credentialNamespace = "giantswarm"
 
-	// kubernetesLabelSelector is the label selector we use to retrieve credentials.
-	kubernetesLabelSelector = "app=credentiald"
+	// credentialLabelSelector is the label selector we use to retrieve credentials.
+	credentialLabelSelector = "app=credentiald"
 )
 
 // getUniqueClientSets fetches all unique Azure clients.
 func getUniqueClientSets(k8sClient kubernetes.Interface, environmentName string) ([]*client.AzureClientSet, error) {
-	credentialList, err := k8sClient.CoreV1().Secrets(kubernetesCredentialNamespace).List(metav1.ListOptions{
-		LabelSelector: kubernetesLabelSelector,
+	credentialList, err := k8sClient.CoreV1().Secrets(credentialNamespace).List(metav1.ListOptions{
+		LabelSelector: credentialLabelSelector,
 	})
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/service/collector/resource_group.go
+++ b/service/collector/resource_group.go
@@ -101,24 +101,23 @@ func (r *ResourceGroup) Collect(ch chan<- prometheus.Metric) error {
 }
 
 func (r *ResourceGroup) collectForClientSet(ch chan<- prometheus.Metric, client *resources.GroupsClient) error {
-	resultsPage, err := client.List(context.Background(), "", nil)
+	resultsPage, err := client.ListComplete(context.Background(), "", nil)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
 	for resultsPage.NotDone() {
-		for _, group := range resultsPage.Values() {
-			ch <- prometheus.MustNewConstMetric(
-				resourceGroupDesc,
-				prometheus.GaugeValue,
-				gaugeValue,
-				getID(group),
-				getName(group),
-				getState(group),
-				getLocation(group),
-				getManagedBy(group),
-			)
-		}
+		group := resultsPage.Value()
+		ch <- prometheus.MustNewConstMetric(
+			resourceGroupDesc,
+			prometheus.GaugeValue,
+			gaugeValue,
+			getID(group),
+			getName(group),
+			getState(group),
+			getLocation(group),
+			getManagedBy(group),
+		)
 
 		if err := resultsPage.Next(); err != nil {
 			return microerror.Mask(err)

--- a/service/collector/resource_group.go
+++ b/service/collector/resource_group.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/prometheus/client_golang/prometheus"
@@ -102,7 +101,7 @@ func (r *ResourceGroup) Collect(ch chan<- prometheus.Metric) error {
 }
 
 func (r *ResourceGroup) collectForClientSet(ch chan<- prometheus.Metric, client *resources.GroupsClient) error {
-	resultsPage, err := client.List(context.Background(), "", to.Int32Ptr(100))
+	resultsPage, err := client.List(context.Background(), "", nil)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/collector/resource_group.go
+++ b/service/collector/resource_group.go
@@ -1,0 +1,171 @@
+package collector
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/sync/errgroup"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	labelID        = "id"
+	labelName      = "name"
+	labelState     = "state"
+	labelLocation  = "location"
+	labelManagedBy = "managed_by"
+)
+
+var (
+	resourceGroupDesc *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName("azure_operator", "resource_group", "info"),
+		"Resource group information.",
+		[]string{
+			labelID,
+			labelName,
+			labelState,
+			labelLocation,
+			labelManagedBy,
+		},
+		nil,
+	)
+
+	gaugeValue float64 = 1
+)
+
+type ResourceGroupConfig struct {
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+
+	EnvironmentName string
+}
+
+type ResourceGroup struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+
+	environmentName string
+}
+
+func NewResourceGroup(config ResourceGroupConfig) (*ResourceGroup, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.EnvironmentName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.EnvironmentName must not be empty", config)
+	}
+
+	r := &ResourceGroup{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+
+		environmentName: config.EnvironmentName,
+	}
+
+	return r, nil
+}
+
+func (r *ResourceGroup) Collect(ch chan<- prometheus.Metric) error {
+	clientSets, err := getUniqueClientSets(r.k8sClient, r.environmentName)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var g errgroup.Group
+
+	for _, item := range clientSets {
+		clientSet := item
+
+		g.Go(func() error {
+			err := r.collectForClientSet(ch, clientSet.GroupsClient)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *ResourceGroup) collectForClientSet(ch chan<- prometheus.Metric, client *resources.GroupsClient) error {
+	resultsPage, err := client.List(context.Background(), "", to.Int32Ptr(100))
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for resultsPage.NotDone() {
+		for _, group := range resultsPage.Values() {
+			ch <- prometheus.MustNewConstMetric(
+				resourceGroupDesc,
+				prometheus.GaugeValue,
+				gaugeValue,
+				getID(group),
+				getName(group),
+				getState(group),
+				getLocation(group),
+				getManagedBy(group),
+			)
+		}
+
+		if err := resultsPage.Next(); err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	return nil
+}
+
+func (r *ResourceGroup) Describe(ch chan<- *prometheus.Desc) error {
+	ch <- resourceGroupDesc
+
+	return nil
+}
+
+func getID(group resources.Group) string {
+	if group.ID != nil {
+		return *group.ID
+	}
+	return ""
+}
+
+func getName(group resources.Group) string {
+	if group.Name != nil {
+		return *group.Name
+	}
+	return ""
+}
+
+func getState(group resources.Group) string {
+	if group.Properties != nil && group.Properties.ProvisioningState != nil {
+		return *group.Properties.ProvisioningState
+	}
+	return ""
+}
+
+func getLocation(group resources.Group) string {
+	if group.Location != nil {
+		return *group.Location
+	}
+	return ""
+}
+
+func getManagedBy(group resources.Group) string {
+	if group.ManagedBy != nil {
+		return *group.ManagedBy
+	}
+	return ""
+}

--- a/service/collector/resource_group.go
+++ b/service/collector/resource_group.go
@@ -74,7 +74,7 @@ func NewResourceGroup(config ResourceGroupConfig) (*ResourceGroup, error) {
 }
 
 func (r *ResourceGroup) Collect(ch chan<- prometheus.Metric) error {
-	clientSets, err := getUniqueClientSets(r.k8sClient, r.environmentName)
+	clientSets, err := getClientSets(r.k8sClient, r.environmentName)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/collector/resource_group.go
+++ b/service/collector/resource_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/prometheus/client_golang/prometheus"
@@ -112,11 +113,11 @@ func (r *ResourceGroup) collectForClientSet(ch chan<- prometheus.Metric, client 
 			resourceGroupDesc,
 			prometheus.GaugeValue,
 			gaugeValue,
-			getID(group),
-			getName(group),
+			to.String(group.ID),
+			to.String(group.Name),
 			getState(group),
-			getLocation(group),
-			getManagedBy(group),
+			to.String(group.Location),
+			to.String(group.ManagedBy),
 		)
 
 		if err := resultsPage.Next(); err != nil {
@@ -133,37 +134,10 @@ func (r *ResourceGroup) Describe(ch chan<- *prometheus.Desc) error {
 	return nil
 }
 
-func getID(group resources.Group) string {
-	if group.ID != nil {
-		return *group.ID
-	}
-	return ""
-}
-
-func getName(group resources.Group) string {
-	if group.Name != nil {
-		return *group.Name
-	}
-	return ""
-}
-
 func getState(group resources.Group) string {
-	if group.Properties != nil && group.Properties.ProvisioningState != nil {
-		return *group.Properties.ProvisioningState
+	if group.Properties != nil {
+		return to.String(group.Properties.ProvisioningState)
 	}
-	return ""
-}
 
-func getLocation(group resources.Group) string {
-	if group.Location != nil {
-		return *group.Location
-	}
-	return ""
-}
-
-func getManagedBy(group resources.Group) string {
-	if group.ManagedBy != nil {
-		return *group.ManagedBy
-	}
 	return ""
 }

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -46,11 +46,27 @@ func NewSet(config SetConfig) (*Set, error) {
 		}
 	}
 
+	var resourceGroupCollector *ResourceGroup
+	{
+		c := ResourceGroupConfig{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			EnvironmentName: config.EnvironmentName,
+		}
+
+		resourceGroupCollector, err = NewResourceGroup(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var collectorSet *collector.Set
 	{
 		c := collector.SetConfig{
 			Collectors: []collector.Interface{
 				deploymentCollector,
+				resourceGroupCollector,
 			},
 			Logger: config.Logger,
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3581

```
$ curl -Ss localhost:8000/metrics | grep azure_operator_resource_group_info
# HELP azure_operator_resource_group_info Resource group information.
# TYPE azure_operator_resource_group_info gauge
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/54k5t",location="westeurope",managed_by="azure-operator",name="54k5t",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/5dpdu",location="westeurope",managed_by="azure-operator",name="5dpdu",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/6cs7a",location="westeurope",managed_by="azure-operator",name="6cs7a",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/6dz48",location="westeurope",managed_by="azure-operator",name="6dz48",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/6iec4",location="westeurope",managed_by="azure-operator",name="6iec4",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/79f6f",location="westeurope",managed_by="azure-operator",name="79f6f",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/8ydf9",location="westeurope",managed_by="azure-operator",name="8ydf9",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/9iihk",location="westeurope",managed_by="azure-operator",name="9iihk",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/bdba3",location="westeurope",managed_by="azure-operator",name="bdba3",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/ci-cleaner",location="westeurope",managed_by="",name="ci-cleaner",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/ci-cur-bbe81-7a52e",location="westeurope",managed_by="azure-operator",name="ci-cur-bbe81-7a52e",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/ci-cur-bbe81-cba40",location="westeurope",managed_by="azure-operator",name="ci-cur-bbe81-cba40",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/ci-wip-bbe81-5e958",location="westeurope",managed_by="azure-operator",name="ci-wip-bbe81-5e958",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/ci-wip-bbe81-c1c86",location="westeurope",managed_by="azure-operator",name="ci-wip-bbe81-c1c86",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/continuous-delivery-for-host-clusters",location="westeurope",managed_by="",name="continuous-delivery-for-host-clusters",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/ep5sx",location="westeurope",managed_by="azure-operator",name="ep5sx",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/g5igw",location="westeurope",managed_by="azure-operator",name="g5igw",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/ghost",location="westeurope",managed_by="",name="ghost",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/ghost-terraform",location="westeurope",managed_by="",name="ghost-terraform",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/godsmack",location="westeurope",managed_by="",name="godsmack",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/godsmack-terraform",location="westeurope",managed_by="",name="godsmack-terraform",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/gollum",location="westeurope",managed_by="",name="gollum",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/gollum-terraform",location="westeurope",managed_by="",name="gollum-terraform",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/gv83s",location="westeurope",managed_by="azure-operator",name="gv83s",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/kmf6d",location="westeurope",managed_by="azure-operator",name="kmf6d",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/ng5t5",location="westeurope",managed_by="azure-operator",name="ng5t5",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/root_dns_zone_rg",location="westeurope",managed_by="",name="root_dns_zone_rg",state="Succeeded"} 1
azure_operator_resource_group_info{id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/x4sf9",location="westeurope",managed_by="azure-operator",name="x4sf9",state="Succeeded"} 1
```