### PR TITLE
Add check for mising tenant k8s client

### DIFF
--- a/service/controller/v13/resource/instance/error.go
+++ b/service/controller/v13/resource/instance/error.go
@@ -5,6 +5,15 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+var clientNotFoundError = &microerror.Error{
+	Kind: "clientNotFoundError",
+}
+
+// IsClientNotFound asserts clientNotFoundError.
+func IsClientNotFound(err error) bool {
+	return microerror.Cause(err) == clientNotFoundError
+}
+
 // executionFailedError is an error type for situations where Resource
 // execution cannot continue and must always fall back to operatorkit.
 //


### PR DESCRIPTION
It can happen that tenant is not reachable and therefore the code should check
for missing client and keep the state until it's there.