### PR TITLE
E2e bastion

### DIFF
--- a/service/controller/v13/resource/deployment/deployment.go
+++ b/service/controller/v13/resource/deployment/deployment.go
@@ -19,7 +19,7 @@ func (r Resource) newDeployment(ctx context.Context, customObject providerv1alph
 	}
 
 	defaultParams := map[string]interface{}{
-		"bastionSubnetCidr":       sc.AzureNetwork.Bastion.String(),
+		"bastionE2ESubnetCidr":    sc.AzureNetwork.BastionE2E.String(),
 		"blobContainerName":       key.BlobContainerName(),
 		"calicoSubnetCidr":        sc.AzureNetwork.Calico.String(),
 		"clusterID":               key.ClusterID(customObject),

--- a/service/controller/v13/resource/deployment/deployment.go
+++ b/service/controller/v13/resource/deployment/deployment.go
@@ -19,6 +19,7 @@ func (r Resource) newDeployment(ctx context.Context, customObject providerv1alph
 	}
 
 	defaultParams := map[string]interface{}{
+		"bastionSubnetCidr":       sc.AzureNetwork.Bastion.String(),
 		"blobContainerName":       key.BlobContainerName(),
 		"calicoSubnetCidr":        sc.AzureNetwork.Calico.String(),
 		"clusterID":               key.ClusterID(customObject),

--- a/service/controller/v13/resource/deployment/template/bastion_e2e_vm.json
+++ b/service/controller/v13/resource/deployment/template/bastion_e2e_vm.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "GiantSwarmTags":{
+      "type":"object",
+      "defaultValue":{
+        "provider":"F80D01C0-7AAC-4440-98F6-5061511962AD"
+      }
+    },
+    "subnetID": {
+      "type": "string"
+    },
+    "adminPublicKey": {
+      "type": "secureString"
+    }
+  },
+  "variables": {
+    "networkInterfaceName": "bastionE2ENetworkInterface",
+    "publicIpAddressName": "bastionE2EPublicIpAddressName"
+  },
+  "resources": [
+    {
+      "name": "[variables('networkInterfaceName')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "apiVersion": "2019-07-01",
+      "location":"[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIpAddresses/', variables('publicIpAddressName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "subnet": {
+                "id": "[parameters('subnetID')]"
+              },
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIpAddress": {
+                "id": "[resourceId(resourceGroup().name, 'Microsoft.Network/publicIpAddresses', variables('publicIpAddressName'))]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "[variables('publicIpAddressName')]",
+      "type": "Microsoft.Network/publicIpAddresses",
+      "apiVersion": "2019-02-01",
+      "location":"[resourceGroup().location]",
+      "properties": {
+        "publicIpAllocationMethod": "Static"
+      },
+      "sku": {
+        "name": "Basic"
+      }
+    },
+    {
+      "name": "[parameters('virtualMachineName')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "apiVersion": "2019-07-01",
+      "location":"[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('networkInterfaceName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "Standard_D2_v2"
+        },
+        "storageProfile": {
+          "osDisk": {
+            "createOption": "fromImage",
+            "managedDisk": {
+              "storageAccountType": "[parameters('osDiskType')]"
+            }
+          },
+          "imageReference": {
+            "publisher": "CoreOS",
+            "offer": "CoreOS",
+            "sku": "Stable",
+            "version": "2191.5.0"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('networkInterfaceName'))]"
+            }
+          ]
+        },
+        "osProfile": {
+          "computerName": "[parameters('virtualMachineName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
+            "ssh": {
+              "publicKeys": [
+                {
+                  "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+                  "keyData": "[parameters('adminPublicKey')]"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "adminUsername": {
+      "type": "string",
+      "value": "[parameters('adminUsername')]"
+    }
+  }
+}

--- a/service/controller/v13/resource/deployment/template/main.json
+++ b/service/controller/v13/resource/deployment/template/main.json
@@ -219,6 +219,9 @@
           "virtualNetworkCidr":{
             "value":"[parameters('virtualNetworkCidr')]"
           },
+          "bastionSubnetCidr":{
+            "value":"[parameters('bastionSubnetCidr')]"
+          },
           "masterSubnetCidr":{
             "value":"[parameters('masterSubnetCidr')]"
           },
@@ -230,6 +233,9 @@
           },
           "vpnSubnetCidr":{
             "value":"[parameters('vpnSubnetCidr')]"
+          },
+          "bastionSecurityGroupID":{
+            "value":"[reference('security_groups_setup').outputs.bastionSecurityGroupID.value]"
           },
           "masterSecurityGroupID":{
             "value":"[reference('security_groups_setup').outputs.masterSecurityGroupID.value]"

--- a/service/controller/v13/resource/deployment/template/main.json
+++ b/service/controller/v13/resource/deployment/template/main.json
@@ -2,6 +2,12 @@
   "$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion":"1.0.0.0",
   "parameters":{
+    "bastionSubnetCidr":{
+      "type":"string",
+      "metadata":{
+        "description":"CIDR used for the subnet where the e2e bastion will be deployed."
+      }
+    },
     "blobContainerName":{
       "type":"string",
       "metadata":{
@@ -134,6 +140,9 @@
           "contentVersion":"1.0.0.0"
         },
         "parameters":{
+          "bastionSubnetCidr":{
+            "value":"[parameters('bastionSubnetCidr')]"
+          },
           "clusterID":{
             "value":"[parameters('clusterID')]"
           },

--- a/service/controller/v13/resource/deployment/template/main.json
+++ b/service/controller/v13/resource/deployment/template/main.json
@@ -72,6 +72,10 @@
     "kubernetesAPISecurePort":{
       "type":"int"
     },
+    "bastionE2ETemplateFile":{
+      "type":"string",
+      "defaultValue":"bastion_e2e_vm.json"
+    },
     "dnsASetupTemplateFile":{
       "type":"string",
       "defaultValue":"dns_a_setup.json"
@@ -116,6 +120,7 @@
     }
   },
   "variables":{
+    "bastionE2ETemplateURI":"[uri(deployment().properties.templateLink.uri, parameters('bastionE2ETemplateFile'))]",
     "dnsASetupTemplateURI":"[uri(deployment().properties.templateLink.uri, parameters('dnsASetupTemplateFile'))]",
     "dnsCNAMESetupTemplateURI":"[uri(deployment().properties.templateLink.uri, parameters('dnsCNAMESetupTemplateFile'))]",
     "containerSetupTemplateURI":"[uri(deployment().properties.templateLink.uri, parameters('containerSetupTemplateFile'))]",
@@ -441,6 +446,30 @@
           },
           "cname":{
             "value":"[concat('ingress.', parameters('clusterID'), '.k8s.', parameters('dnsZones').ingress.name)]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion":"2016-09-01",
+      "name":"bastion_e2e_vm",
+      "type":"Microsoft.Resources/deployments",
+      "condition":"[contains(parameters('virtualNetworkName'), 'ci-')]",
+      "properties":{
+        "mode":"incremental",
+        "templateLink":{
+          "uri":"[variables('bastionE2ETemplateURI')]",
+          "contentVersion":"1.0.0.0"
+        },
+        "parameters":{
+          "adminPublicKey":{
+            "value":""
+          },
+          "GiantSwarmTags":{
+            "value":"[parameters('GiantSwarmTags')]"
+          },
+          "subnetID":{
+            "value":"[reference('virtual_network_setup').outputs.bastionE2ESubnetID.value]"
           }
         }
       }

--- a/service/controller/v13/resource/deployment/template/main.json
+++ b/service/controller/v13/resource/deployment/template/main.json
@@ -2,7 +2,7 @@
   "$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion":"1.0.0.0",
   "parameters":{
-    "bastionSubnetCidr":{
+    "bastionE2ESubnetCidr":{
       "type":"string",
       "metadata":{
         "description":"CIDR used for the subnet where the e2e bastion will be deployed."
@@ -140,8 +140,8 @@
           "contentVersion":"1.0.0.0"
         },
         "parameters":{
-          "bastionSubnetCidr":{
-            "value":"[parameters('bastionSubnetCidr')]"
+          "bastionE2ESubnetCidr":{
+            "value":"[parameters('bastionE2ESubnetCidr')]"
           },
           "clusterID":{
             "value":"[parameters('clusterID')]"
@@ -219,8 +219,8 @@
           "virtualNetworkCidr":{
             "value":"[parameters('virtualNetworkCidr')]"
           },
-          "bastionSubnetCidr":{
-            "value":"[parameters('bastionSubnetCidr')]"
+          "bastionE2ESubnetCidr":{
+            "value":"[parameters('bastionE2ESubnetCidr')]"
           },
           "masterSubnetCidr":{
             "value":"[parameters('masterSubnetCidr')]"
@@ -234,8 +234,8 @@
           "vpnSubnetCidr":{
             "value":"[parameters('vpnSubnetCidr')]"
           },
-          "bastionSecurityGroupID":{
-            "value":"[reference('security_groups_setup').outputs.bastionSecurityGroupID.value]"
+          "bastionE2ESecurityGroupID":{
+            "value":"[reference('security_groups_setup').outputs.bastionE2ESecurityGroupID.value]"
           },
           "masterSecurityGroupID":{
             "value":"[reference('security_groups_setup').outputs.masterSecurityGroupID.value]"

--- a/service/controller/v13/resource/deployment/template/security_groups_setup.json
+++ b/service/controller/v13/resource/deployment/template/security_groups_setup.json
@@ -2,7 +2,7 @@
   "$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion":"1.0.0.0",
   "parameters":{
-    "bastionSubnetCidr":{
+    "bastionE2ESubnetCidr":{
       "type":"string",
       "metadata":{
         "description":"CIDR used for the subnet where the e2e bastion will be deployed."
@@ -55,8 +55,8 @@
     "masterSecurityGroupID":"[resourceId('Microsoft.Network/networkSecurityGroups', variables('masterSecurityGroupName'))]",
     "workerSecurityGroupName":"[concat(parameters('clusterID'), '-WorkerSecurityGroup')]",
     "workerSecurityGroupID":"[resourceId('Microsoft.Network/networkSecurityGroups', variables('workerSecurityGroupName'))]",
-    "bastionSecurityGroupName":"[concat(parameters('clusterID'), '-BastionSecurityGroup')]",
-    "bastionSecurityGroupID":"[resourceId('Microsoft.Network/networkSecurityGroups', variables('bastionSecurityGroupName'))]",
+    "bastionE2ESecurityGroupName":"[concat(parameters('clusterID'), '-BastionE2ESecurityGroup')]",
+    "bastionE2ESecurityGroupID":"[resourceId('Microsoft.Network/networkSecurityGroups', variables('bastionE2ESecurityGroupName'))]",
     "cadvisorPort":"4194",
     "etcdPort":"2379",
     "kubeletPort":"10250",
@@ -131,13 +131,13 @@
             }
           },
           {
-            "name":"sshBastionToMasterSubnetRule",
+            "name":"sshBastionE2EToMasterSubnetRule",
             "properties":{
               "description":"Allow the e2e bastion to reach this tenant cluster master subnet.",
               "protocol":"*",
               "sourcePortRange":"*",
               "destinationPortRange":"22",
-              "sourceAddressPrefix":"[parameters('bastionSubnetCidr')]",
+              "sourceAddressPrefix":"[parameters('bastionE2ESubnetCidr')]",
               "destinationAddressPrefix":"[parameters('masterSubnetCidr')]",
               "access":"Allow",
               "direction":"Inbound",
@@ -341,13 +341,13 @@
             }
           },
           {
-            "name":"sshBastionToWorkerSubnetRule",
+            "name":"sshBastionE2EToWorkerSubnetRule",
             "properties":{
               "description":"Allow the e2e bastion to reach this tenant cluster worker subnet.",
               "protocol":"*",
               "sourcePortRange":"*",
               "destinationPortRange":"22",
-              "sourceAddressPrefix":"[parameters('bastionSubnetCidr')]",
+              "sourceAddressPrefix":"[parameters('bastionE2ESubnetCidr')]",
               "destinationAddressPrefix":"[parameters('workerSubnetCidr')]",
               "access":"Allow",
               "direction":"Inbound",
@@ -457,7 +457,7 @@
     },
     {
       "type":"Microsoft.Network/networkSecurityGroups",
-      "name":"[variables('bastionSecurityGroupName')]",
+      "name":"[variables('bastionE2ESecurityGroupName')]",
       "condition":"[equals(parameters('initialProvisioning'), 'Yes')]",
       "apiVersion":"[parameters('networkSecurityGroupsAPIVersion')]",
       "location":"[resourceGroup().location]",
@@ -467,14 +467,14 @@
       "properties":{
         "securityRules":[
           {
-            "name":"sshToBastionSubnetRule",
+            "name":"sshToBastionE2ESubnetRule",
             "properties":{
               "description":"Allow SSH traffic into the bastion subnet",
               "protocol":"TCP",
               "sourcePortRange":"*",
               "destinationPortRange":"22",
               "sourceAddressPrefix":"*",
-              "destinationAddressPrefix":"[parameters('bastionSubnetCidr')]",
+              "destinationAddressPrefix":"[parameters('bastionE2ESubnetCidr')]",
               "access":"Allow",
               "direction":"Inbound",
               "priority":"4093"
@@ -493,9 +493,9 @@
       "type":"string",
       "value":"[variables('workerSecurityGroupID')]"
     },
-    "bastionSecurityGroupID":{
+    "bastionE2ESecurityGroupID":{
       "type":"string",
-      "value":"[variables('bastionSecurityGroupID')]"
+      "value":"[variables('bastionE2ESecurityGroupID')]"
     }
   }
 }

--- a/service/controller/v13/resource/deployment/template/security_groups_setup.json
+++ b/service/controller/v13/resource/deployment/template/security_groups_setup.json
@@ -2,6 +2,12 @@
   "$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion":"1.0.0.0",
   "parameters":{
+    "bastionSubnetCidr":{
+      "type":"string",
+      "metadata":{
+        "description":"CIDR used for the subnet where the e2e bastion will be deployed."
+      }
+    },
     "networkSecurityGroupsAPIVersion":{
       "type":"string",
       "defaultValue":"2016-09-01",
@@ -120,6 +126,20 @@
               "access":"Allow",
               "direction":"Inbound",
               "priority":"4093"
+            }
+          },
+          {
+            "name":"sshBastionToMasterSubnetRule",
+            "properties":{
+              "description":"Allow the e2e bastion to reach this tenant cluster master subnet.",
+              "protocol":"*",
+              "sourcePortRange":"*",
+              "destinationPortRange":"22",
+              "sourceAddressPrefix":"[parameters('bastionSubnetCidr')]",
+              "destinationAddressPrefix":"[parameters('masterSubnetCidr')]",
+              "access":"Allow",
+              "direction":"Inbound",
+              "priority":"4092"
             }
           },
           {
@@ -316,6 +336,20 @@
               "access":"Allow",
               "direction":"Inbound",
               "priority":"4093"
+            }
+          },
+          {
+            "name":"sshBastionToWorkerSubnetRule",
+            "properties":{
+              "description":"Allow the e2e bastion to reach this tenant cluster worker subnet.",
+              "protocol":"*",
+              "sourcePortRange":"*",
+              "destinationPortRange":"22",
+              "sourceAddressPrefix":"[parameters('bastionSubnetCidr')]",
+              "destinationAddressPrefix":"[parameters('workerSubnetCidr')]",
+              "access":"Allow",
+              "direction":"Inbound",
+              "priority":"4092"
             }
           },
           {

--- a/service/controller/v13/resource/deployment/template/security_groups_setup.json
+++ b/service/controller/v13/resource/deployment/template/security_groups_setup.json
@@ -55,6 +55,8 @@
     "masterSecurityGroupID":"[resourceId('Microsoft.Network/networkSecurityGroups', variables('masterSecurityGroupName'))]",
     "workerSecurityGroupName":"[concat(parameters('clusterID'), '-WorkerSecurityGroup')]",
     "workerSecurityGroupID":"[resourceId('Microsoft.Network/networkSecurityGroups', variables('workerSecurityGroupName'))]",
+    "bastionSecurityGroupName":"[concat(parameters('clusterID'), '-BastionSecurityGroup')]",
+    "bastionSecurityGroupID":"[resourceId('Microsoft.Network/networkSecurityGroups', variables('bastionSecurityGroupName'))]",
     "cadvisorPort":"4194",
     "etcdPort":"2379",
     "kubeletPort":"10250",
@@ -452,6 +454,34 @@
           }
         ]
       }
+    },
+    {
+      "type":"Microsoft.Network/networkSecurityGroups",
+      "name":"[variables('bastionSecurityGroupName')]",
+      "condition":"[equals(parameters('initialProvisioning'), 'Yes')]",
+      "apiVersion":"[parameters('networkSecurityGroupsAPIVersion')]",
+      "location":"[resourceGroup().location]",
+      "tags":{
+        "provider":"[toUpper(parameters('GiantSwarmTags').provider)]"
+      },
+      "properties":{
+        "securityRules":[
+          {
+            "name":"sshToBastionSubnetRule",
+            "properties":{
+              "description":"Allow SSH traffic into the bastion subnet",
+              "protocol":"TCP",
+              "sourcePortRange":"*",
+              "destinationPortRange":"22",
+              "sourceAddressPrefix":"*",
+              "destinationAddressPrefix":"[parameters('bastionSubnetCidr')]",
+              "access":"Allow",
+              "direction":"Inbound",
+              "priority":"4093"
+            }
+          }
+        ]
+      }
     }
   ],
   "outputs":{
@@ -462,6 +492,10 @@
     "workerSecurityGroupID":{
       "type":"string",
       "value":"[variables('workerSecurityGroupID')]"
+    },
+    "bastionSecurityGroupID":{
+      "type":"string",
+      "value":"[variables('bastionSecurityGroupID')]"
     }
   }
 }

--- a/service/controller/v13/resource/deployment/template/virtual_network_setup.json
+++ b/service/controller/v13/resource/deployment/template/virtual_network_setup.json
@@ -2,6 +2,18 @@
   "$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion":"1.0.0.0",
   "parameters":{
+    "bastionSecurityGroupID":{
+      "type":"string",
+      "metadata":{
+        "description":"Security group that allows traffic on port 22 from nodes on the same Virtual Network."
+      }
+    },
+    "bastionSubnetCidr":{
+      "type":"string",
+      "metadata":{
+        "description":"CIDR used for the subnet where the e2e bastion will be deployed."
+      }
+    },
     "GiantSwarmTags":{
       "type":"object",
       "defaultValue":{
@@ -45,6 +57,7 @@
   },
   "variables":{
     "virtualNetworkID":"[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
+    "bastionSubnetName":"[concat(parameters('virtualNetworkName'), '-BastionSubnet')]",
     "masterSubnetName":"[concat(parameters('virtualNetworkName'), '-MasterSubnet')]",
     "masterSubnetID":"[concat(variables('virtualNetworkID'), '/subnets/', variables('masterSubnetName'))]",
     "workerSubnetName":"[concat(parameters('virtualNetworkName'), '-WorkerSubnet')]",
@@ -66,6 +79,18 @@
           ]
         },
         "subnets":[
+          {
+            "name":"[variables('bastionSubnetName')]",
+            "properties":{
+              "addressPrefix":"[parameters('bastionSubnetCidr')]",
+              "networkSecurityGroup":{
+                "id":"[parameters('bastionSecurityGroupID')]"
+              },
+              "routeTable":{
+                "id":"[parameters('routeTableID')]"
+              }
+            }
+          },
           {
             "name":"[variables('masterSubnetName')]",
             "properties":{

--- a/service/controller/v13/resource/deployment/template/virtual_network_setup.json
+++ b/service/controller/v13/resource/deployment/template/virtual_network_setup.json
@@ -2,13 +2,13 @@
   "$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion":"1.0.0.0",
   "parameters":{
-    "bastionSecurityGroupID":{
+    "bastionE2ESecurityGroupID":{
       "type":"string",
       "metadata":{
-        "description":"Security group that allows traffic on port 22 from nodes on the same Virtual Network."
+        "description":"Security group that allows traffic on port 22 from everywhere."
       }
     },
-    "bastionSubnetCidr":{
+    "bastionE2ESubnetCidr":{
       "type":"string",
       "metadata":{
         "description":"CIDR used for the subnet where the e2e bastion will be deployed."
@@ -57,17 +57,17 @@
   },
   "variables":{
     "virtualNetworkID":"[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-    "bastionSubnetName":"[concat(parameters('virtualNetworkName'), '-BastionSubnet')]",
+    "bastionE2ESubnetName":"[concat(parameters('virtualNetworkName'), '-BastionE2ESubnet')]",
     "masterSubnetName":"[concat(parameters('virtualNetworkName'), '-MasterSubnet')]",
     "masterSubnetID":"[concat(variables('virtualNetworkID'), '/subnets/', variables('masterSubnetName'))]",
     "workerSubnetName":"[concat(parameters('virtualNetworkName'), '-WorkerSubnet')]",
     "workerSubnetID":"[concat(variables('virtualNetworkID'), '/subnets/', variables('workerSubnetName'))]",
-    "bastionSubnetDefinition": [{
-      "name":"[variables('bastionSubnetName')]",
+    "bastionE2ESubnetDefinition": [{
+      "name":"[variables('bastionE2ESubnetName')]",
       "properties":{
-        "addressPrefix":"[parameters('bastionSubnetCidr')]",
+        "addressPrefix":"[parameters('bastionE2ESubnetCidr')]",
         "networkSecurityGroup":{
-          "id":"[parameters('bastionSecurityGroupID')]"
+          "id":"[parameters('bastionE2ESecurityGroupID')]"
         },
         "routeTable":{
           "id":"[parameters('routeTableID')]"
@@ -133,7 +133,7 @@
             "[parameters('virtualNetworkCidr')]"
           ]
         },
-        "subnets":"[concat( parameters('subnets'), if( contains(parameters('virtualNetworkName'), 'ci-'), variables('bastionSubnetDefinition'), []) )]"
+        "subnets":"[concat( parameters('subnets'), if( contains(parameters('virtualNetworkName'), 'ci-'), variables('bastionE2ESubnetDefinition'), []) )]"
       }
     }
   ],

--- a/service/controller/v13/resource/deployment/template/virtual_network_setup.json
+++ b/service/controller/v13/resource/deployment/template/virtual_network_setup.json
@@ -58,6 +58,7 @@
   "variables":{
     "virtualNetworkID":"[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
     "bastionE2ESubnetName":"[concat(parameters('virtualNetworkName'), '-BastionE2ESubnet')]",
+    "bastionE2ESubnetID":"[concat(variables('virtualNetworkID'), '/subnets/', variables('bastionE2ESubnetName'))]",
     "masterSubnetName":"[concat(parameters('virtualNetworkName'), '-MasterSubnet')]",
     "masterSubnetID":"[concat(variables('virtualNetworkID'), '/subnets/', variables('masterSubnetName'))]",
     "workerSubnetName":"[concat(parameters('virtualNetworkName'), '-WorkerSubnet')]",
@@ -133,7 +134,7 @@
             "[parameters('virtualNetworkCidr')]"
           ]
         },
-        "subnets":"[concat( parameters('subnets'), if( contains(parameters('virtualNetworkName'), 'ci-'), variables('bastionE2ESubnetDefinition'), []) )]"
+        "subnets":"[concat( variables('subnets'), if( contains(parameters('virtualNetworkName'), 'ci-'), variables('bastionE2ESubnetDefinition'), []) )]"
       }
     }
   ],
@@ -145,6 +146,10 @@
     "workerSubnetID":{
       "type":"string",
       "value":"[variables('workerSubnetID')]"
+    },
+    "bastionE2ESubnetID":{
+      "type":"string",
+      "value":"[variables('bastionE2ESubnetID')]"
     }
   }
 }

--- a/service/controller/v13/resource/deployment/template/virtual_network_setup.json
+++ b/service/controller/v13/resource/deployment/template/virtual_network_setup.json
@@ -61,7 +61,62 @@
     "masterSubnetName":"[concat(parameters('virtualNetworkName'), '-MasterSubnet')]",
     "masterSubnetID":"[concat(variables('virtualNetworkID'), '/subnets/', variables('masterSubnetName'))]",
     "workerSubnetName":"[concat(parameters('virtualNetworkName'), '-WorkerSubnet')]",
-    "workerSubnetID":"[concat(variables('virtualNetworkID'), '/subnets/', variables('workerSubnetName'))]"
+    "workerSubnetID":"[concat(variables('virtualNetworkID'), '/subnets/', variables('workerSubnetName'))]",
+    "bastionSubnetDefinition": [{
+      "name":"[variables('bastionSubnetName')]",
+      "properties":{
+        "addressPrefix":"[parameters('bastionSubnetCidr')]",
+        "networkSecurityGroup":{
+          "id":"[parameters('bastionSecurityGroupID')]"
+        },
+        "routeTable":{
+          "id":"[parameters('routeTableID')]"
+        }
+      }
+    }],
+    "subnets": [
+      {
+        "name":"[variables('masterSubnetName')]",
+        "properties":{
+          "addressPrefix":"[parameters('masterSubnetCidr')]",
+          "networkSecurityGroup":{
+            "id":"[parameters('masterSecurityGroupID')]"
+          },
+          "routeTable":{
+            "id":"[parameters('routeTableID')]"
+          }
+        }
+      },
+      {
+        "name":"[variables('workerSubnetName')]",
+        "properties":{
+          "addressPrefix":"[parameters('workerSubnetCidr')]",
+          "networkSecurityGroup":{
+            "id":"[parameters('workerSecurityGroupID')]"
+          },
+          "routeTable":{
+            "id":"[parameters('routeTableID')]"
+          },
+          "serviceEndpoints": [
+            { "service": "Microsoft.Storage" },
+            { "service": "Microsoft.Sql" },
+            { "service": "Microsoft.AzureCosmosDB" },
+            { "service": "Microsoft.KeyVault" },
+            { "service": "Microsoft.ServiceBus" },
+            { "service": "Microsoft.EventHub" },
+            { "service": "Microsoft.AzureActiveDirectory" },
+            { "service": "Microsoft.ContainerRegistry" },
+            { "service": "Microsoft.Web" }
+          ]
+        }
+      },
+      {
+        "name":"[parameters('vnetGatewaySubnetName')]",
+        "properties":{
+          "addressPrefix":"[parameters('vpnSubnetCidr')]"
+        }
+      }
+    ]
   },
   "resources":[
     {
@@ -78,61 +133,7 @@
             "[parameters('virtualNetworkCidr')]"
           ]
         },
-        "subnets":[
-          {
-            "name":"[variables('bastionSubnetName')]",
-            "properties":{
-              "addressPrefix":"[parameters('bastionSubnetCidr')]",
-              "networkSecurityGroup":{
-                "id":"[parameters('bastionSecurityGroupID')]"
-              },
-              "routeTable":{
-                "id":"[parameters('routeTableID')]"
-              }
-            }
-          },
-          {
-            "name":"[variables('masterSubnetName')]",
-            "properties":{
-              "addressPrefix":"[parameters('masterSubnetCidr')]",
-              "networkSecurityGroup":{
-                "id":"[parameters('masterSecurityGroupID')]"
-              },
-              "routeTable":{
-                "id":"[parameters('routeTableID')]"
-              }
-            }
-          },
-          {
-            "name":"[variables('workerSubnetName')]",
-            "properties":{
-              "addressPrefix":"[parameters('workerSubnetCidr')]",
-              "networkSecurityGroup":{
-                "id":"[parameters('workerSecurityGroupID')]"
-              },
-              "routeTable":{
-                "id":"[parameters('routeTableID')]"
-              },
-              "serviceEndpoints": [
-                { "service": "Microsoft.Storage" },
-                { "service": "Microsoft.Sql" },
-                { "service": "Microsoft.AzureCosmosDB" },
-                { "service": "Microsoft.KeyVault" },
-                { "service": "Microsoft.ServiceBus" },
-                { "service": "Microsoft.EventHub" },
-                { "service": "Microsoft.AzureActiveDirectory" },
-                { "service": "Microsoft.ContainerRegistry" },
-                { "service": "Microsoft.Web" }
-              ]
-            }
-          },
-          {
-            "name":"[parameters('vnetGatewaySubnetName')]",
-            "properties":{
-              "addressPrefix":"[parameters('vpnSubnetCidr')]"
-            }
-          }
-        ]
+        "subnets":"[concat( parameters('subnets'), if( contains(parameters('virtualNetworkName'), 'ci-'), variables('bastionSubnetDefinition'), []) )]"
       }
     }
   ],

--- a/service/network/network.go
+++ b/service/network/network.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	masterSubnetMask = 24
-	workerSubnetMask = 24
-	vpnSubnetMask    = 24
+	masterSubnetMask  = 24
+	workerSubnetMask  = 24
+	vpnSubnetMask     = 24
+	bastionSubnetMask = 24
 
 	ipv4MaskSize = 32
 )
@@ -42,6 +43,12 @@ func Compute(network net.IPNet) (subnets *Subnets, err error) {
 
 	vpnCIDRMask := net.CIDRMask(vpnSubnetMask, ipv4MaskSize)
 	subnets.VPN, err = ipam.Free(network, vpnCIDRMask, []net.IPNet{subnets.Calico, subnets.Master, subnets.Worker})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	bastionCIDRMask := net.CIDRMask(bastionSubnetMask, ipv4MaskSize)
+	subnets.Bastion, err = ipam.Free(network, bastionCIDRMask, []net.IPNet{subnets.Calico, subnets.Master, subnets.Worker, subnets.VPN})
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/network/network.go
+++ b/service/network/network.go
@@ -8,10 +8,10 @@ import (
 )
 
 const (
-	masterSubnetMask  = 24
-	workerSubnetMask  = 24
-	vpnSubnetMask     = 24
-	bastionSubnetMask = 24
+	masterSubnetMask     = 24
+	workerSubnetMask     = 24
+	vpnSubnetMask        = 24
+	bastionE2ESubnetMask = 24
 
 	ipv4MaskSize = 32
 )
@@ -47,8 +47,8 @@ func Compute(network net.IPNet) (subnets *Subnets, err error) {
 		return nil, microerror.Mask(err)
 	}
 
-	bastionCIDRMask := net.CIDRMask(bastionSubnetMask, ipv4MaskSize)
-	subnets.Bastion, err = ipam.Free(network, bastionCIDRMask, []net.IPNet{subnets.Calico, subnets.Master, subnets.Worker, subnets.VPN})
+	bastionE2ECIDRMask := net.CIDRMask(bastionE2ESubnetMask, ipv4MaskSize)
+	subnets.BastionE2E, err = ipam.Free(network, bastionE2ECIDRMask, []net.IPNet{subnets.Calico, subnets.Master, subnets.Worker, subnets.VPN})
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/network/subnets.go
+++ b/service/network/subnets.go
@@ -7,11 +7,12 @@ import (
 
 // Subnets holds network subnets used by guest clusters.
 type Subnets struct {
-	Parent net.IPNet
-	Calico net.IPNet
-	Master net.IPNet
-	VPN    net.IPNet
-	Worker net.IPNet
+	Parent  net.IPNet
+	Bastion net.IPNet
+	Calico  net.IPNet
+	Master  net.IPNet
+	VPN     net.IPNet
+	Worker  net.IPNet
 }
 
 // Equal return true when every network IP and Mask in a and b are equal.

--- a/service/network/subnets.go
+++ b/service/network/subnets.go
@@ -7,12 +7,12 @@ import (
 
 // Subnets holds network subnets used by guest clusters.
 type Subnets struct {
-	Parent  net.IPNet
-	Bastion net.IPNet
-	Calico  net.IPNet
-	Master  net.IPNet
-	VPN     net.IPNet
-	Worker  net.IPNet
+	Parent     net.IPNet
+	BastionE2E net.IPNet
+	Calico     net.IPNet
+	Master     net.IPNet
+	VPN        net.IPNet
+	Worker     net.IPNet
 }
 
 // Equal return true when every network IP and Mask in a and b are equal.


### PR DESCRIPTION
These changes would allow us to spin up an Azure VM on the bastion subnet and ssh into the tenant cluster nodes.

With this approach, the security group used for tenant cluster nodes will always allow SSH traffic coming from the bastion subnet, even if this subnet doesn't exist (another approach would be to allow all SSH traffic coming from the _whole_ virtual network, but the bastion VM still needs its own subnet).

This subnet is only created when running e2e tests. Not sure if this is the right approach: the virtual network during tests would be different than in production.

