### PR TITLE
build and release tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ workflows:
       - build:
           filters:
             tags:
-              only: /^v.*/
+              only: /^v[0-9]\.[0-9]\.[0-9].*/
       - hold:
           type: approval
       - master:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
           if [ "${CIRCLE_BRANCH}" == "master" ]; then
             ./architect deploy
           fi
+    - run: ./architect release
   master:
     docker:
       - image: busybox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,10 @@ workflows:
   version: 2
   build_and_e2eTest:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only: /^v.*/
       - hold:
           type: approval
       - master:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ workflows:
       - build:
           filters:
             tags:
-              only: /^v[0-9]\.[0-9]\.[0-9].*/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$/
       - hold:
           type: approval
       - master:

--- a/README.md
+++ b/README.md
@@ -58,3 +58,4 @@ contribution workflow as well as reporting bugs.
 
 azure-operator is under the Apache 2.0 license. See the [LICENSE](LICENSE) file for
 details.
+

--- a/README.md
+++ b/README.md
@@ -58,4 +58,3 @@ contribution workflow as well as reporting bugs.
 
 azure-operator is under the Apache 2.0 license. See the [LICENSE](LICENSE) file for
 details.
-

--- a/helm/azure-operator-chart/Chart.yaml
+++ b/helm/azure-operator-chart/Chart.yaml
@@ -1,2 +1,2 @@
 name: azure-operator-chart
-version: 1.0.0-[[ .SHA ]]
+version: [[ .Version ]]

--- a/helm/azure-operator-chart/templates/deployment.yaml
+++ b/helm/azure-operator-chart/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: azure-operator
       containers:
       - name: azure-operator
-        image: quay.io/giantswarm/azure-operator:[[ .SHA ]]
+        image: quay.io/giantswarm/azure-operator:[[ .DockerTag ]]
         volumeMounts:
         - name: azure-operator-configmap
           mountPath: /var/run/azure-operator/configmap/

--- a/helm/azure-operator-resource-chart/Chart.yaml
+++ b/helm/azure-operator-resource-chart/Chart.yaml
@@ -1,3 +1,3 @@
 name: azure-resource-chart
-version: 0.1.0
+version: [[ .Version ]]
 description: azure cluster definition to be used in the azure-operator lab


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/5206

This PR enable tagged version to be built and released.

What are the results in case a `v1.0.2` tag  is created:
- docker image `quay.io/giantswarm/azure-operator:1.0.2`
- helm chart `quay.io/giantswarm/azure-operator-chart@1.0.2`
- github v1.0.2 release with `azure-operator-chart-1.0.2.tgz` asset

Breaking change:
- ~chart version for untagged commit will change from `1.0.0-<sha>` to `v0.0.0-<sha>`~

Manual update:
- circleci token has to be updated with full access to private and public github repositories in order for architect to be able to publish github releases. see `repo` in "Available scopes" https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes
