### PR TITLE
Change Deployment rollout strategy to Recreate

### DIFF
--- a/helm/azure-operator-chart/templates/deployment.yaml
+++ b/helm/azure-operator-chart/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       app: {{ .Values.project.name }}
       version: {{ .Values.project.version }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/helm/azure-operator/templates/deployment.yaml
+++ b/helm/azure-operator/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       app: {{ .Values.project.name }}
       version: {{ .Values.project.version }}
   strategy:
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Towards: giantswarm/giantswarm#9173

Same change from in https://github.com/giantswarm/aws-operator/pull/2164 to prevent MultipleOperatorsRunningSameBundleVersion fires during an operator update.