### PR TITLE
Release 8.6.0 with Kubernetes 1.14.10

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -419,7 +419,11 @@
     "v_5_0_0",
   ]
   pruneopts = "T"
+<<<<<<< HEAD
   revision = "d11385a99ef46892c42aad12dd1d2a6893702a39"
+=======
+  revision = "6b2f007d6b1edb70f70acbe6e6270b1b39d69e37"
+>>>>>>> f7e6b024... vendor k8scc
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -404,7 +404,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5f3f9f2fcdad72fa8349cf10a3ad6b64fdea867bb7ac72fb8b0f9c9ae24754ef"
+  digest = "1:6a676db3c44436908060d5931b2ab8cebadcbc0b1ba0867dfc87e70693a62e40"
   name = "github.com/giantswarm/k8scloudconfig"
   packages = [
     "ignition/v_2_2_0",
@@ -419,7 +419,7 @@
     "v_5_0_0",
   ]
   pruneopts = "T"
-  revision = "d11385a99ef46892c42aad12dd1d2a6893702a39"
+  revision = "9f452e481c2ba255c8352ceccc58ac25b4f0f7d7"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -419,15 +419,7 @@
     "v_5_0_0",
   ]
   pruneopts = "T"
-<<<<<<< HEAD
-<<<<<<< HEAD
   revision = "d11385a99ef46892c42aad12dd1d2a6893702a39"
-=======
-  revision = "6b2f007d6b1edb70f70acbe6e6270b1b39d69e37"
->>>>>>> f7e6b024... vendor k8scc
-=======
-  revision = "0d94f8c311ace01f0f9ac4a050b12ba67ec3d1c8"
->>>>>>> 1ab69bb9... bumped k8scloudconfig
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -420,10 +420,14 @@
   ]
   pruneopts = "T"
 <<<<<<< HEAD
+<<<<<<< HEAD
   revision = "d11385a99ef46892c42aad12dd1d2a6893702a39"
 =======
   revision = "6b2f007d6b1edb70f70acbe6e6270b1b39d69e37"
 >>>>>>> f7e6b024... vendor k8scc
+=======
+  revision = "0d94f8c311ace01f0f9ac4a050b12ba67ec3d1c8"
+>>>>>>> 1ab69bb9... bumped k8scloudconfig
 
 [[projects]]
   branch = "master"

--- a/service/controller/v10patch2/resource/instance/types.go
+++ b/service/controller/v10patch2/resource/instance/types.go
@@ -33,7 +33,7 @@ func newNodeOSImageCoreOS() nodeOSImage {
 		Offer:     "CoreOS",
 		Publisher: "CoreOS",
 		SKU:       "Stable",
-		Version:   "2135.4.0",
+		Version:   "2135.6.0",
 	}
 }
 

--- a/service/controller/v10patch2/version_bundle.go
+++ b/service/controller/v10patch2/version_bundle.go
@@ -9,11 +9,11 @@ func VersionBundle() versionbundle.Bundle {
 		Changelogs: []versionbundle.Changelog{
 			{
 				Component:   "kubernetes",
-				Description: "Update from v1.14.6 to v1.14.9.",
+				Description: "Update from v1.14.6 to v1.14.10.",
 				Kind:        versionbundle.KindChanged,
 				URLs: []string{
-					"https://github.com/giantswarm/aws-operator/pull/2088",
-					"https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#changelog-since-v1149",
+					"https://github.com/giantswarm/azure-operator/pull/611",
+					"https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#changelog-since-v11410",
 				},
 			},
 			{
@@ -37,7 +37,7 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Update from 2135.4.0 to 2135.6.0 for improved regional availability.",
 				Kind:        versionbundle.KindChanged,
 				URLs: []string{
-					"https://github.com/giantswarm/aws-operator/pull/2088",
+					"https://github.com/giantswarm/azure-operator/pull/613",
 				},
 			},
 		},
@@ -60,7 +60,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "kubernetes",
-				Version: "1.14.8",
+				Version: "1.14.10",
 			},
 		},
 		Name:    "azure-operator",

--- a/service/controller/v10patch2/version_bundle.go
+++ b/service/controller/v10patch2/version_bundle.go
@@ -25,7 +25,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "containerlinux",
-				Version: "2135.4.0",
+				Version: "2135.6.0",
 			},
 			{
 				Name:    "docker",

--- a/service/controller/v10patch2/version_bundle.go
+++ b/service/controller/v10patch2/version_bundle.go
@@ -11,14 +11,11 @@ func VersionBundle() versionbundle.Bundle {
 				Component:   "azure-operator",
 				Description: "Update to kubernetes 1.14.8.",
 				Kind:        versionbundle.KindChanged,
-<<<<<<< HEAD
 			},
 			{
 				Component:   "azure-operator",
 				Description: "Added new rule to the Public Load Balancer to allow outgoing UDP traffic from the master nodes",
 				Kind:        versionbundle.KindChanged,
-=======
->>>>>>> 21e1e308... update version bundle
 			},
 		},
 		Components: []versionbundle.Component{

--- a/service/controller/v10patch2/version_bundle.go
+++ b/service/controller/v10patch2/version_bundle.go
@@ -11,11 +11,14 @@ func VersionBundle() versionbundle.Bundle {
 				Component:   "azure-operator",
 				Description: "Update to kubernetes 1.14.8.",
 				Kind:        versionbundle.KindChanged,
+<<<<<<< HEAD
 			},
 			{
 				Component:   "azure-operator",
 				Description: "Added new rule to the Public Load Balancer to allow outgoing UDP traffic from the master nodes",
 				Kind:        versionbundle.KindChanged,
+=======
+>>>>>>> 21e1e308... update version bundle
 			},
 		},
 		Components: []versionbundle.Component{

--- a/service/controller/v10patch2/version_bundle.go
+++ b/service/controller/v10patch2/version_bundle.go
@@ -8,14 +8,37 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "azure-operator",
-				Description: "Update to kubernetes 1.14.8.",
+				Component:   "kubernetes",
+				Description: "Update from v1.14.6 to v1.14.9.",
 				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/aws-operator/pull/2088",
+					"https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#changelog-since-v1149",
+				},
 			},
 			{
 				Component:   "azure-operator",
-				Description: "Added new rule to the Public Load Balancer to allow outgoing UDP traffic from the master nodes",
+				Description: "Add new rule to the Public Load Balancer to allow outgoing UDP traffic from the master nodes.",
+				Kind:        versionbundle.KindAdded,
+				URLs: []string{
+					"https://github.com/giantswarm/azure-operator/pull/579",
+				},
+			},
+			{
+				Component:   "containerlinux",
+				Description: "Increase fs.inotify.max_user_instances to 8192.",
 				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/k8scloudconfig/pull/617",
+				},
+			},
+			{
+				Component:   "containerlinux",
+				Description: "Update from 2135.4.0 to 2135.6.0 for improved regional availability.",
+				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/aws-operator/pull/2088",
+				},
 			},
 		},
 		Components: []versionbundle.Component{

--- a/vendor/github.com/giantswarm/k8scloudconfig/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/k8scloudconfig/CHANGELOG.md
@@ -38,11 +38,11 @@ version directory, and  then changes are introduced.
 - Use `/bin/calico-node -felix-live` for `calico-node` liveness probe instead of `httpGet`.
 - Generally minimize differences between [Calico v3.9 yaml](https://docs.projectcalico.org/v3.9/manifests/calico.yaml) and `calico-all.yaml`.
 
-## [v4.8.1] - 2019-12-04
+## [v4.8.1] - 2019-12-31
 
 ### Changed
 
-- Update kubernetes to 1.14.9, includes fixes for CVE-2019-11253.
+- Update Kubernetes to 1.14.10, includes fixes for CVE-2019-11253 and some Azure fixes.
 - Increase `fs.inotify.max_user_instances` to 8192.
 
 ## [v4.8.0] 

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_4_8_1/cloudconfig.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_4_8_1/cloudconfig.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultRegistryDomain            = "quay.io"
 	defaultImagePullProgressDeadline = "1m"
-	kubernetesImage                  = "giantswarm/hyperkube:v1.14.9"
+	kubernetesImage                  = "giantswarm/hyperkube:v1.14.10"
 	etcdImage                        = "giantswarm/etcd:v3.3.13"
 	etcdPort                         = 443
 )


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7302

`v10patch2` with Kubernetes 1.14.8 was already merged to master but not yet released. This PR bumps it to Kubernetes 1.14.9 before 8.6.0 goes out.