### PR TITLE
Skip upgrade process if there have been no changes to apply

### DIFF
--- a/service/controller/v13/resource/instance/create_deployment_completed.go
+++ b/service/controller/v13/resource/instance/create_deployment_completed.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/giantswarm/azure-operator/service/controller/v13/blobclient"
+	"github.com/giantswarm/microerror"
+
 	"github.com/giantswarm/azure-operator/service/controller/v13/key"
 	"github.com/giantswarm/azure-operator/service/controller/v13/resource/instance/internal/state"
-	"github.com/giantswarm/microerror"
 )
 
 func (r *Resource) deploymentCompletedTransition(ctx context.Context, obj interface{}, currentState state.State) (state.State, error) {
@@ -33,43 +33,18 @@ func (r *Resource) deploymentCompletedTransition(ctx context.Context, obj interf
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deployment is in state '%s'", s))
 
 	if key.IsSucceededProvisioningState(s) {
-		computedDeployment, err := r.newDeployment(ctx, customObject, nil)
-		if blobclient.IsBlobNotFound(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "ignition blob not found")
-			return currentState, nil
-		} else if err != nil {
-			return "", microerror.Mask(err)
-		} else {
-			desiredDeploymentTemplateChk, err := getDeploymentTemplateChecksum(computedDeployment)
-			if err != nil {
-				return "", microerror.Mask(err)
-			}
-
-			desiredDeploymentParametersChk, err := getDeploymentParametersChecksum(computedDeployment)
-			if err != nil {
-				return "", microerror.Mask(err)
-			}
-
-			currentDeploymentTemplateChk, err := r.getResourceStatus(customObject, DeploymentTemplateChecksum)
-			if err != nil {
-				return "", microerror.Mask(err)
-			}
-
-			currentDeploymentParametersChk, err := r.getResourceStatus(customObject, DeploymentParametersChecksum)
-			if err != nil {
-				return "", microerror.Mask(err)
-			}
-
-			if currentDeploymentTemplateChk != desiredDeploymentTemplateChk || currentDeploymentParametersChk != desiredDeploymentParametersChk {
-				r.logger.LogCtx(ctx, "level", "debug", "message", "template or parameters changed")
-				// As current and desired state differs, start process from the beginning.
-				return DeploymentUninitialized, nil
-			}
-
-			r.logger.LogCtx(ctx, "level", "debug", "message", "template and parameters unchanged")
-
-			return currentState, nil
+		areThereChangesToReconciliate, err := r.areThereChangesToReconciliate(err, ctx, customObject)
+		if err != nil {
+			return DeploymentUninitialized, microerror.Mask(err)
 		}
+
+		if areThereChangesToReconciliate {
+			// As current and desired state differs, start process from the beginning.
+			return DeploymentUninitialized, nil
+		}
+
+		return currentState, nil
+
 	} else if key.IsFinalProvisioningState(s) {
 		// Deployment has failed. Restart from beginning.
 		return DeploymentUninitialized, nil


### PR DESCRIPTION
IIUC when we create a new AzureConfig, it will go through the initial state, then `DeploymentInitialized`, and it will stay on that state until the Deployment has finished.

Then it will go to `ProvisioningSuccessful` and then `ClusterUpgradeRequirementCheck`. It's here where we branch. We either
- Detect changes in the ARM template/parameters that need to be applied, so we go to `MasterInstancesUpgrading`.
- The cluster is currently scaling, or we don't detect changes in the template. In that case, we go to the last stage `DeploymentCompleted`, which will check on every reconciliation if something needs to be reconciled. If we _missed_ an update because the cluster was scaling, this will take care of it.

Before these changes, the `DeploymentCompleted` stage was already checking if something needed to be applied and, in that case, going to the first stage `DeploymentUninitialized`.

Update: Thinking about it deeper, I think the PR is wrong because it will never go through `MasterInstancesUpgrading`, since `DeploymentUninitialized` calculates the checksum, so it will never be different.