### PR TITLE
Avoid collecting metrics twice

### DIFF
--- a/service/collector/client.go
+++ b/service/collector/client.go
@@ -1,11 +1,12 @@
 package collector
 
 import (
-	"github.com/giantswarm/azure-operator/client"
-	"github.com/giantswarm/azure-operator/service/credential"
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/azure-operator/client"
+	"github.com/giantswarm/azure-operator/service/credential"
 )
 
 const (
@@ -16,8 +17,9 @@ const (
 	credentialLabelSelector = "app=credentiald"
 )
 
-// getClientSets fetches all unique Azure clients.
-func getClientSets(k8sClient kubernetes.Interface, environmentName string) ([]*client.AzureClientSet, error) {
+// getClientSets fetches all Azure clients, grouped by subscription id.
+// If two secrets use the same subscription but different client id, only one is returned
+func getClientSets(k8sClient kubernetes.Interface, environmentName string) (map[string]*client.AzureClientSet, error) {
 	credentialList, err := k8sClient.CoreV1().Secrets(credentialNamespace).List(metav1.ListOptions{
 		LabelSelector: credentialLabelSelector,
 	})
@@ -25,7 +27,7 @@ func getClientSets(k8sClient kubernetes.Interface, environmentName string) ([]*c
 		return nil, microerror.Mask(err)
 	}
 
-	clientSets := []*client.AzureClientSet{}
+	clientSets := map[string]*client.AzureClientSet{}
 
 	for _, secret := range credentialList.Items {
 		config, err := credential.GetAzureConfig(k8sClient, secret.Name, secret.Namespace)
@@ -40,7 +42,7 @@ func getClientSets(k8sClient kubernetes.Interface, environmentName string) ([]*c
 			return nil, microerror.Mask(err)
 		}
 
-		clientSets = append(clientSets, clientSet)
+		clientSets[config.SubscriptionID] = clientSet
 	}
 
 	return clientSets, nil


### PR DESCRIPTION
We have two secrets with different client id's, but they use the same subscription id. Two different clients can see the same resource groups since they use the same subscription. This makes the metrics endpoint to fail

![image](https://user-images.githubusercontent.com/627038/76429065-ce033f00-63ae-11ea-8b71-89199c32098d.png)

This groups the clients by subscription id, only exposing once metrics for every subscription id.