### PR TITLE
Re-use already allocated Public IP for ingress LB

### DIFF
--- a/service/controller/v13/cloudconfig/base_extension.go
+++ b/service/controller/v13/cloudconfig/base_extension.go
@@ -55,6 +55,7 @@ func (e *baseExtension) templateData(certFiles certs.Files) templateData {
 		},
 		ingressLBFileParams{
 			ClusterDNSDomain: key.ClusterDNSDomain(e.customObject),
+			PublicIPName:     key.IngressPIPName(e.customObject),
 		},
 	}
 }

--- a/service/controller/v13/cloudconfig/types.go
+++ b/service/controller/v13/cloudconfig/types.go
@@ -45,4 +45,5 @@ type certificateDecrypterUnitParams struct {
 
 type ingressLBFileParams struct {
 	ClusterDNSDomain string
+	PublicIPName     string
 }

--- a/service/controller/v13/resource/deployment/template/main.json
+++ b/service/controller/v13/resource/deployment/template/main.json
@@ -51,6 +51,13 @@
     "calicoSubnetCidr":{
       "type":"string"
     },
+    "ingressPIPName":{
+      "defaultValue":"dummy-pip",
+      "type":"string",
+      "metadata":{
+        "description":"Name of the allocated Public IP that is used for Ingress LB."
+      }
+    },
     "masterSubnetCidr":{
       "type":"string"
     },
@@ -322,6 +329,9 @@
         "parameters":{
           "initialProvisioning":{
             "value":"[parameters('initialProvisioning')]"
+          },
+          "ingressPIPName"{
+            "value":"[parameters('ingressPIPName')]"
           }
         }
       }

--- a/service/controller/v13/templates/ignition/ingress_lb.go
+++ b/service/controller/v13/templates/ignition/ingress_lb.go
@@ -9,6 +9,8 @@ metadata:
     external-dns.alpha.kubernetes.io/hostname: ingress.{{ .ClusterDNSDomain }}.
     # this annotation adds lb rules fot both TCP and UDP to allow UDP outbound connection with Standard LB
     service.beta.kubernetes.io/azure-load-balancer-mixed-protocols: "true" 
+    # this annotation re-uses already allocated public IP for ingress LB.
+    service.beta.kubernetes.io/azure-pip-name: {{ .PublicIPName }}
   labels:
     app: ingress-loadbalancer
 spec:

--- a/service/controller/v13/version_bundle.go
+++ b/service/controller/v13/version_bundle.go
@@ -8,11 +8,12 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "TODO",
+				Component:   "azure-operator",
+				Description: "Ingress LB public IP is re-used for ingress controller.",
 				Kind:        versionbundle.KindChanged,
 				URLs: []string{
-					"TODO",
+					"https://github.com/giantswarm/azure-operator/pull/604",
+					"https://github.com/giantswarm/azure-operator/pull/642",
 				},
 			},
 		},


### PR DESCRIPTION
This change picks up name of the already allocated public IP and assigns it as
annotation to ingress LB.

This is the complementary PR for https://github.com/giantswarm/azure-operator/pull/604
Towards https://github.com/giantswarm/giantswarm/issues/6636