### PR TITLE
Tag for autoscaling

### DIFF
--- a/service/controller/v12/resource/instance/template/vmss.json
+++ b/service/controller/v12/resource/instance/template/vmss.json
@@ -181,7 +181,10 @@
       "name":"[parameters('vmssName')]",
       "location":"[parameters('location')]",
       "tags":{
-        "provider":"[toUpper(parameters('GiantSwarmTags').provider)]"
+        "provider":"[toUpper(parameters('GiantSwarmTags').provider)]",
+        "k8s.io/cluster-autoscaler/enabled":"true",
+        "[concat('k8s.io/cluster-autoscaler/', parameters('vmssName'))]": "true"
+
       },
       "sku":{
         "name":"[parameters('vmssVmSize')]",

--- a/service/controller/v12/resource/instance/template/vmss.json
+++ b/service/controller/v12/resource/instance/template/vmss.json
@@ -1,9 +1,9 @@
 {
-  "$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion":"1.0.0.0",
   "parameters":{
     "location":{
-      "type":"String"
+      "type":"string"
     },
     "GiantSwarmTags":{
       "type":"object",
@@ -29,7 +29,7 @@
       "type":"array"
     },
     "vmssSshUser":{
-      "type":"String"
+      "type":"string"
     },
     "vmssSshPublicKey":{
       "type":"string"
@@ -51,7 +51,7 @@
       "defaultValue":"true"
     },
     "vmssVmCustomData":{
-      "type":"secureString"
+      "type":"securestring"
     },
     "vmssLbBackendPools":{
       "type":"array"

--- a/service/controller/v12/resource/instance/template/vmss.json
+++ b/service/controller/v12/resource/instance/template/vmss.json
@@ -182,9 +182,8 @@
       "location":"[parameters('location')]",
       "tags":{
         "provider":"[toUpper(parameters('GiantSwarmTags').provider)]",
-        "k8s.io/cluster-autoscaler/enabled":"true",
-        "[concat('k8s.io/cluster-autoscaler/', parameters('vmssName'))]": "true"
-
+        "cluster-autoscaler-enabled":"true",
+        "cluster-autoscaler-name":"[parameters('vmssName')]"
       },
       "sku":{
         "name":"[parameters('vmssVmSize')]",


### PR DESCRIPTION
The `cluster-autoscaler` auto-discovery feature needs that we tag our VMSS. These labels will be later passed as parameters to `cluster-autoscaler`, so that the autoscaler knows which VMSS to scale.

Any tag can be used, but for consistency sake, I've chosen the same tags that we are using on AWS for `cluster-autoscaler`. 