### PR TITLE
Fix coreOS version

### DIFF
--- a/service/controller/v12/version_bundle.go
+++ b/service/controller/v12/version_bundle.go
@@ -54,14 +54,6 @@ func VersionBundle() versionbundle.Bundle {
 				},
 			},
 			{
-				Component:   "containerlinux",
-				Description: "Update from v2191.5.0 to v2247.6.0.",
-				Kind:        versionbundle.KindChanged,
-				URLs: []string{
-					"https://github.com/giantswarm/azure-operator/pull/609",
-				},
-			},
-			{
 				Component:   "etcd",
 				Description: "Update from v3.3.15 to v3.3.17.",
 				Kind:        versionbundle.KindChanged,
@@ -85,7 +77,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "containerlinux",
-				Version: "2247.6.0",
+				Version: "2191.5.0",
 			},
 			{
 				Name:    "docker",

--- a/service/controller/v13/resource/instance/types.go
+++ b/service/controller/v13/resource/instance/types.go
@@ -50,7 +50,7 @@ func newNodeOSImageCoreOS() nodeOSImage {
 		Offer:     "CoreOS",
 		Publisher: "CoreOS",
 		SKU:       "Stable",
-		Version:   "2247.6.0",
+		Version:   "2191.5.0",
 	}
 }
 

--- a/service/controller/v13/resource/instance/types.go
+++ b/service/controller/v13/resource/instance/types.go
@@ -50,7 +50,7 @@ func newNodeOSImageCoreOS() nodeOSImage {
 		Offer:     "CoreOS",
 		Publisher: "CoreOS",
 		SKU:       "Stable",
-		Version:   "2191.5.0",
+		Version:   "2247.6.0",
 	}
 }
 

--- a/service/controller/v13/version_bundle.go
+++ b/service/controller/v13/version_bundle.go
@@ -16,14 +16,6 @@ func VersionBundle() versionbundle.Bundle {
 				},
 			},
 			{
-				Component:   "containerlinux",
-				Description: "Update from v2191.5.0 to v2247.6.0.",
-				Kind:        versionbundle.KindChanged,
-				URLs: []string{
-					"https://github.com/giantswarm/azure-operator/pull/609",
-				},
-			},
-			{
 				Component:   "k8scloudconfig",
 				Description: "Fixed node labeling when base36 encoded node ID contains letters.",
 				Kind:        versionbundle.KindFixed,
@@ -39,7 +31,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "containerlinux",
-				Version: "2247.6.0",
+				Version: "2191.5.0",
 			},
 			{
 				Name:    "docker",

--- a/service/controller/v13/version_bundle.go
+++ b/service/controller/v13/version_bundle.go
@@ -16,6 +16,14 @@ func VersionBundle() versionbundle.Bundle {
 				},
 			},
 			{
+				Component:   "containerlinux",
+				Description: "Update from v2191.5.0 to v2247.6.0.",
+				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/azure-operator/pull/609",
+				},
+			},
+			{
 				Component:   "k8scloudconfig",
 				Description: "Fixed node labeling when base36 encoded node ID contains letters.",
 				Kind:        versionbundle.KindFixed,


### PR DESCRIPTION
So, coreOS version was bumped in v12 (2.8.0) version's changelog from v2191.5.0 to v2247.6.0 but that wasn't done.
I changed the v12 version_bundle to change the coreOS version to the used one (2191.5.0).
Same thing about v13 (2.9.0) which was copied from (2.8.0).