### PR TITLE
fix waiting for node-operator being installed

### DIFF
--- a/integration/setup/common.go
+++ b/integration/setup/common.go
@@ -76,7 +76,7 @@ func common(ctx context.Context, config Config) error {
 			return microerror.Mask(err)
 		}
 
-		err = config.Release.InstallOperator(ctx, key.NodeOperatorReleaseName(), release.NewStableVersion(), values, corev1alpha1.NewDrainerConfigCRD()())
+		err = config.Release.InstallOperator(ctx, key.NodeOperatorReleaseName(), release.NewStableVersion(), values, corev1alpha1.NewDrainerConfigCRD())
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/integration/setup/common.go
+++ b/integration/setup/common.go
@@ -76,7 +76,7 @@ func common(ctx context.Context, config Config) error {
 			return microerror.Mask(err)
 		}
 
-		err = config.Release.InstallOperator(ctx, key.NodeOperatorReleaseName(), release.NewStableVersion(), values, corev1alpha1.NewNodeConfigCRD())
+		err = config.Release.InstallOperator(ctx, key.NodeOperatorReleaseName(), release.NewStableVersion(), values, corev1alpha1.NewDrainerConfigCRD()())
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
We dropped the `NodeConfig` CR recently and have to consider the `DrainerConfig` CR now. 