### PR TITLE
migration: fix setting default credential secret

### DIFF
--- a/service/controller/v4patch1/resource/migration/resource.go
+++ b/service/controller/v4patch1/resource/migration/resource.go
@@ -62,7 +62,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	oldSpec := *customObject.Spec.DeepCopy()
 
-	if customObject.Spec.Azure.CredentialSecret.Name != "" {
+	if customObject.Spec.Azure.CredentialSecret.Name == "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "CR is missing credential, setting the default")
 
 		customObject.Spec.Azure.CredentialSecret.Namespace = credentialSecretDefaultNamespace

--- a/service/controller/v5/resource/migration/resource.go
+++ b/service/controller/v5/resource/migration/resource.go
@@ -62,7 +62,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	oldSpec := *customObject.Spec.DeepCopy()
 
-	if customObject.Spec.Azure.CredentialSecret.Name != "" {
+	if customObject.Spec.Azure.CredentialSecret.Name == "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "CR is missing credential, setting the default")
 
 		customObject.Spec.Azure.CredentialSecret.Namespace = credentialSecretDefaultNamespace


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/5251

Default credential secret should be set when the string is `== ""` and not `!= ""`.