### PR TITLE
Using CR field to decide docker volume size

### DIFF
--- a/service/controller/v12/resource/instance/deployment.go
+++ b/service/controller/v12/resource/instance/deployment.go
@@ -45,10 +45,11 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 	var masterNodes []node
 	for _, m := range obj.Spec.Azure.Masters {
 		n := node{
-			AdminUsername:   key.AdminUsername(obj),
-			AdminSSHKeyData: key.AdminSSHKeyData(obj),
-			OSImage:         newNodeOSImageCoreOS(),
-			VMSize:          m.VMSize,
+			AdminUsername:      key.AdminUsername(obj),
+			AdminSSHKeyData:    key.AdminSSHKeyData(obj),
+			OSImage:            newNodeOSImageCoreOS(),
+			VMSize:             m.VMSize,
+			DockerVolumeSizeGB: m.DockerVolumeSizeGB,
 		}
 		masterNodes = append(masterNodes, n)
 	}
@@ -56,10 +57,11 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 	var workerNodes []node
 	for _, w := range obj.Spec.Azure.Workers {
 		n := node{
-			AdminUsername:   key.AdminUsername(obj),
-			AdminSSHKeyData: key.AdminSSHKeyData(obj),
-			OSImage:         newNodeOSImageCoreOS(),
-			VMSize:          w.VMSize,
+			AdminUsername:      key.AdminUsername(obj),
+			AdminSSHKeyData:    key.AdminSSHKeyData(obj),
+			OSImage:            newNodeOSImageCoreOS(),
+			VMSize:             w.VMSize,
+			DockerVolumeSizeGB: w.DockerVolumeSizeGB,
 		}
 		workerNodes = append(workerNodes, n)
 	}

--- a/service/controller/v12/resource/instance/template/main.json
+++ b/service/controller/v12/resource/instance/template/main.json
@@ -106,7 +106,7 @@
               },
               {
                 "name":"DockerDisk",
-                "sizeGB":"[parameters('masterNodes')[0].dockerVolumeSizeGB]"
+                "sizeGB":"[if(greater(parameters('masterNodes')[0].dockerVolumeSizeGB, 0), parameters('masterNodes')[0].dockerVolumeSizeGB, 50)]"
               }
             ]
           },
@@ -186,7 +186,7 @@
             "value":[
               {
                 "name":"DockerDisk",
-                "sizeGB":"[parameters('workerNodes')[0].dockerVolumeSizeGB]"
+                "sizeGB":"[if(greater(parameters('workerNodes')[0].dockerVolumeSizeGB, 0), parameters('workerNodes')[0].dockerVolumeSizeGB, 50)]"
               }
             ]
           },

--- a/service/controller/v12/resource/instance/template/main.json
+++ b/service/controller/v12/resource/instance/template/main.json
@@ -106,7 +106,7 @@
               },
               {
                 "name":"DockerDisk",
-                "sizeGB":50
+                "sizeGB":"[parameters('masterNodes')[0].dockerVolumeSizeGB]"
               }
             ]
           },
@@ -186,7 +186,7 @@
             "value":[
               {
                 "name":"DockerDisk",
-                "sizeGB":50
+                "sizeGB":"[parameters('workerNodes')[0].dockerVolumeSizeGB]"
               }
             ]
           },

--- a/service/controller/v12/resource/instance/types.go
+++ b/service/controller/v12/resource/instance/types.go
@@ -11,6 +11,8 @@ type node struct {
 	OSImage nodeOSImage `json:"osImage" yaml:"osImage"`
 	// VMSize is the master vm size (e.g. Standard_A1)
 	VMSize string `json:"vmSize" yaml:"vmSize"`
+	// Size of the Disk mounted in /var/lib/docker
+	DockerVolumeSizeGB int `json:"dockerVolumeSizeGB" yaml:"dockerVolumeSizeGB"`
 }
 
 // nodeOSImage provides OS information for Microsoft.Compute/virtualMachines


### PR DESCRIPTION
There is a `DockerVolumeSizeGB` field in the `AzureConfig` CRD that allows customizing the Azure disk mounted on `/var/lib/docker` for both masters and workers.
We are not using that field yet in the VMSS template, and we hardcoded 50Gb size for the docker disk.
This PR aims at using the CRD field for sizing the docker disk.
I tested it by setting the Disk size manually on the CR and it worked just fine.