### PR TITLE
Added new virtual disk on /var/lib/kubelet for workers and master

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -263,7 +263,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fcb75264e7f1a4276044b71f706baf6b1eba4e619f3a3bc95f33c677cbe25f6c"
+  digest = "1:c84823c2230acaa7031e4f03d97b9c5c939b087c4a61a2927303322051c00800"
   name = "github.com/giantswarm/apiextensions"
   packages = [
     "pkg/apis/application/v1alpha1",
@@ -280,7 +280,7 @@
     "pkg/clientset/versioned/typed/release/v1alpha1",
   ]
   pruneopts = "UT"
-  revision = "efa5c38da056932db3d24b786daf200b856dc9a2"
+  revision = "ea105a560aa1495b9d4fb17f08181f8b0e28ab21"
 
 [[projects]]
   branch = "master"

--- a/service/controller/v12/cloudconfig/master_template.go
+++ b/service/controller/v12/cloudconfig/master_template.go
@@ -271,6 +271,11 @@ func (me *masterExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
 			Enabled:      true,
 		},
 		{
+			AssetContent: ignition.KubeletMountUnit,
+			Name:         "var-lib-kubelet.mount",
+			Enabled:      true,
+		},
+		{
 			AssetContent: ignition.IngressLBUnit,
 			Name:         "ingress-lb.service",
 			Enabled:      true,

--- a/service/controller/v12/cloudconfig/worker_template.go
+++ b/service/controller/v12/cloudconfig/worker_template.go
@@ -160,6 +160,11 @@ func (we *workerExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
 			Enabled:      true,
 		},
 		{
+			AssetContent: ignition.KubeletMountUnit,
+			Name:         "kubelet.mount",
+			Enabled:      true,
+		},
+		{
 			AssetContent: ignition.VNICConfigurationUnit,
 			Name:         "vnic-configuration.service",
 			Enabled:      true,

--- a/service/controller/v12/cloudconfig/worker_template.go
+++ b/service/controller/v12/cloudconfig/worker_template.go
@@ -156,7 +156,7 @@ func (we *workerExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
 		},
 		{
 			AssetContent: ignition.DockerMountUnit,
-			Name:         "docker.mount",
+			Name:         "var-lib-docker.mount",
 			Enabled:      true,
 		},
 		{

--- a/service/controller/v12/cloudconfig/worker_template.go
+++ b/service/controller/v12/cloudconfig/worker_template.go
@@ -161,7 +161,7 @@ func (we *workerExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
 		},
 		{
 			AssetContent: ignition.KubeletMountUnit,
-			Name:         "kubelet.mount",
+			Name:         "var-lib-kubelet.mount",
 			Enabled:      true,
 		},
 		{

--- a/service/controller/v12/key/key.go
+++ b/service/controller/v12/key/key.go
@@ -51,8 +51,6 @@ const (
 
 	DockerDiskName  = "DockerDisk"
 	KubeletDiskName = "KubeletDisk"
-
-	VmssDeploymentName = "cluster-vmss-template"
 )
 
 const (

--- a/service/controller/v12/key/key.go
+++ b/service/controller/v12/key/key.go
@@ -48,6 +48,11 @@ const (
 	CertificateEncryptionNamespace = "default"
 	CertificateEncryptionKeyName   = "encryptionkey"
 	CertificateEncryptionIVName    = "encryptioniv"
+
+	DockerDiskName  = "DockerDisk"
+	KubeletDiskName = "KubeletDisk"
+
+	VmssDeploymentName = "cluster-vmss-template"
 )
 
 const (

--- a/service/controller/v12/key/key.go
+++ b/service/controller/v12/key/key.go
@@ -48,9 +48,6 @@ const (
 	CertificateEncryptionNamespace = "default"
 	CertificateEncryptionKeyName   = "encryptionkey"
 	CertificateEncryptionIVName    = "encryptioniv"
-
-	DockerDiskName  = "DockerDisk"
-	KubeletDiskName = "KubeletDisk"
 )
 
 const (

--- a/service/controller/v12/resource/instance/create.go
+++ b/service/controller/v12/resource/instance/create.go
@@ -177,8 +177,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 				ws, err := r.nextInstance(ctx, customObject, allMasterInstances, drainerConfigs, key.MasterInstanceName, versionValue)
 				desiredDiskSizes := map[string]int32{
-					dockerDiskName:  int32(customObject.Spec.Azure.Masters[0].DockerVolumeSizeGB),
-					kubeletDiskName: int32(customObject.Spec.Azure.Masters[0].KubeletVolumeSizeGB),
+					key.DockerDiskName:  int32(customObject.Spec.Azure.Masters[0].DockerVolumeSizeGB),
+					key.KubeletDiskName: int32(customObject.Spec.Azure.Masters[0].KubeletVolumeSizeGB),
 				}
 
 				masterInstanceToUpdate, masterInstanceToDrain, masterInstanceToReimage, err := r.nextInstance(ctx, customObject, allMasterInstances, drainerConfigs, key.MasterInstanceName, versionValue, desiredDiskSizes)

--- a/service/controller/v12/resource/instance/create.go
+++ b/service/controller/v12/resource/instance/create.go
@@ -18,6 +18,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	vmssDeploymentName = "cluster-vmss-template"
+)
+
 // EnsureCreated operates in 3 different stages which are executed sequentially.
 // The first stage is for uploading ARM templates and is represented by stage
 // DeploymentInitialized. The second stage is for waiting for ARM templates to
@@ -53,7 +57,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		} else if err != nil {
 			return microerror.Mask(err)
 		} else {
-			res, err := deploymentsClient.CreateOrUpdate(ctx, key.ClusterID(customObject), key.VmssDeploymentName, computedDeployment)
+			res, err := deploymentsClient.CreateOrUpdate(ctx, key.ClusterID(customObject), vmssDeploymentName, computedDeployment)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -79,7 +83,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if hasResourceStatus(customObject, Stage, DeploymentInitialized) {
-		d, err := deploymentsClient.Get(ctx, key.ClusterID(customObject), key.VmssDeploymentName)
+		d, err := deploymentsClient.Get(ctx, key.ClusterID(customObject), vmssDeploymentName)
 		if IsDeploymentNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "deployment not found")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for creation")
@@ -174,10 +178,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			} else {
 				r.logger.LogCtx(ctx, "level", "debug", "message", "processing master VMSSs")
 
-				//desiredDiskSizes := map[string]int32{
-				//	key.DockerDiskName:  int32(customObject.Spec.Azure.Masters[0].DockerVolumeSizeGB),
-				//	key.KubeletDiskName: int32(customObject.Spec.Azure.Masters[0].KubeletVolumeSizeGB),
-				//}
 				ws, err := r.nextInstance(ctx, customObject, allMasterInstances, drainerConfigs, key.MasterInstanceName, versionValue)
 
 				if err != nil {
@@ -225,10 +225,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			} else {
 				r.logger.LogCtx(ctx, "level", "debug", "message", "processing worker VMSSs")
 
-				//desiredDiskSizes := map[string]int32{
-				//	key.DockerDiskName:  int32(customObject.Spec.Azure.Workers[0].DockerVolumeSizeGB),
-				//	key.KubeletDiskName: int32(customObject.Spec.Azure.Workers[0].KubeletVolumeSizeGB),
-				//}
 				ws, err := r.nextInstance(ctx, customObject, allWorkerInstances, drainerConfigs, key.WorkerInstanceName, versionValue)
 				if err != nil {
 					return microerror.Mask(err)

--- a/service/controller/v12/resource/instance/create.go
+++ b/service/controller/v12/resource/instance/create.go
@@ -226,6 +226,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			} else {
 				r.logger.LogCtx(ctx, "level", "debug", "message", "processing worker VMSSs")
 
+				workerInstanceToUpdate, workerInstanceToDrain, workerInstanceToReimage, err := r.nextInstance(ctx, customObject, allWorkerInstances, drainerConfigs, key.WorkerInstanceName, versionValue)
 				desiredDiskSizes := map[string]int32{
 					key.DockerDiskName:  int32(customObject.Spec.Azure.Workers[0].DockerVolumeSizeGB),
 					key.KubeletDiskName: int32(customObject.Spec.Azure.Workers[0].KubeletVolumeSizeGB),
@@ -630,11 +631,9 @@ func firstInstanceToReimage(customObject providerv1alpha1.AzureConfig, list []co
 			return nil, microerror.Mask(err)
 		}
 		instanceVersion, ok := versionValue[instanceName]
-		// current version unavailable, skip this instance
 		if !ok {
 			continue
 		}
-		// version is changed
 		if desiredVersion == instanceVersion {
 			continue
 		}

--- a/service/controller/v12/resource/instance/create.go
+++ b/service/controller/v12/resource/instance/create.go
@@ -174,13 +174,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			} else {
 				r.logger.LogCtx(ctx, "level", "debug", "message", "processing master VMSSs")
 
+				//desiredDiskSizes := map[string]int32{
+				//	key.DockerDiskName:  int32(customObject.Spec.Azure.Masters[0].DockerVolumeSizeGB),
+				//	key.KubeletDiskName: int32(customObject.Spec.Azure.Masters[0].KubeletVolumeSizeGB),
+				//}
 				ws, err := r.nextInstance(ctx, customObject, allMasterInstances, drainerConfigs, key.MasterInstanceName, versionValue)
-				desiredDiskSizes := map[string]int32{
-					key.DockerDiskName:  int32(customObject.Spec.Azure.Masters[0].DockerVolumeSizeGB),
-					key.KubeletDiskName: int32(customObject.Spec.Azure.Masters[0].KubeletVolumeSizeGB),
-				}
 
-				masterInstanceToUpdate, masterInstanceToDrain, masterInstanceToReimage, err := r.nextInstance(ctx, customObject, allMasterInstances, drainerConfigs, key.MasterInstanceName, versionValue)
 				if err != nil {
 					return microerror.Mask(err)
 				}
@@ -226,12 +225,10 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			} else {
 				r.logger.LogCtx(ctx, "level", "debug", "message", "processing worker VMSSs")
 
-				workerInstanceToUpdate, workerInstanceToDrain, workerInstanceToReimage, err := r.nextInstance(ctx, customObject, allWorkerInstances, drainerConfigs, key.WorkerInstanceName, versionValue)
-				desiredDiskSizes := map[string]int32{
-					key.DockerDiskName:  int32(customObject.Spec.Azure.Workers[0].DockerVolumeSizeGB),
-					key.KubeletDiskName: int32(customObject.Spec.Azure.Workers[0].KubeletVolumeSizeGB),
-				}
-				workerInstanceToUpdate, workerInstanceToDrain, workerInstanceToReimage, err := r.nextInstance(ctx, customObject, allWorkerInstances, drainerConfigs, key.WorkerInstanceName, versionValue, desiredDiskSizes)
+				//desiredDiskSizes := map[string]int32{
+				//	key.DockerDiskName:  int32(customObject.Spec.Azure.Workers[0].DockerVolumeSizeGB),
+				//	key.KubeletDiskName: int32(customObject.Spec.Azure.Workers[0].KubeletVolumeSizeGB),
+				//}
 				ws, err := r.nextInstance(ctx, customObject, allWorkerInstances, drainerConfigs, key.WorkerInstanceName, versionValue)
 				if err != nil {
 					return microerror.Mask(err)

--- a/service/controller/v12/resource/instance/create.go
+++ b/service/controller/v12/resource/instance/create.go
@@ -179,7 +179,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				r.logger.LogCtx(ctx, "level", "debug", "message", "processing master VMSSs")
 
 				ws, err := r.nextInstance(ctx, customObject, allMasterInstances, drainerConfigs, key.MasterInstanceName, versionValue)
-
 				if err != nil {
 					return microerror.Mask(err)
 				}

--- a/service/controller/v12/resource/instance/create.go
+++ b/service/controller/v12/resource/instance/create.go
@@ -19,12 +19,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	vmssDeploymentName = "cluster-vmss-template"
-	dockerDiskName     = "DockerDisk"
-	kubeletDiskName    = "KubeletDisk"
-)
-
 // EnsureCreated operates in 3 different stages which are executed sequentially.
 // The first stage is for uploading ARM templates and is represented by stage
 // DeploymentInitialized. The second stage is for waiting for ARM templates to
@@ -60,7 +54,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		} else if err != nil {
 			return microerror.Mask(err)
 		} else {
-			res, err := deploymentsClient.CreateOrUpdate(ctx, key.ClusterID(customObject), vmssDeploymentName, computedDeployment)
+			res, err := deploymentsClient.CreateOrUpdate(ctx, key.ClusterID(customObject), key.VmssDeploymentName, computedDeployment)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -86,7 +80,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	if hasResourceStatus(customObject, Stage, DeploymentInitialized) {
-		d, err := deploymentsClient.Get(ctx, key.ClusterID(customObject), vmssDeploymentName)
+		d, err := deploymentsClient.Get(ctx, key.ClusterID(customObject), key.VmssDeploymentName)
 		if IsDeploymentNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "deployment not found")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for creation")
@@ -234,8 +228,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				r.logger.LogCtx(ctx, "level", "debug", "message", "processing worker VMSSs")
 
 				desiredDiskSizes := map[string]int32{
-					dockerDiskName:  int32(customObject.Spec.Azure.Workers[0].DockerVolumeSizeGB),
-					kubeletDiskName: int32(customObject.Spec.Azure.Workers[0].KubeletVolumeSizeGB),
+					key.DockerDiskName:  int32(customObject.Spec.Azure.Workers[0].DockerVolumeSizeGB),
+					key.KubeletDiskName: int32(customObject.Spec.Azure.Workers[0].KubeletVolumeSizeGB),
 				}
 				workerInstanceToUpdate, workerInstanceToDrain, workerInstanceToReimage, err := r.nextInstance(ctx, customObject, allWorkerInstances, drainerConfigs, key.WorkerInstanceName, versionValue, desiredDiskSizes)
 				ws, err := r.nextInstance(ctx, customObject, allWorkerInstances, drainerConfigs, key.WorkerInstanceName, versionValue)

--- a/service/controller/v12/resource/instance/create_test.go
+++ b/service/controller/v12/resource/instance/create_test.go
@@ -13,43 +13,6 @@ import (
 )
 
 func Test_Resource_Instance_findActionableInstance(t *testing.T) {
-	oneGBDataDisks := []compute.DataDisk{
-		{
-			Name:       to.StringPtr(key.DockerDiskName),
-			DiskSizeGB: to.Int32Ptr(1),
-		},
-		{
-			Name:       to.StringPtr(key.KubeletDiskName),
-			DiskSizeGB: to.Int32Ptr(1),
-		},
-	}
-
-	twoGBDataDisks := []compute.DataDisk{
-		{
-			Name:       to.StringPtr(key.DockerDiskName),
-			DiskSizeGB: to.Int32Ptr(2),
-		},
-		{
-			Name:       to.StringPtr(key.KubeletDiskName),
-			DiskSizeGB: to.Int32Ptr(2),
-		},
-	}
-
-	desiredDiskSizeOneGb := map[string]int32{
-		key.DockerDiskName:  int32(1),
-		key.KubeletDiskName: int32(1),
-	}
-
-	desiredDiskSizesDockerTwoGb := map[string]int32{
-		key.DockerDiskName:  int32(2),
-		key.KubeletDiskName: int32(1),
-	}
-
-	desiredDiskSizesKubeletTwoGb := map[string]int32{
-		key.DockerDiskName:  int32(1),
-		key.KubeletDiskName: int32(2),
-	}
-
 	testCases := []struct {
 		Name                      string
 		CustomObject              providerv1alpha1.AzureConfig
@@ -60,7 +23,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 		ExpectedInstanceToUpdate  *compute.VirtualMachineScaleSetVM
 		ExpectedInstanceToDrain   *compute.VirtualMachineScaleSetVM
 		ExpectedInstanceToReimage *compute.VirtualMachineScaleSetVM
-		DesiredDiskSizes          map[string]int32
 		ErrorMatcher              func(err error) bool
 	}{
 		{
@@ -73,7 +35,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 			ExpectedInstanceToUpdate:  nil,
 			ExpectedInstanceToDrain:   nil,
 			ExpectedInstanceToReimage: nil,
-			DesiredDiskSizes:          desiredDiskSizeOneGb,
 			ErrorMatcher:              IsVersionBlobEmpty,
 		},
 		{
@@ -94,9 +55,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 			},
@@ -110,7 +68,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 			ExpectedInstanceToUpdate:  nil,
 			ExpectedInstanceToDrain:   nil,
 			ExpectedInstanceToReimage: nil,
-			DesiredDiskSizes:          desiredDiskSizeOneGb,
 			ErrorMatcher:              nil,
 		},
 		{
@@ -131,9 +88,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 				{
@@ -141,9 +95,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 			},
@@ -158,7 +109,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 			ExpectedInstanceToUpdate:  nil,
 			ExpectedInstanceToDrain:   nil,
 			ExpectedInstanceToReimage: nil,
-			DesiredDiskSizes:          desiredDiskSizeOneGb,
 			ErrorMatcher:              nil,
 		},
 		{
@@ -179,9 +129,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(false),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 			},
@@ -197,14 +144,10 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 					LatestModelApplied: to.BoolPtr(false),
 					ProvisioningState:  to.StringPtr("Succeeded"),
-					StorageProfile: &compute.StorageProfile{
-						DataDisks: &oneGBDataDisks,
-					},
 				},
 			},
 			ExpectedInstanceToDrain:   nil,
 			ExpectedInstanceToReimage: nil,
-			DesiredDiskSizes:          desiredDiskSizeOneGb,
 			ErrorMatcher:              nil,
 		},
 		{
@@ -225,9 +168,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(false),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 				{
@@ -235,9 +175,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(false),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 			},
@@ -254,14 +191,10 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 					LatestModelApplied: to.BoolPtr(false),
 					ProvisioningState:  to.StringPtr("Succeeded"),
-					StorageProfile: &compute.StorageProfile{
-						DataDisks: &oneGBDataDisks,
-					},
 				},
 			},
 			ExpectedInstanceToDrain:   nil,
 			ExpectedInstanceToReimage: nil,
-			DesiredDiskSizes:          desiredDiskSizeOneGb,
 			ErrorMatcher:              nil,
 		},
 		{
@@ -282,9 +215,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 				{
@@ -292,9 +222,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(false),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 			},
@@ -311,14 +238,10 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 					LatestModelApplied: to.BoolPtr(false),
 					ProvisioningState:  to.StringPtr("Succeeded"),
-					StorageProfile: &compute.StorageProfile{
-						DataDisks: &oneGBDataDisks,
-					},
 				},
 			},
 			ExpectedInstanceToDrain:   nil,
 			ExpectedInstanceToReimage: nil,
-			DesiredDiskSizes:          desiredDiskSizeOneGb,
 			ErrorMatcher:              nil,
 		},
 		{
@@ -339,9 +262,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 				{
@@ -349,9 +269,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 			},
@@ -370,13 +287,9 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 					LatestModelApplied: to.BoolPtr(true),
 					ProvisioningState:  to.StringPtr("Succeeded"),
-					StorageProfile: &compute.StorageProfile{
-						DataDisks: &oneGBDataDisks,
-					},
 				},
 			},
-			DesiredDiskSizes: desiredDiskSizeOneGb,
-			ErrorMatcher:     nil,
+			ErrorMatcher: nil,
 		},
 		{
 			Name: "case 7: one instance having the latest version bundle version applied and one instance not having the latest version bundle version applied results in reimaging the second instance",
@@ -396,9 +309,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 				{
@@ -406,9 +316,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 			},
@@ -427,13 +334,9 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 					LatestModelApplied: to.BoolPtr(true),
 					ProvisioningState:  to.StringPtr("Succeeded"),
-					StorageProfile: &compute.StorageProfile{
-						DataDisks: &oneGBDataDisks,
-					},
 				},
 			},
-			DesiredDiskSizes: desiredDiskSizeOneGb,
-			ErrorMatcher:     nil,
+			ErrorMatcher: nil,
 		},
 		{
 			Name: "case 8: two instances not having the latest version bundle version applied and being in provisioning state 'InProgress' results in no action",
@@ -453,9 +356,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("InProgress"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 				{
@@ -463,9 +363,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("InProgress"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 			},
@@ -480,7 +377,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 			ExpectedInstanceToUpdate:  nil,
 			ExpectedInstanceToDrain:   nil,
 			ExpectedInstanceToReimage: nil,
-			DesiredDiskSizes:          desiredDiskSizeOneGb,
 			ErrorMatcher:              nil,
 		},
 		{
@@ -501,9 +397,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("InProgress"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 				{
@@ -511,9 +404,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("InProgress"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 			},
@@ -528,7 +418,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 			ExpectedInstanceToUpdate:  nil,
 			ExpectedInstanceToDrain:   nil,
 			ExpectedInstanceToReimage: nil,
-			DesiredDiskSizes:          desiredDiskSizeOneGb,
 			ErrorMatcher:              nil,
 		},
 		{
@@ -549,9 +438,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 				{
@@ -559,9 +445,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 			},
@@ -579,13 +462,9 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 					LatestModelApplied: to.BoolPtr(true),
 					ProvisioningState:  to.StringPtr("Succeeded"),
-					StorageProfile: &compute.StorageProfile{
-						DataDisks: &oneGBDataDisks,
-					},
 				},
 			},
 			ExpectedInstanceToReimage: nil,
-			DesiredDiskSizes:          desiredDiskSizeOneGb,
 			ErrorMatcher:              nil,
 		},
 		{
@@ -606,9 +485,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 				{
@@ -616,9 +492,6 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 						LatestModelApplied: to.BoolPtr(true),
 						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
 					},
 				},
 			},
@@ -636,142 +509,9 @@ func Test_Resource_Instance_findActionableInstance(t *testing.T) {
 				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 					LatestModelApplied: to.BoolPtr(true),
 					ProvisioningState:  to.StringPtr("Succeeded"),
-					StorageProfile: &compute.StorageProfile{
-						DataDisks: &oneGBDataDisks,
-					},
 				},
 			},
 			ExpectedInstanceToReimage: nil,
-			DesiredDiskSizes:          desiredDiskSizeOneGb,
-			ErrorMatcher:              nil,
-		},
-		{
-			Name: "case 12: one instance being up to date, docker disk size changed",
-			CustomObject: providerv1alpha1.AzureConfig{
-				Spec: providerv1alpha1.AzureConfigSpec{
-					Cluster: providerv1alpha1.Cluster{
-						ID: "al9qy",
-					},
-					VersionBundle: providerv1alpha1.AzureConfigSpecVersionBundle{
-						Version: "0.1.0",
-					},
-				},
-			},
-			Instances: []compute.VirtualMachineScaleSetVM{
-				{
-					InstanceID: to.StringPtr("1"),
-					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-						LatestModelApplied: to.BoolPtr(true),
-						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
-					},
-				},
-			},
-			DrainerConfigs: []corev1alpha1.DrainerConfig{
-				newFinalDrainerConfigForID("al9qy-worker-000001"),
-			},
-			InstanceNameFunc: key.WorkerInstanceName,
-			VersionValue: map[string]string{
-				"al9qy-worker-000001": "0.1.0",
-			},
-			ExpectedInstanceToUpdate: nil,
-			ExpectedInstanceToDrain:  nil,
-			ExpectedInstanceToReimage: &compute.VirtualMachineScaleSetVM{
-				InstanceID: to.StringPtr("1"),
-				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					LatestModelApplied: to.BoolPtr(true),
-					ProvisioningState:  to.StringPtr("Succeeded"),
-					StorageProfile: &compute.StorageProfile{
-						DataDisks: &oneGBDataDisks,
-					},
-				},
-			},
-			DesiredDiskSizes: desiredDiskSizesDockerTwoGb,
-			ErrorMatcher:     nil,
-		},
-		{
-			Name: "case 13: one instance being up to date, kubelet disk size changed",
-			CustomObject: providerv1alpha1.AzureConfig{
-				Spec: providerv1alpha1.AzureConfigSpec{
-					Cluster: providerv1alpha1.Cluster{
-						ID: "al9qy",
-					},
-					VersionBundle: providerv1alpha1.AzureConfigSpecVersionBundle{
-						Version: "0.1.0",
-					},
-				},
-			},
-			Instances: []compute.VirtualMachineScaleSetVM{
-				{
-					InstanceID: to.StringPtr("1"),
-					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-						LatestModelApplied: to.BoolPtr(true),
-						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &oneGBDataDisks,
-						},
-					},
-				},
-			},
-			DrainerConfigs: []corev1alpha1.DrainerConfig{
-				newFinalDrainerConfigForID("al9qy-worker-000001"),
-			},
-			InstanceNameFunc: key.WorkerInstanceName,
-			VersionValue: map[string]string{
-				"al9qy-worker-000001": "0.1.0",
-			},
-			ExpectedInstanceToUpdate: nil,
-			ExpectedInstanceToDrain:  nil,
-			ExpectedInstanceToReimage: &compute.VirtualMachineScaleSetVM{
-				InstanceID: to.StringPtr("1"),
-				VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-					LatestModelApplied: to.BoolPtr(true),
-					ProvisioningState:  to.StringPtr("Succeeded"),
-					StorageProfile: &compute.StorageProfile{
-						DataDisks: &oneGBDataDisks,
-					},
-				},
-			},
-			DesiredDiskSizes: desiredDiskSizesKubeletTwoGb,
-			ErrorMatcher:     nil,
-		},
-		{
-			Name: "case 14: kubelet disk size decreased, no instance should be updated",
-			CustomObject: providerv1alpha1.AzureConfig{
-				Spec: providerv1alpha1.AzureConfigSpec{
-					Cluster: providerv1alpha1.Cluster{
-						ID: "al9qy",
-					},
-					VersionBundle: providerv1alpha1.AzureConfigSpecVersionBundle{
-						Version: "0.1.0",
-					},
-				},
-			},
-			Instances: []compute.VirtualMachineScaleSetVM{
-				{
-					InstanceID: to.StringPtr("1"),
-					VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
-						LatestModelApplied: to.BoolPtr(true),
-						ProvisioningState:  to.StringPtr("Succeeded"),
-						StorageProfile: &compute.StorageProfile{
-							DataDisks: &twoGBDataDisks,
-						},
-					},
-				},
-			},
-			DrainerConfigs: []corev1alpha1.DrainerConfig{
-				newFinalDrainerConfigForID("al9qy-worker-000001"),
-			},
-			InstanceNameFunc: key.WorkerInstanceName,
-			VersionValue: map[string]string{
-				"al9qy-worker-000001": "0.1.0",
-			},
-			ExpectedInstanceToUpdate:  nil,
-			ExpectedInstanceToDrain:   nil,
-			ExpectedInstanceToReimage: nil,
-			DesiredDiskSizes:          desiredDiskSizesKubeletTwoGb,
 			ErrorMatcher:              nil,
 		},
 	}

--- a/service/controller/v12/resource/instance/create_test.go
+++ b/service/controller/v12/resource/instance/create_test.go
@@ -13,32 +13,30 @@ import (
 )
 
 func Test_Resource_Instance_findActionableInstance(t *testing.T) {
-	const dockerDiskName = "DockerDisk"
-	const kubeletDiskName = "KubeletDisk"
 	oneGBDataDisks := []compute.DataDisk{
-		compute.DataDisk{
-			Name:       to.StringPtr(dockerDiskName),
+		{
+			Name:       to.StringPtr(key.DockerDiskName),
 			DiskSizeGB: to.Int32Ptr(1),
 		},
-		compute.DataDisk{
-			Name:       to.StringPtr(kubeletDiskName),
+		{
+			Name:       to.StringPtr(key.KubeletDiskName),
 			DiskSizeGB: to.Int32Ptr(1),
 		},
 	}
 
 	desiredDiskSizeOneGb := map[string]int32{
-		dockerDiskName:  int32(1),
-		kubeletDiskName: int32(1),
+		key.DockerDiskName:  int32(1),
+		key.KubeletDiskName: int32(1),
 	}
 
 	desiredDiskSizesDockerTwoGb := map[string]int32{
-		dockerDiskName:  int32(2),
-		kubeletDiskName: int32(1),
+		key.DockerDiskName:  int32(2),
+		key.KubeletDiskName: int32(1),
 	}
 
 	desiredDiskSizesKubeletTwoGb := map[string]int32{
-		dockerDiskName:  int32(1),
-		kubeletDiskName: int32(2),
+		key.DockerDiskName:  int32(1),
+		key.KubeletDiskName: int32(2),
 	}
 
 	testCases := []struct {

--- a/service/controller/v12/resource/instance/deployment.go
+++ b/service/controller/v12/resource/instance/deployment.go
@@ -45,11 +45,12 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 	var masterNodes []node
 	for _, m := range obj.Spec.Azure.Masters {
 		n := node{
-			AdminUsername:      key.AdminUsername(obj),
-			AdminSSHKeyData:    key.AdminSSHKeyData(obj),
-			OSImage:            newNodeOSImageCoreOS(),
-			VMSize:             m.VMSize,
-			DockerVolumeSizeGB: m.DockerVolumeSizeGB,
+			AdminUsername:       key.AdminUsername(obj),
+			AdminSSHKeyData:     key.AdminSSHKeyData(obj),
+			OSImage:             newNodeOSImageCoreOS(),
+			VMSize:              m.VMSize,
+			DockerVolumeSizeGB:  m.DockerVolumeSizeGB,
+			KubeletVolumeSizeGB: m.KubeletVolumeSizeGB,
 		}
 		masterNodes = append(masterNodes, n)
 	}
@@ -57,11 +58,12 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 	var workerNodes []node
 	for _, w := range obj.Spec.Azure.Workers {
 		n := node{
-			AdminUsername:      key.AdminUsername(obj),
-			AdminSSHKeyData:    key.AdminSSHKeyData(obj),
-			OSImage:            newNodeOSImageCoreOS(),
-			VMSize:             w.VMSize,
-			DockerVolumeSizeGB: w.DockerVolumeSizeGB,
+			AdminUsername:       key.AdminUsername(obj),
+			AdminSSHKeyData:     key.AdminSSHKeyData(obj),
+			OSImage:             newNodeOSImageCoreOS(),
+			VMSize:              w.VMSize,
+			DockerVolumeSizeGB:  w.DockerVolumeSizeGB,
+			KubeletVolumeSizeGB: w.KubeletVolumeSizeGB,
 		}
 		workerNodes = append(workerNodes, n)
 	}

--- a/service/controller/v12/resource/instance/template/main.json
+++ b/service/controller/v12/resource/instance/template/main.json
@@ -107,6 +107,10 @@
               {
                 "name":"DockerDisk",
                 "sizeGB":"[if(greater(parameters('masterNodes')[0].dockerVolumeSizeGB, 0), parameters('masterNodes')[0].dockerVolumeSizeGB, 50)]"
+              },
+              {
+                "name":"KubeletDisk",
+                "sizeGB":100
               }
             ]
           },
@@ -187,6 +191,10 @@
               {
                 "name":"DockerDisk",
                 "sizeGB":"[if(greater(parameters('workerNodes')[0].dockerVolumeSizeGB, 0), parameters('workerNodes')[0].dockerVolumeSizeGB, 50)]"
+              },
+              {
+                "name":"KubeletDisk",
+                "sizeGB":100
               }
             ]
           },

--- a/service/controller/v12/resource/instance/template/main.json
+++ b/service/controller/v12/resource/instance/template/main.json
@@ -110,7 +110,7 @@
               },
               {
                 "name":"KubeletDisk",
-                "sizeGB":100
+                "sizeGB":"[if(greater(parameters('masterNodes')[0].kubeletVolumeSizeGB, 0), parameters('masterNodes')[0],.kubeletVolumeSizeGB, 100)]"
               }
             ]
           },
@@ -194,7 +194,7 @@
               },
               {
                 "name":"KubeletDisk",
-                "sizeGB":100
+                "sizeGB":"[if(greater(parameters('workerNodes')[0].kubeletVolumeSizeGB, 0), parameters('workerNodes')[0],.kubeletVolumeSizeGB, 100)]"
               }
             ]
           },

--- a/service/controller/v12/resource/instance/template/main.json
+++ b/service/controller/v12/resource/instance/template/main.json
@@ -110,7 +110,7 @@
               },
               {
                 "name":"KubeletDisk",
-                "sizeGB":"[if(greater(parameters('masterNodes')[0].kubeletVolumeSizeGB, 0), parameters('masterNodes')[0],.kubeletVolumeSizeGB, 100)]"
+                "sizeGB":"[if(greater(parameters('masterNodes')[0].kubeletVolumeSizeGB, 0), parameters('masterNodes')[0].kubeletVolumeSizeGB, 100)]"
               }
             ]
           },
@@ -194,7 +194,7 @@
               },
               {
                 "name":"KubeletDisk",
-                "sizeGB":"[if(greater(parameters('workerNodes')[0].kubeletVolumeSizeGB, 0), parameters('workerNodes')[0],.kubeletVolumeSizeGB, 100)]"
+                "sizeGB":"[if(greater(parameters('workerNodes')[0].kubeletVolumeSizeGB, 0), parameters('workerNodes')[0].kubeletVolumeSizeGB, 100)]"
               }
             ]
           },

--- a/service/controller/v12/resource/instance/types.go
+++ b/service/controller/v12/resource/instance/types.go
@@ -13,6 +13,8 @@ type node struct {
 	VMSize string `json:"vmSize" yaml:"vmSize"`
 	// Size of the Disk mounted in /var/lib/docker
 	DockerVolumeSizeGB int `json:"dockerVolumeSizeGB" yaml:"dockerVolumeSizeGB"`
+	// Size of the Disk mounted in /var/lib/kubelet
+	KubeletVolumeSizeGB int `json:"kubeletVolumeSizeGB" yaml:"kubeletVolumeSizeGB"`
 }
 
 // nodeOSImage provides OS information for Microsoft.Compute/virtualMachines

--- a/service/controller/v12/templates/ignition/kubelet_mount_unit.go
+++ b/service/controller/v12/templates/ignition/kubelet_mount_unit.go
@@ -1,0 +1,14 @@
+package ignition
+
+const KubeletMountUnit = `[Unit]
+Description=Mounts disk to /var/lib/kubelet
+Before=k8s-kubelet.service
+
+[Mount]
+What=/dev/disk/by-label/kubelet
+Where=/var/lib/kubelet
+Type=xfs
+
+[Install]
+WantedBy=multi-user.target
+`

--- a/service/controller/v12/templates/ignition/small.go
+++ b/service/controller/v12/templates/ignition/small.go
@@ -39,6 +39,15 @@ const Small = `{
           "label": "docker",
           "format": "xfs"
         }
+      },
+      { 
+        "name": "kubelet",
+        "mount": {
+          "device": "/dev/disk/azure/scsi1/{{ if eq .InstanceRole "master"}}lun2{{ else }}lun1{{end}}",
+          "wipeFilesystem": true,
+          "label": "kubelet",
+          "format": "xfs"
+        }
       }{{ if eq .InstanceRole "master" -}},
       {
         "name": "etcd",

--- a/vendor/github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1/azure_types.go
+++ b/vendor/github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1/azure_types.go
@@ -112,8 +112,10 @@ type AzureConfigSpecAzureVirtualNetwork struct {
 type AzureConfigSpecAzureNode struct {
 	// VMSize is the master vm size (e.g. Standard_A1)
 	VMSize string `json:"vmSize" yaml:"vmSize"`
-	// Size of a volume mounted to /var/lib/docker.
+	// DockerVolumeSizeGB is the size of a volume mounted to /var/lib/docker.
 	DockerVolumeSizeGB int `json:"dockerVolumeSizeGB" yaml:"dockerVolumeSizeGB"`
+	// KubeletVolumeSizeGB is the size of a volume mounted to /var/lib/kubelet.
+	KubeletVolumeSizeGB int `json:"kubeletVolumeSizeGB" yaml:"kubeletVolumeSizeGB"`
 }
 
 type AzureConfigSpecVersionBundle struct {


### PR DESCRIPTION
The goal of this PR is to add to the master and workers template a new volume mounted on /var/lib/kubelet.
The volume size will be adjustable by modifying the CR AzureConfig.
This PR also includes a fix on the previously existing Docker volume which wasn't mounted correctly on worker nodes.
The related issue is https://github.com/giantswarm/giantswarm/issues/7526