### PR TITLE
Labels are immutable in v1, we need to go back so draughtsman can deploy

### DIFF
--- a/helm/azure-operator-chart/templates/deployment.yaml
+++ b/helm/azure-operator-chart/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: azure-operator


### PR DESCRIPTION
When we want to deploy the `thiccc` branch, the deployment fails unless we remove the helm release before deploying.

I believe the problem comes for the fact that we don't use `apiVersion: extensions/v1beta1` but `apiVersion: apps/v1` which made the field immutable.
