### PR TITLE
Fix volume names in chart

### DIFF
--- a/helm/azure-operator/templates/deployment.yaml
+++ b/helm/azure-operator/templates/deployment.yaml
@@ -24,13 +24,13 @@ spec:
         version: {{ .Values.project.version }}
     spec:
       volumes:
-      - name: {{ .Values.project.name }}-configmap
+      - name: {{ tpl .Values.resource.default.name  . }}-configmap
         configMap:
           name: {{ tpl .Values.resource.default.name  . }}
           items:
           - key: config.yaml
             path: config.yaml
-      - name: {{ .Values.project.name }}-secret
+      - name: {{ tpl .Values.resource.default.name  . }}-secret
         secret:
           secretName: {{ tpl .Values.resource.default.name  . }}
           items:


### PR DESCRIPTION
Merging without approval.

Trying to fix 
```
failed to create resource: Deployment.apps "azure-operator-master" is invalid: [spec.template.spec.containers[0].volumeMounts[0].name: Not found: "azure-operator-master-configmap", spec.template.spec.containers[0].volumeMounts[1].name: Not found: "azure-operator-master-secret"]
```