### PR TITLE
make error handling of encryption key deletion more graceful

### DIFF
--- a/service/controller/v5/resource/encryptionkey/delete.go
+++ b/service/controller/v5/resource/encryptionkey/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/azure-operator/service/controller/v5/key"
@@ -18,7 +19,9 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting encryptionkey secret")
 
 	err = r.k8sClient.CoreV1().Secrets(key.CertificateEncryptionNamespace).Delete(key.CertificateEncryptionSecretName(customObject), &metav1.DeleteOptions{})
-	if err != nil {
+	if errors.IsNotFound(err) {
+		// fall through
+	} else if err != nil {
 		return microerror.Mask(err)
 	}
 

--- a/service/controller/v6/resource/encryptionkey/delete.go
+++ b/service/controller/v6/resource/encryptionkey/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/azure-operator/service/controller/v6/key"
@@ -18,7 +19,9 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting encryptionkey secret")
 
 	err = r.k8sClient.CoreV1().Secrets(key.CertificateEncryptionNamespace).Delete(key.CertificateEncryptionSecretName(customObject), &metav1.DeleteOptions{})
-	if err != nil {
+	if errors.IsNotFound(err) {
+		// fall through
+	} else if err != nil {
 		return microerror.Mask(err)
 	}
 

--- a/service/controller/v7/resource/encryptionkey/delete.go
+++ b/service/controller/v7/resource/encryptionkey/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/azure-operator/service/controller/v7/key"
@@ -15,14 +16,18 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting encryptionkey secret")
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting encryptionkey secret upon delete event")
 
-	err = r.k8sClient.CoreV1().Secrets(key.CertificateEncryptionNamespace).Delete(key.CertificateEncryptionSecretName(customObject), &metav1.DeleteOptions{})
-	if err != nil {
-		return microerror.Mask(err)
+		err = r.k8sClient.CoreV1().Secrets(key.CertificateEncryptionNamespace).Delete(key.CertificateEncryptionSecretName(customObject), &metav1.DeleteOptions{})
+		if errors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "encryptionkey secret already deleted")
+		} else if err != nil {
+			return microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "deleted encryptionkey secret upon delete event")
+		}
 	}
-
-	r.logger.LogCtx(ctx, "level", "debug", "message", "deleted encryptionkey secret")
 
 	return nil
 }


### PR DESCRIPTION
I see a lot of clusters on Azure being stuck in deleting CRs. This PR should improve at least this issue.

> {"caller":"github.com/giantswarm/azure-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/resource_wrapper.go:98","controller":"azure-operator","event":"delete","level":"warning","loop":"2266","message":"retrying due to error","object":"/apis/provider.giantswarm.io/v1alpha1/namespaces/default/azureconfigs/miv40","resource":"encryptionkeyv7","stack":"[{/go/src/github.com/giantswarm/azure-operator/vendor/github.com/giantswarm/operatorkit/controller/resource/retryresource/resource_wrapper.go:91: } {/go/src/github.com/giantswarm/azure-operator/service/controller/v7/resource/encryptionkey/delete.go:22: } {secrets \"miv40-certificate-encryption\" not found}]","time":"2019-04-11T09:14:04.192154+00:00","underlyingResource":"encryptionkeyv7","version":"57515605"}