### PR TITLE
Double the size of VMSS before upgrading worker instances

### DIFF
--- a/service/controller/v12/key/key.go
+++ b/service/controller/v12/key/key.go
@@ -474,6 +474,10 @@ func VPNGatewayName(customObject providerv1alpha1.AzureConfig) string {
 	return fmt.Sprintf("%s-%s", ClusterID(customObject), vpnGatewaySuffix)
 }
 
+func WorkerCount(customObject providerv1alpha1.AzureConfig) int {
+	return len(customObject.Spec.Azure.Workers)
+}
+
 func WorkerInstanceName(customObject providerv1alpha1.AzureConfig, instanceID string) (string, error) {
 	idB36, err := vmssInstanceIDBase36(instanceID)
 	if err != nil {

--- a/service/controller/v12/resource/instance/status.go
+++ b/service/controller/v12/resource/instance/status.go
@@ -17,6 +17,7 @@ const (
 	// States
 	DeploymentInitialized  = "DeploymentInitialized"
 	DeploymentCompleted    = "DeploymentCompleted"
+	ScaleVMSSToDouble      = "ScaleVMSSToDouble"
 	InstancesUpgrading     = "InstancesUpgrading"
 	ProvisioningSuccessful = "ProvisioningSuccessful"
 )


### PR DESCRIPTION
This is first part of changes towards more graceful upgrades in Azure.

General direction here is following:
  - Double the size of Worker VMSS.
  - Cordon old nodes.
  - Drain old nodes one-by-one.
  - Terminate old nodes.
  - Scale Worker VMSS down.

Towards https://github.com/giantswarm/giantswarm/issues/7735