### PR TITLE
Use apps/v1 for deployment

### DIFF
--- a/helm/azure-operator-chart/templates/deployment.yaml
+++ b/helm/azure-operator-chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: azure-operator
@@ -10,6 +10,9 @@ metadata:
 spec:
   replicas: 1
   revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: azure-operator
   strategy:
     type: RollingUpdate
   template:
@@ -41,7 +44,7 @@ spec:
         runAsGroup: {{ .Values.groupID }}
       containers:
       - name: azure-operator
-        image: quay.io/giantswarm/azure-operator:[[ .SHA ]]
+        image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         volumeMounts:
         - name: azure-operator-configmap
           mountPath: /var/run/azure-operator/configmap/

--- a/helm/azure-operator-chart/values.yaml
+++ b/helm/azure-operator-chart/values.yaml
@@ -1,4 +1,9 @@
 namespace: giantswarm
 
+image:
+  registry: "quay.io"
+  name: "giantswarm/azure-operator"
+  tag: "[[ .SHA ]]"
+
 userID: 1000
 groupID: 1000


### PR DESCRIPTION
Updating the `Deployment` object to a more recent `apiVersion`, since it could lead to problems, like those fixed here https://github.com/giantswarm/aws-operator/pull/2077.