### PR TITLE
Add the diskSizeGB option to the workers VMSS to allow adjusting root…

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -263,7 +263,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fcb75264e7f1a4276044b71f706baf6b1eba4e619f3a3bc95f33c677cbe25f6c"
+  digest = "1:a374f09a72142fb281d11d2a5c597cdcba086af3d7f6f68a641014afb245691b"
   name = "github.com/giantswarm/apiextensions"
   packages = [
     "pkg/apis/application/v1alpha1",
@@ -280,7 +280,7 @@
     "pkg/clientset/versioned/typed/release/v1alpha1",
   ]
   pruneopts = "UT"
-  revision = "efa5c38da056932db3d24b786daf200b856dc9a2"
+  revision = "0aaa0207de6050f957629b20f62b5d21d6051ffe"
 
 [[projects]]
   branch = "master"

--- a/service/controller/v12/resource/instance/deployment.go
+++ b/service/controller/v12/resource/instance/deployment.go
@@ -50,6 +50,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 			OSImage:            newNodeOSImageCoreOS(),
 			VMSize:             m.VMSize,
 			DockerVolumeSizeGB: m.DockerVolumeSizeGB,
+			RootVolumeSizeGB:   m.RootVolumeSizeGB,
 		}
 		masterNodes = append(masterNodes, n)
 	}
@@ -62,6 +63,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 			OSImage:            newNodeOSImageCoreOS(),
 			VMSize:             w.VMSize,
 			DockerVolumeSizeGB: w.DockerVolumeSizeGB,
+			RootVolumeSizeGB:   w.RootVolumeSizeGB,
 		}
 		workerNodes = append(workerNodes, n)
 	}

--- a/service/controller/v12/resource/instance/template/main.json
+++ b/service/controller/v12/resource/instance/template/main.json
@@ -233,6 +233,9 @@
           },
           "vmssUpgradePolicy":{
             "value":"Manual"
+          },
+          "vmssRootDiskSizeGB":{
+            "value":"[parameters('vmssRootDiskSizeGB')]"
           }
         }
       }

--- a/service/controller/v12/resource/instance/template/main.json
+++ b/service/controller/v12/resource/instance/template/main.json
@@ -62,10 +62,6 @@
       "metadata":{
         "description":"Output value of the worker subnet ID as referenced from the virtual network setup."
       }
-    },
-    "vmssRootDiskSizeGB":{
-      "type":"int",
-      "defaultValue":40
     }
   },
   "variables":{
@@ -155,7 +151,7 @@
             "value":"Manual"
           },
           "vmssRootDiskSizeGB":{
-            "value":"[parameters('vmssRootDiskSizeGB')]"
+            "value":"[if(greater(parameters('masterNodes')[0].rootVolumeSizeGB, 30), parameters('masterNodes')[0].rootVolumeSizeGB, 30)]"
           }
         }
       }
@@ -235,7 +231,7 @@
             "value":"Manual"
           },
           "vmssRootDiskSizeGB":{
-            "value":"[parameters('vmssRootDiskSizeGB')]"
+            "value":"[if(greater(parameters('workerNodes')[0].rootVolumeSizeGB, 30), parameters('workerNodes')[0].rootVolumeSizeGB, 30)]"
           }
         }
       }

--- a/service/controller/v12/resource/instance/template/main.json
+++ b/service/controller/v12/resource/instance/template/main.json
@@ -62,6 +62,10 @@
       "metadata":{
         "description":"Output value of the worker subnet ID as referenced from the virtual network setup."
       }
+    },
+    "vmssRootDiskSizeGB":{
+      "type":"int",
+      "defaultValue":40
     }
   },
   "variables":{
@@ -149,6 +153,9 @@
           },
           "vmssUpgradePolicy":{
             "value":"Manual"
+          },
+          "vmssRootDiskSizeGB":{
+            "value":"[parameters('vmssRootDiskSizeGB')]"
           }
         }
       }

--- a/service/controller/v12/resource/instance/template/vmss.json
+++ b/service/controller/v12/resource/instance/template/vmss.json
@@ -62,6 +62,12 @@
     "vmssUpgradePolicy":{
       "type":"string",
       "defaultValue":"Manual"
+    },
+    "vmssRootDiskSizeGB":{
+      "type":"int",
+      "defaultValue":40,
+      "minValue":30,
+      "maxValue":1023
     }
   },
   "variables":{
@@ -224,6 +230,7 @@
             "osDisk":{
               "caching":"ReadWrite",
               "createOption":"FromImage",
+              "diskSizeGB": "[parameters('vmssRootDiskSizeGB')]",
               "managedDisk":{
                 "storageAccountType":"[variables('vmssStorageAccountType')]"
               }

--- a/service/controller/v12/resource/instance/types.go
+++ b/service/controller/v12/resource/instance/types.go
@@ -13,6 +13,8 @@ type node struct {
 	VMSize string `json:"vmSize" yaml:"vmSize"`
 	// Size of the Disk mounted in /var/lib/docker
 	DockerVolumeSizeGB int `json:"dockerVolumeSizeGB" yaml:"dockerVolumeSizeGB"`
+	// Size of the Disk mounted in /
+	RootVolumeSizeGB int `json:"rootVolumeSizeGB" yaml:"rootVolumeSizeGB"`
 }
 
 // nodeOSImage provides OS information for Microsoft.Compute/virtualMachines

--- a/vendor/github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1/azure_types.go
+++ b/vendor/github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1/azure_types.go
@@ -112,8 +112,10 @@ type AzureConfigSpecAzureVirtualNetwork struct {
 type AzureConfigSpecAzureNode struct {
 	// VMSize is the master vm size (e.g. Standard_A1)
 	VMSize string `json:"vmSize" yaml:"vmSize"`
-	// Size of a volume mounted to /var/lib/docker.
+	// DockerVolumeSizeGB is the size of a volume mounted to /var/lib/docker.
 	DockerVolumeSizeGB int `json:"dockerVolumeSizeGB" yaml:"dockerVolumeSizeGB"`
+	// RootVolumeSizeGB is the size of a volume mounted to /.
+	RootVolumeSizeGB int `json:"rootVolumeSizeGB" yaml:"rootVolumeSizeGB"`
 }
 
 type AzureConfigSpecVersionBundle struct {


### PR DESCRIPTION
… disk size

This will allow customizing the root volume size by editing the CR for the tenant cluster.
This is not reactive yet, but it can be edited before the VMSS are spawn.
Plan is to make it automatically reconciled on change (but will ask for help).
Tested on godsmack, looks good.