### PR TITLE
pkg, service: replace `bundleVersion` with `version`

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,17 +1,12 @@
 package project
 
 var (
-	bundleVersion        = "3.0.0-dev"
-	description   string = "The azure-operator manages Kubernetes clusters on Azure."
-	gitSHA               = "n/a"
-	name          string = "azure-operator"
-	source        string = "https://github.com/giantswarm/azure-operator"
-	version              = "n/a"
+	description string = "The azure-operator manages Kubernetes clusters on Azure."
+	gitSHA             = "n/a"
+	name        string = "azure-operator"
+	source      string = "https://github.com/giantswarm/azure-operator"
+	version            = "3.0.0-dev"
 )
-
-func BundleVersion() string {
-	return bundleVersion
-}
 
 func Description() string {
 	return description

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -39,6 +39,6 @@ func NewVersionBundle() versionbundle.Bundle {
 			},
 		},
 		Name:    Name(),
-		Version: BundleVersion(),
+		Version: Version(),
 	}
 }

--- a/service/controller/resource_set.go
+++ b/service/controller/resource_set.go
@@ -403,7 +403,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 			return false
 		}
 
-		if key.OperatorVersion(cr) == project.BundleVersion() {
+		if key.OperatorVersion(cr) == project.Version() {
 			return true
 		}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8637

We want to invert how the project version is maintained and now that
it isn't injected during the build from git data, we can remove the
separate concept of _bundle version_ and replace it with just _version_.
