### PR TITLE
Already checked subscriptions should not be used again

### DIFF
--- a/service/collector/vmss_rate_limit.go
+++ b/service/collector/vmss_rate_limit.go
@@ -138,6 +138,8 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 			if inArray(doneSubscriptions, config.SubscriptionID) {
 				continue
 			}
+			doneSubscriptions = append(doneSubscriptions, config.SubscriptionID)
+
 			azureClients, err := client.NewAzureClientSet(*config)
 			if err != nil {
 				return microerror.Mask(err)


### PR DESCRIPTION
Same changes as https://github.com/giantswarm/azure-operator/pull/708