### PR TITLE
vendor: updated statusresource

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -524,12 +524,12 @@
   revision = "5e18457bd062f9a11d11fe5719ccf28101945ce0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:779bc27eaf7906f25a3e361f5ddcab0b6d4ddce63aa8b3323db4ce9bb9ae7e02"
+  branch = "fix-status-init"
+  digest = "1:b93f97cc5eae826c035de4cd63249a4f06b51f2e0f25fcdbf79e6cce050f6f2c"
   name = "github.com/giantswarm/statusresource"
   packages = ["."]
   pruneopts = "UT"
-  revision = "047d92c988eb4d8fe2a9b320b638b9f570051da3"
+  revision = "c5f1208e376ddab8671b46cde4a5c45a19fdd833"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -524,12 +524,12 @@
   revision = "5e18457bd062f9a11d11fe5719ccf28101945ce0"
 
 [[projects]]
-  branch = "fix-status-init"
+  branch = "master"
   digest = "1:b93f97cc5eae826c035de4cd63249a4f06b51f2e0f25fcdbf79e6cce050f6f2c"
   name = "github.com/giantswarm/statusresource"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c5f1208e376ddab8671b46cde4a5c45a19fdd833"
+  revision = "1c017ce979b34a7f9bd1f46ebaeb2ca95771c758"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,7 +114,7 @@ required = [
 
 [[constraint]]
   name = "github.com/giantswarm/statusresource"
-  branch = "fix-status-init"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/giantswarm/tenantcluster"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -114,7 +114,7 @@ required = [
 
 [[constraint]]
   name = "github.com/giantswarm/statusresource"
-  branch = "master"
+  branch = "fix-status-init"
 
 [[constraint]]
   name = "github.com/giantswarm/tenantcluster"

--- a/vendor/github.com/giantswarm/statusresource/resource.go
+++ b/vendor/github.com/giantswarm/statusresource/resource.go
@@ -3,6 +3,7 @@ package statusresource
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"time"
 
@@ -141,11 +142,11 @@ func ensureDefaultPatches(clusterStatus providerv1alpha1.StatusCluster, patches 
 	nodesEmpty := clusterStatus.Nodes == nil
 	versionsEmpty := clusterStatus.Versions == nil
 
-	if conditionsEmpty && nodesEmpty && versionsEmpty {
+	if reflect.DeepEqual(clusterStatus, providerv1alpha1.StatusCluster{}) {
 		patches = append(patches, Patch{
 			Op:    "add",
-			Path:  "/status",
-			Value: Status{},
+			Path:  "/status/cluster",
+			Value: providerv1alpha1.StatusCluster{},
 		})
 	}
 


### PR DESCRIPTION
Towards giantswarm/giantswarm#7675

Confirming https://github.com/giantswarm/statusresource/pull/45 works for all providers.