### PR TITLE
Remove e2e tests for already released version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,106 +53,33 @@ jobs:
 
 
 
-  e2eTestCurMasterClusterState:
-    environment:
-      TESTED_VERSION: "current"
-      TEST_DIR: "integration/test/clusterstate"
-    <<: *e2eTest
-  e2eTestCurPRClusterState:
-    environment:
-      TESTED_VERSION: "current"
-      TEST_DIR: "integration/test/clusterstate"
-    <<: *e2eTest
-  e2eTestWIPMasterClusterState:
-    environment:
-      TESTED_VERSION: "wip"
-      TEST_DIR: "integration/test/clusterstate"
-    <<: *e2eTest
   e2eTestWIPPRClusterState:
     environment:
       TESTED_VERSION: "wip"
       TEST_DIR: "integration/test/clusterstate"
     <<: *e2eTest
 
-
-
-  e2eTestCurMasterScaling:
-    environment:
-      TESTED_VERSION: "current"
-      TEST_DIR: "integration/test/scaling"
-    <<: *e2eTest
-  e2eTestCurPRScaling:
-    environment:
-      TESTED_VERSION: "current"
-      TEST_DIR: "integration/test/scaling"
-    <<: *e2eTest
-  e2eTestWIPMasterScaling:
-    environment:
-      TESTED_VERSION: "wip"
-      TEST_DIR: "integration/test/scaling"
-    <<: *e2eTest
   e2eTestWIPPRScaling:
     environment:
       TESTED_VERSION: "wip"
       TEST_DIR: "integration/test/scaling"
     <<: *e2eTest
 
-
-
-  e2eTestCurMasterMultiAZ:
-    environment:
-      TESTED_VERSION: "current"
-      TEST_DIR: "integration/test/multiaz"
-    <<: *e2eTest
-  e2eTestCurPRMultiAZ:
-    environment:
-      TESTED_VERSION: "current"
-      TEST_DIR: "integration/test/multiaz"
-    <<: *e2eTest
-  e2eTestWIPMasterMultiAZ:
-    environment:
-      TESTED_VERSION: "wip"
-      TEST_DIR: "integration/test/multiaz"
-    <<: *e2eTest
   e2eTestWIPPRMultiAZ:
     environment:
       TESTED_VERSION: "wip"
       TEST_DIR: "integration/test/multiaz"
     <<: *e2eTest
 
-
-
-  e2eTestCurMasterClusterDeletion:
-    environment:
-      TESTED_VERSION: "current"
-      TEST_DIR: "integration/test/clusterdeletion"
-    <<: *e2eTest
-  e2eTestCurPRClusterDeletion:
-    environment:
-      TESTED_VERSION: "current"
-      TEST_DIR: "integration/test/clusterdeletion"
-    <<: *e2eTest
-  e2eTestWIPMasterClusterDeletion:
-    environment:
-      TESTED_VERSION: "wip"
-      TEST_DIR: "integration/test/clusterdeletion"
-    <<: *e2eTest
   e2eTestWIPPRClusterDeletion:
     environment:
       TESTED_VERSION: "wip"
       TEST_DIR: "integration/test/clusterdeletion"
     <<: *e2eTest
 
-
-
   # Note we only have update tests for the current version because it anyway
   # tests one version transition. Having the same tests for WIP only runs the
   # same test twice and we can simply save resources by not doing so.
-  e2eTestCurMasterUpdate:
-    environment:
-      TESTED_VERSION: "current"
-      TEST_DIR: "integration/test/update"
-    <<: *e2eTest
   e2eTestCurPRUpdate:
     environment:
       TESTED_VERSION: "current"
@@ -182,59 +109,22 @@ workflows:
             branches:
               ignore: master
 
-
-
-#     - e2eTestCurMasterClusterState:
-#         requires:
-#         - master
-#     - e2eTestWIPMasterClusterState:
-#         requires:
-#         - master
-      - e2eTestCurPRClusterState:
-          requires:
-          - pr
       - e2eTestWIPPRClusterState:
           requires:
           - pr
 
-
-
-#     - e2eTestCurMasterScaling:
-#         requires:
-#         - master
-#     - e2eTestWIPMasterScaling:
-#         requires:
-#         - master
-      - e2eTestCurPRScaling:
-          requires:
-          - pr
       - e2eTestWIPPRScaling:
           requires:
           - pr
 
-
-
-      - e2eTestCurPRMultiAZ:
-          requires:
-          - pr
       - e2eTestWIPPRMultiAZ:
           requires:
           - pr
 
-
-
-      - e2eTestCurPRClusterDeletion:
-          requires:
-          - pr
       - e2eTestWIPPRClusterDeletion:
           requires:
           - pr
 
-
-
-#     - e2eTestCurMasterUpdate:
-#         requires:
-#         - master
       - e2eTestCurPRUpdate:
           requires:
           - pr


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8767

We currently have tests for the `wip` version, and the `current` version (the latest release). This PR removes tests for the `current` version, since that was tested already when it was `wip`.

Only the `updating` test for `current` is kept, as this test checks the update process from `wip` to `current`.