### PR TITLE
Improve scrape of usage

### DIFF
--- a/service/collector/usage.go
+++ b/service/collector/usage.go
@@ -140,7 +140,7 @@ func (u *Usage) Collect(ch chan<- prometheus.Metric) error {
 	for _, c := range clients {
 		r, err := c.List(context.Background(), u.location)
 		if err != nil {
-			u.logger.Log("level", "warning", "message", "An error occured during the scraping of usage", "stack", fmt.Sprintf("%v", err))
+			u.logger.Log("level", "warning", "message", "an error occurred during the scraping of usage", "stack", fmt.Sprintf("%v", err))
 			u.usageScrapeError.Inc()
 			ch <- u.usageScrapeError
 		} else {

--- a/service/collector/usage.go
+++ b/service/collector/usage.go
@@ -90,7 +90,7 @@ func NewUsage(config UsageConfig) (*Usage, error) {
 			Namespace: namespace,
 			Subsystem: component,
 			Name:      "scrape_error",
-			Help:      "Total number of times Usage scraping returned an error.",
+			Help:      "Total number of times compute resource usage information scraping returned an error.",
 		}),
 
 		environmentName: config.EnvironmentName,
@@ -140,7 +140,7 @@ func (u *Usage) Collect(ch chan<- prometheus.Metric) error {
 	for _, c := range clients {
 		r, err := c.List(context.Background(), u.location)
 		if err != nil {
-			u.logger.Log("level", "warning", "message", "an error occurred during the scraping of usage", "stack", fmt.Sprintf("%v", err))
+			u.logger.Log("level", "warning", "message", "an error occurred during the scraping of current compute resource usage information", "stack", fmt.Sprintf("%v", err))
 			u.usageScrapeError.Inc()
 			ch <- u.usageScrapeError
 		} else {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6426

Same as done here https://github.com/giantswarm/cluster-service/commit/135da30bc9f30b6dc2831f9e669620a140d09ef4 we improve the scraping so a failure of scraping external resources that might be nonresponsive does not put the service down from a Prom perspective and trigger us with annoying `TargetDown` pages