### PR TITLE
fix-missing-ingress-loadbalancer

### DIFF
--- a/service/controller/v6/cloudconfig/cloud_config.go
+++ b/service/controller/v6/cloudconfig/cloud_config.go
@@ -183,6 +183,7 @@ func (c CloudConfig) NewMasterCloudConfig(customObject providerv1alpha1.AzureCon
 		}
 		params.ExtraManifests = []string{
 			"calico-azure.yaml",
+			"k8s-ingress-loadbalancer.yaml",
 		}
 		params.SSOPublicKey = c.ssoPublicKey
 	}

--- a/service/controller/v7/cloudconfig/master_template.go
+++ b/service/controller/v7/cloudconfig/master_template.go
@@ -118,6 +118,7 @@ func (c CloudConfig) NewMasterCloudConfig(customObject providerv1alpha1.AzureCon
 		}
 		params.ExtraManifests = []string{
 			"calico-azure.yaml",
+			"k8s-ingress-loadbalancer.yaml",
 		}
 		params.SSOPublicKey = c.ssoPublicKey
 	}


### PR DESCRIPTION
during https://github.com/giantswarm/giantswarm/issues/3585 testing i found that we actually dont apply loadbalancer manifest to the cluster so no ingress access is possible that seems to be wrong

fixing for WIP and also  backporting to current active release