### PR TITLE
Fix incorrect equality check for default credential

### DIFF
--- a/service/controller/v4patch2/resource/migration/resource.go
+++ b/service/controller/v4patch2/resource/migration/resource.go
@@ -62,7 +62,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	oldSpec := *customObject.Spec.DeepCopy()
 
-	if customObject.Spec.Azure.CredentialSecret.Name != "" {
+	if customObject.Spec.Azure.CredentialSecret.Name == "" {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "CR is missing credential, setting the default")
 
 		customObject.Spec.Azure.CredentialSecret.Namespace = credentialSecretDefaultNamespace


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5251

We fixed this in https://github.com/giantswarm/azure-operator/pull/456 for v4patch1 and v5, but apparently missed this one.