### PR TITLE
Release for kubernetes 1.14.8

### DIFF
--- a/service/controller/v10patch1/version_bundle.go
+++ b/service/controller/v10patch1/version_bundle.go
@@ -36,6 +36,6 @@ func VersionBundle() versionbundle.Bundle {
 			},
 		},
 		Name:    "azure-operator",
-		Version: "2.6.2",
+		Version: "2.6.1",
 	}
 }

--- a/service/controller/v10patch2/version_bundle.go
+++ b/service/controller/v10patch2/version_bundle.go
@@ -9,8 +9,8 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "azure-operator",
-				Description: "Add service endpoints to the worker VNET.",
-				Kind:        versionbundle.KindAdded,
+				Description: "Update to kubernetes 1.14.8.",
+				Kind:        versionbundle.KindChanged,
 			},
 		},
 		Components: []versionbundle.Component{
@@ -32,10 +32,10 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "kubernetes",
-				Version: "1.14.6",
+				Version: "1.14.8",
 			},
 		},
 		Name:    "azure-operator",
-		Version: "2.6.1",
+		Version: "2.6.2",
 	}
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7302 and https://github.com/giantswarm/giantswarm/issues/7257

I made a mistake in the previous PR and updated the version bundle of `v10patch1` instead of `v10patch2`. This corrects that mistake and adds the kubernetes change to the changelog.