### PR TITLE
helm: Ensure proper labels on all resources

### DIFF
--- a/helm/azure-operator/Chart.yaml
+++ b/helm/azure-operator/Chart.yaml
@@ -1,3 +1,3 @@
 name: azure-operator
 version: [[ .Version ]]
-appVersion: [[ .Version ]]
+appVersion: [[ .AppVersion ]]

--- a/helm/azure-operator/Chart.yaml
+++ b/helm/azure-operator/Chart.yaml
@@ -1,2 +1,3 @@
 name: azure-operator
 version: [[ .Version ]]
+appVersion: [[ .Version ]]

--- a/helm/azure-operator/templates/_helpers.tpl
+++ b/helm/azure-operator/templates/_helpers.tpl
@@ -1,0 +1,38 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "azure-operator.name" -}}
+{{- default .Chart.Name .Values.project.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "azure-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "azure-operator.labels" -}}
+helm.sh/chart: {{ include "azure-operator.chart" . }}
+{{ include "azure-operator.selectorLabels" . }}
+{{ include "azure-operator.name" . }}.giantswarm.io/branch: {{ .Values.project.branch }}
+{{ include "azure-operator.name" . }}.giantswarm.io/commit: {{ .Values.project.commit }}
+app.kubernetes.io/name: {{ include "azure-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "azure-operator.selectorLabels" -}}
+app: {{ include "azure-operator.name" . }}
+{{ include "azure-operator.name" . }}.giantswarm.io/version: {{ .Chart.AppVersion }}
+{{- end -}}

--- a/helm/azure-operator/templates/_helpers.tpl
+++ b/helm/azure-operator/templates/_helpers.tpl
@@ -3,7 +3,7 @@
 Expand the name of the chart.
 */}}
 {{- define "azure-operator.name" -}}
-{{- default .Chart.Name .Values.project.name | trunc 63 | trimSuffix "-" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -17,22 +17,19 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "azure-operator.labels" -}}
-helm.sh/chart: {{ include "azure-operator.chart" . }}
+app: {{ include "azure-operator.name" . | quote }}
 {{ include "azure-operator.selectorLabels" . }}
-{{ include "azure-operator.name" . }}.giantswarm.io/branch: {{ .Values.project.branch }}
-{{ include "azure-operator.name" . }}.giantswarm.io/commit: {{ .Values.project.commit }}
-app.kubernetes.io/name: {{ include "azure-operator.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Chart.AppVersion }}
+app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
+app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "azure-operator.chart" . | quote }}
 {{- end -}}
 
 {{/*
 Selector labels
 */}}
 {{- define "azure-operator.selectorLabels" -}}
-app: {{ include "azure-operator.name" . }}
-{{ include "azure-operator.name" . }}.giantswarm.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/name: {{ include "azure-operator.name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- end -}}

--- a/helm/azure-operator/templates/configmap.yaml
+++ b/helm/azure-operator/templates/configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
+  labels:
+    {{- include "azure-operator.labels" . | nindent 4 }}
 data:
   config.yaml: |
     server:

--- a/helm/azure-operator/templates/deployment.yaml
+++ b/helm/azure-operator/templates/deployment.yaml
@@ -4,15 +4,13 @@ metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-    app: {{ .Values.project.name }}
-    version: {{ .Values.project.version }}
+    {{- include "azure-operator.labels" . | nindent 4 }}
 spec:
   replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: {{ .Values.project.name }}
-      version: {{ .Values.project.version }}
+      {{- include "azure-operator.selectorLabels" . | nindent 6 }}
   strategy:
     type: Recreate
   template:
@@ -20,8 +18,7 @@ spec:
       annotations:
         releasetime: {{ $.Release.Time }}
       labels:
-        app: {{ .Values.project.name }}
-        version: {{ .Values.project.version }}
+        {{- include "azure-operator.selectorLabels" . | nindent 8 }}
     spec:
       volumes:
       - name: {{ tpl .Values.resource.default.name  . }}-configmap

--- a/helm/azure-operator/templates/deployment.yaml
+++ b/helm/azure-operator/templates/deployment.yaml
@@ -41,13 +41,13 @@ spec:
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
       containers:
-      - name: {{ .Values.project.name }}
+      - name: {{ .Chart.Name }}
         image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         volumeMounts:
         - name: {{ tpl .Values.resource.default.name  . }}-configmap
-          mountPath: /var/run/{{ .Values.project.name }}/configmap/
+          mountPath: /var/run/{{ .Chart.Name }}/configmap/
         - name: {{ tpl .Values.resource.default.name  . }}-secret
-          mountPath: /var/run/{{ .Values.project.name }}/secret/
+          mountPath: /var/run/{{ .Chart.Name }}/secret/
           readOnly: true
         - name: certs
           mountPath: /etc/ssl/certs/ca-certificates.crt
@@ -57,8 +57,8 @@ spec:
           containerPort: 8000
         args:
         - daemon
-        - --config.dirs=/var/run/{{ .Values.project.name }}/configmap/
-        - --config.dirs=/var/run/{{ .Values.project.name }}/secret/
+        - --config.dirs=/var/run/{{ .Chart.Name }}/configmap/
+        - --config.dirs=/var/run/{{ .Chart.Name }}/secret/
         - --config.files=config
         - --config.files=secret
         livenessProbe:

--- a/helm/azure-operator/templates/psp.yaml
+++ b/helm/azure-operator/templates/psp.yaml
@@ -2,6 +2,8 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ tpl .Values.resource.psp.name . }}
+  labels:
+    {{- include "azure-operator.labels" . | nindent 4 }}
 spec:
   privileged: false
   fsGroup:

--- a/helm/azure-operator/templates/pull-secret.yml
+++ b/helm/azure-operator/templates/pull-secret.yml
@@ -4,5 +4,7 @@ type: kubernetes.io/dockerconfigjson
 metadata:
   name: {{ tpl .Values.resource.pullSecret.name . }}
   namespace: {{ tpl .Values.resource.pullSecret.namespace . }}
+  labels:
+    {{- include "azure-operator.labels" . | nindent 4 }}
 data:
   .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}

--- a/helm/azure-operator/templates/rbac.yaml
+++ b/helm/azure-operator/templates/rbac.yaml
@@ -2,6 +2,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
+  labels:
+    {{- include "azure-operator.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - apiextensions.k8s.io
@@ -82,6 +84,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
+  labels:
+    {{- include "azure-operator.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ tpl .Values.resource.default.name  . }}
@@ -95,6 +99,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ tpl .Values.resource.psp.name . }}
+  labels:
+    {{- include "azure-operator.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - extensions
@@ -109,6 +115,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ tpl .Values.resource.psp.name . }}
+  labels:
+    {{- include "azure-operator.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ tpl .Values.resource.default.name  . }}

--- a/helm/azure-operator/templates/secret.yaml
+++ b/helm/azure-operator/templates/secret.yaml
@@ -4,5 +4,7 @@ type: Opaque
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
+  labels:
+    {{- include "azure-operator.labels" . | nindent 4 }}
 data:
   secret.yaml: {{ .Values.Installation.V1.Secret.AzureOperator.SecretYaml | b64enc | quote }}

--- a/helm/azure-operator/templates/service-account.yaml
+++ b/helm/azure-operator/templates/service-account.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
+  labels:
+    {{- include "azure-operator.labels" . | nindent 4 }}

--- a/helm/azure-operator/templates/service.yaml
+++ b/helm/azure-operator/templates/service.yaml
@@ -4,8 +4,7 @@ metadata:
   name: {{ tpl .Values.resource.default.name  . }}
   namespace: {{ tpl .Values.resource.default.namespace  . }}
   labels:
-    app: {{ .Values.project.name }}
-    version: {{ .Values.project.version }}
+    {{- include "azure-operator.labels" . | nindent 4 }}
   annotations:
     prometheus.io/scrape: "true"
 spec:
@@ -13,5 +12,4 @@ spec:
   ports:
   - port: 8000
   selector:
-    app: {{ .Values.project.name }}
-    version: {{ .Values.project.version }}
+    {{- include "azure-operator.selectorLabels" . | nindent 4 }}

--- a/helm/azure-operator/values.yaml
+++ b/helm/azure-operator/values.yaml
@@ -1,6 +1,8 @@
 project:
   name: "azure-operator"
   version: "[[ .Version ]]"
+  branch: "[[ .Branch ]]"
+  commit: "[[ .SHA ]]"
 image:
   name: "giantswarm/azure-operator"
   tag: "[[ .Version ]]"

--- a/helm/azure-operator/values.yaml
+++ b/helm/azure-operator/values.yaml
@@ -1,6 +1,4 @@
 project:
-  name: "azure-operator"
-  version: "[[ .Version ]]"
   branch: "[[ .Branch ]]"
   commit: "[[ .SHA ]]"
 image:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8632

Refactor labels out into a template helper to be able to maintain them
in one place and use on multiple objects. This borrows from a structure
of a default chart template in upstream Helm.

Ensure all resources created when the chart is installed have proper
labels, i.e. `$OPERATOR.giantswarm.io/` + `version` - used as selector
together with `app`, as well as `branch` and `commit` - purely
informational.

Also add common labels advocated by Kubernetes
https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
so that resources can be queried and visualised by shared tooling.