### PR TITLE
Ensure that scaling shortcut is active

### DIFF
--- a/service/controller/v13/resource/instance/create_provisioning_successful.go
+++ b/service/controller/v13/resource/instance/create_provisioning_successful.go
@@ -8,5 +8,5 @@ import (
 
 func (r *Resource) provisioningSuccessfulTransition(ctx context.Context, obj interface{}, currentState state.State) (state.State, error) {
 	r.logger.LogCtx(ctx, "level", "debug", "message", "VMSS deployment successfully provisioned")
-	return MasterInstancesUpgrading, nil
+	return ClusterUpgradeRequirementCheck, nil
 }


### PR DESCRIPTION
When tenant cluster workers are scaled, it's enough that VMSS deployment gets
updated and then we just consider it done. We don't want to re-image master[s]
nor replace worker nodes with new ones. We only want to update the VMSS
deployment and that configures the VMSS accordingly.