### PR TITLE
Revert "build and release tags (#499)"

### DIFF
--- a/helm/azure-operator-chart/Chart.yaml
+++ b/helm/azure-operator-chart/Chart.yaml
@@ -1,2 +1,2 @@
 name: azure-operator-chart
-version: [[ .Version ]]
+version: 1.0.0-[[ .SHA ]]

--- a/helm/azure-operator-resource-chart/Chart.yaml
+++ b/helm/azure-operator-resource-chart/Chart.yaml
@@ -1,3 +1,3 @@
 name: azure-resource-chart
-version: [[ .Version ]]
+version: 0.1.0
 description: azure cluster definition to be used in the azure-operator lab


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/7044

This reverts commit 05f0061f06e069268eb640af38f2e2e018aa73ca.

This PR revert the chart version to fixed `1.0.0-<sha>`. So we do not rely on the version detected by architect which is going to change https://github.com/giantswarm/architect/pull/335