### PR TITLE
Remove executionFailedError matchers to align with fmt

### DIFF
--- a/service/controller/v9/blobclient/error.go
+++ b/service/controller/v9/blobclient/error.go
@@ -7,13 +7,16 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+// executionFailedError is an error type for situations where Resource
+// execution cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
 var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
-}
-
-// IsExecutionFailed asserts executionFailedError.
-func IsExecutionFailed(err error) bool {
-	return microerror.Cause(err) == executionFailedError
 }
 
 var invalidConfigError = &microerror.Error{

--- a/service/controller/v9/key/error.go
+++ b/service/controller/v9/key/error.go
@@ -2,13 +2,16 @@ package key
 
 import "github.com/giantswarm/microerror"
 
+// executionFailedError is an error type for situations where Resource
+// execution cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
 var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
-}
-
-// IsExecutionFailed asserts executionFailedError.
-func IsExecutionFailed(err error) bool {
-	return microerror.Cause(err) == executionFailedError
 }
 
 var missingOutputValueError = &microerror.Error{

--- a/service/controller/v9/resource/containerurl/error.go
+++ b/service/controller/v9/resource/containerurl/error.go
@@ -6,13 +6,16 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+// executionFailedError is an error type for situations where Resource
+// execution cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
 var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
-}
-
-// IsExecutionFailed asserts executionFailedError.
-func IsExecutionFailed(err error) bool {
-	return microerror.Cause(err) == executionFailedError
 }
 
 var invalidConfigError = &microerror.Error{

--- a/service/controller/v9/resource/encryptionkey/error.go
+++ b/service/controller/v9/resource/encryptionkey/error.go
@@ -4,13 +4,16 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+// executionFailedError is an error type for situations where Resource
+// execution cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
 var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
-}
-
-// IsExecutionFailed asserts executionFailedError.
-func IsExecutionFailed(err error) bool {
-	return microerror.Cause(err) == executionFailedError
 }
 
 var invalidConfigError = &microerror.Error{

--- a/service/controller/v9/resource/instance/error.go
+++ b/service/controller/v9/resource/instance/error.go
@@ -5,13 +5,16 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+// executionFailedError is an error type for situations where Resource
+// execution cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
 var executionFailedError = &microerror.Error{
 	Kind: "executionFailedError",
-}
-
-// IsExecutionFailed asserts executionFailedError.
-func IsExecutionFailed(err error) bool {
-	return microerror.Cause(err) == executionFailedError
 }
 
 var invalidConfigError = &microerror.Error{


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/6569