### PR TITLE
Delete beta from default storage class

### DIFF
--- a/service/controller/v8/templates/ignition/default_storage_class.go
+++ b/service/controller/v8/templates/ignition/default_storage_class.go
@@ -1,11 +1,11 @@
 package ignition
 
-const DefaultStorageClass = `apiVersion: storage.k8s.io/v1beta1
+const DefaultStorageClass = `apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: default
   annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true"
+    storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
 provisioner: kubernetes.io/azure-disk
@@ -13,7 +13,7 @@ parameters:
   kind: Managed
   storageaccounttype: Premium_LRS
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: managed-premium
@@ -25,7 +25,7 @@ parameters:
   kind: Managed
   storageaccounttype: Premium_LRS
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: managed-standard


### PR DESCRIPTION
Current Kubernetes version complaints about `default` storage because of having an old annotation parameter.