### PR TITLE
Update exposed info about using k8s 1.16.7

### DIFF
--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -35,7 +35,7 @@ func NewVersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "kubernetes",
-				Version: "1.16.3",
+				Version: "1.16.7",
 			},
 		},
 		Name:    Name(),


### PR DESCRIPTION
I forgot to update the version bundle info regarding the k8s version used.