### PR TITLE
vpn collector

### DIFF
--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -7,6 +7,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/azure-operator/client"
+	"github.com/giantswarm/azure-operator/service/controller/setting"
 )
 
 type SetConfig struct {
@@ -14,10 +17,8 @@ type SetConfig struct {
 	Logger    micrologger.Logger
 	Watcher   func(opts metav1.ListOptions) (watch.Interface, error)
 
-	// EnvironmentName is the name of the Azure environment used to compute the
-	// azure.Environment type. See also
-	// https://godoc.org/github.com/Azure/go-autorest/autorest/azure#Environment.
-	EnvironmentName string
+	AzureSetting             setting.Azure
+	HostAzureClientSetConfig client.AzureClientSetConfig
 }
 
 // Set is basically only a wrapper for the operator's collector implementations.
@@ -37,7 +38,7 @@ func NewSet(config SetConfig) (*Set, error) {
 			Logger:    config.Logger,
 			Watcher:   config.Watcher,
 
-			EnvironmentName: config.EnvironmentName,
+			EnvironmentName: config.AzureSetting.Cloud,
 		}
 
 		deploymentCollector, err = NewDeployment(c)

--- a/service/collector/set.go
+++ b/service/collector/set.go
@@ -47,11 +47,28 @@ func NewSet(config SetConfig) (*Set, error) {
 		}
 	}
 
+	var vpnConnectionCollector *VPNConnection
+	{
+		c := VPNConnectionConfig{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			AzureSetting:             config.AzureSetting,
+			HostAzureClientSetConfig: config.HostAzureClientSetConfig,
+		}
+
+		vpnConnectionCollector, err = NewVPNConnection(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var collectorSet *collector.Set
 	{
 		c := collector.SetConfig{
 			Collectors: []collector.Interface{
 				deploymentCollector,
+				vpnConnectionCollector,
 			},
 			Logger: config.Logger,
 		}

--- a/service/collector/vpn_connection.go
+++ b/service/collector/vpn_connection.go
@@ -92,6 +92,8 @@ func (r *VPNConnection) Collect(ch chan<- prometheus.Metric) error {
 		c := connections.Value()
 		connectionName := to.String(c.Name)
 
+		// ConnectionStatus returned by the API when listing connections is always empty.
+		// Details for each connection must be requested in order to get a value for ConnectionStatus.
 		g.Go(func() error {
 			connection, err := vpnConnectionClient.Get(ctx, resourceGroup, connectionName)
 			if err != nil {

--- a/service/collector/vpn_connection.go
+++ b/service/collector/vpn_connection.go
@@ -88,7 +88,7 @@ func (r *VPNConnection) Collect(ch chan<- prometheus.Metric) error {
 	for connections.NotDone() {
 		connection := connections.Value()
 		ch <- prometheus.MustNewConstMetric(
-			deploymentDesc,
+			vpnConnectionDesc,
 			prometheus.GaugeValue,
 			1,
 			to.String(connection.ID),

--- a/service/collector/vpn_connection.go
+++ b/service/collector/vpn_connection.go
@@ -87,6 +87,12 @@ func (r *VPNConnection) Collect(ch chan<- prometheus.Metric) error {
 
 	for connections.NotDone() {
 		connection := connections.Value()
+
+		connectionDetails, err := vpnConnectionClient.Get(ctx, resourceGroup, to.String(connection.Name))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
 		ch <- prometheus.MustNewConstMetric(
 			vpnConnectionDesc,
 			prometheus.GaugeValue,
@@ -95,7 +101,7 @@ func (r *VPNConnection) Collect(ch chan<- prometheus.Metric) error {
 			to.String(connection.Name),
 			to.String(connection.Location),
 			string(connection.ConnectionType),
-			string(connection.ConnectionStatus),
+			string(connectionDetails.ConnectionStatus),
 			to.String(connection.ProvisioningState),
 		)
 

--- a/service/collector/vpn_connection.go
+++ b/service/collector/vpn_connection.go
@@ -1,0 +1,123 @@
+package collector
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-06-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/azure-operator/client"
+	"github.com/giantswarm/azure-operator/service/controller/setting"
+)
+
+var (
+	vpnConnectionDesc *prometheus.Desc = prometheus.NewDesc(
+		prometheus.BuildFQName("azure_operator", "vpn_connection", "info"),
+		"VPN connection informations.",
+		[]string{
+			"id",
+			"name",
+			"location",
+			"connection_type",
+			"connection_status",
+			"provisioning_state",
+		},
+		nil,
+	)
+)
+
+type VPNConnectionConfig struct {
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+
+	AzureSetting             setting.Azure
+	HostAzureClientSetConfig client.AzureClientSetConfig
+}
+
+type VPNConnection struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+
+	azureSetting             setting.Azure
+	hostAzureClientSetConfig client.AzureClientSetConfig
+}
+
+func NewVPNConnection(config VPNConnectionConfig) (*VPNConnection, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if err := config.AzureSetting.Validate(); err != nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.AzureSetting.%s", config, err)
+	}
+	if err := config.HostAzureClientSetConfig.Validate(); err != nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.HostAzureClientSetConfig.%s", config, err)
+	}
+
+	d := &VPNConnection{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+
+		azureSetting:             config.AzureSetting,
+		hostAzureClientSetConfig: config.HostAzureClientSetConfig,
+	}
+
+	return d, nil
+}
+
+func (r *VPNConnection) Collect(ch chan<- prometheus.Metric) error {
+	vpnConnectionClient, err := r.getVPNConnectionsClient()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	ctx := context.Background()
+	resourceGroup := r.azureSetting.HostCluster.ResourceGroup
+	connections, err := vpnConnectionClient.ListComplete(ctx, resourceGroup)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for connections.NotDone() {
+		connection := connections.Value()
+		ch <- prometheus.MustNewConstMetric(
+			deploymentDesc,
+			prometheus.GaugeValue,
+			1,
+			to.String(connection.ID),
+			to.String(connection.Name),
+			to.String(connection.Location),
+			string(connection.ConnectionType),
+			string(connection.ConnectionStatus),
+			to.String(connection.ProvisioningState),
+		)
+
+		err := connections.Next()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	return nil
+}
+
+func (r *VPNConnection) Describe(ch chan<- *prometheus.Desc) error {
+	ch <- vpnConnectionDesc
+	return nil
+}
+
+func (r *VPNConnection) getVPNConnectionsClient() (*network.VirtualNetworkGatewayConnectionsClient, error) {
+	azureClients, err := client.NewAzureClientSet(r.hostAzureClientSetConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return azureClients.VirtualNetworkGatewayConnectionsClient, nil
+}

--- a/service/collector/vpn_connection.go
+++ b/service/collector/vpn_connection.go
@@ -105,7 +105,7 @@ func (r *VPNConnection) Collect(ch chan<- prometheus.Metric) error {
 			to.String(connection.ProvisioningState),
 		)
 
-		err := connections.Next()
+		err = connections.Next()
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/collector/vpn_connection.go
+++ b/service/collector/vpn_connection.go
@@ -62,7 +62,7 @@ func NewVPNConnection(config VPNConnectionConfig) (*VPNConnection, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.HostAzureClientSetConfig.%s", config, err)
 	}
 
-	d := &VPNConnection{
+	v := &VPNConnection{
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,
 
@@ -70,17 +70,17 @@ func NewVPNConnection(config VPNConnectionConfig) (*VPNConnection, error) {
 		hostAzureClientSetConfig: config.HostAzureClientSetConfig,
 	}
 
-	return d, nil
+	return v, nil
 }
 
-func (r *VPNConnection) Collect(ch chan<- prometheus.Metric) error {
-	vpnConnectionClient, err := r.getVPNConnectionsClient()
+func (v *VPNConnection) Collect(ch chan<- prometheus.Metric) error {
+	vpnConnectionClient, err := v.getVPNConnectionsClient()
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
 	ctx := context.Background()
-	resourceGroup := r.azureSetting.HostCluster.ResourceGroup
+	resourceGroup := v.azureSetting.HostCluster.ResourceGroup
 	connections, err := vpnConnectionClient.ListComplete(ctx, resourceGroup)
 	if err != nil {
 		return microerror.Mask(err)
@@ -127,13 +127,13 @@ func (r *VPNConnection) Collect(ch chan<- prometheus.Metric) error {
 	return nil
 }
 
-func (r *VPNConnection) Describe(ch chan<- *prometheus.Desc) error {
+func (v *VPNConnection) Describe(ch chan<- *prometheus.Desc) error {
 	ch <- vpnConnectionDesc
 	return nil
 }
 
-func (r *VPNConnection) getVPNConnectionsClient() (*network.VirtualNetworkGatewayConnectionsClient, error) {
-	azureClients, err := client.NewAzureClientSet(r.hostAzureClientSetConfig)
+func (v *VPNConnection) getVPNConnectionsClient() (*network.VirtualNetworkGatewayConnectionsClient, error) {
+	azureClients, err := client.NewAzureClientSet(v.hostAzureClientSetConfig)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -165,7 +165,8 @@ func New(config Config) (*Service, error) {
 			Logger:    config.Logger,
 			Watcher:   g8sClient.ProviderV1alpha1().AzureConfigs("").Watch,
 
-			AzureSetting: azure,
+			AzureSetting:             azure,
+			HostAzureClientSetConfig: azureConfig,
 		}
 
 		operatorCollector, err = collector.NewSet(c)

--- a/service/service.go
+++ b/service/service.go
@@ -165,7 +165,7 @@ func New(config Config) (*Service, error) {
 			Logger:    config.Logger,
 			Watcher:   g8sClient.ProviderV1alpha1().AzureConfigs("").Watch,
 
-			EnvironmentName: config.Viper.GetString(config.Flag.Service.Azure.Cloud),
+			AzureSetting: azure,
 		}
 
 		operatorCollector, err = collector.NewSet(c)


### PR DESCRIPTION
Towards: giantswarm/giantswarm#3581

Provide informations about VPN connections via `/metrics` endpoint.

```
$ curl -Ss localhost:8000/metrics|grep azure_operator_vpn_connection_info                                                                                        
# HELP azure_operator_vpn_connection_info VPN connection informations.
# TYPE azure_operator_vpn_connection_info gauge
azure_operator_vpn_connection_info{connection_status="Connected",connection_type="IPsec",id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/godsmack/providers/Microsoft.Network/connections/godsmack-vpn-connection-0",location="westeurope",name="godsmack-vpn-connection-0",provisioning_state="Succeeded"} 1
azure_operator_vpn_connection_info{connection_status="Connected",connection_type="IPsec",id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/godsmack/providers/Microsoft.Network/connections/godsmack-vpn-connection-1",location="westeurope",name="godsmack-vpn-connection-1",provisioning_state="Succeeded"} 1
azure_operator_vpn_connection_info{connection_status="Connected",connection_type="Vnet2Vnet",id="/subscriptions/1be3b2e6-497b-45b9-915f-eb35cae23c6a/resourceGroups/godsmack/providers/Microsoft.Network/connections/si6an",location="westeurope",name="si6an",provisioning_state="Succeeded"} 1
```