### PR TITLE
remove support for .DockerTag and releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,9 +120,6 @@ workflows:
   build_and_e2eTest:
     jobs:
       - build:
-          filters:
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$/
       - hold:
           type: approval
       - master:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,6 @@ jobs:
           if [ "${CIRCLE_BRANCH}" == "master" ]; then
             ./architect deploy
           fi
-    - run: ./architect release
   master:
     docker:
       - image: busybox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ workflows:
   version: 2
   build_and_e2eTest:
     jobs:
-      - build:
+      - build
       - hold:
           type: approval
       - master:

--- a/helm/azure-operator-chart/templates/deployment.yaml
+++ b/helm/azure-operator-chart/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         runAsGroup: {{ .Values.groupID }}
       containers:
       - name: azure-operator
-        image: quay.io/giantswarm/azure-operator:[[ .DockerTag ]]
+        image: quay.io/giantswarm/azure-operator:[[ .SHA ]]
         volumeMounts:
         - name: azure-operator-configmap
           mountPath: /var/run/azure-operator/configmap/


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/6557

Remove `.DockerTag` as we only want to use either the old `.SHA` or the new `.Version`.
Going with old way here, as we are now focusing on aws-operator.