### PR TITLE
Prevent infinite retries in general and on HTTP 429 completely

### DIFF
--- a/client/azure_client_set.go
+++ b/client/azure_client_set.go
@@ -47,16 +47,7 @@ type AzureClientSet struct {
 
 func init() {
 	// ONE DOES NOT SIMPLY RETRY ON HTTP 429.
-	for i, sc := range autorest.StatusCodesForRetry {
-		if sc == http.StatusTooManyRequests {
-			// Shift end of slice to the left by one.
-			copy(autorest.StatusCodesForRetry[i:], autorest.StatusCodesForRetry[i+1:])
-			// Truncate the last element.
-			autorest.StatusCodesForRetry = autorest.StatusCodesForRetry[:len(autorest.StatusCodesForRetry)-1]
-			// Call it a day.
-			break
-		}
-	}
+	autorest.StatusCodesForRetry = removeElementFromSlice(autorest.StatusCodesForRetry, http.StatusTooManyRequests)
 }
 
 // NewAzureClientSet returns the Azure API clients.
@@ -339,4 +330,19 @@ func parseAzureEnvironment(cloudName string) (azure.Environment, error) {
 	}
 
 	return env, nil
+}
+
+func removeElementFromSlice(xs []int, x int) []int {
+	for i, v := range xs {
+		if v == x {
+			// Shift end of slice to the left by one.
+			copy(xs[i:], xs[i+1:])
+			// Truncate the last element.
+			xs = xs[:len(xs)-1]
+			// Call it a day.
+			break
+		}
+	}
+
+	return xs
 }

--- a/client/azure_client_set.go
+++ b/client/azure_client_set.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
@@ -42,6 +43,20 @@ type AzureClientSet struct {
 	VirtualMachineScaleSetVMsClient *compute.VirtualMachineScaleSetVMsClient
 	// VnetPeeringClient manages virtual network peerings.
 	VnetPeeringClient *network.VirtualNetworkPeeringsClient
+}
+
+func init() {
+	// ONE DOES NOT SIMPLY RETRY ON HTTP 429.
+	for i, sc := range autorest.StatusCodesForRetry {
+		if sc == http.StatusTooManyRequests {
+			// Shift end of slice to the left by one.
+			copy(autorest.StatusCodesForRetry[i:], autorest.StatusCodesForRetry[i+1:])
+			// Truncate the last element.
+			autorest.StatusCodesForRetry = autorest.StatusCodesForRetry[:len(autorest.StatusCodesForRetry)-1]
+			// Call it a day.
+			break
+		}
+	}
 }
 
 // NewAzureClientSet returns the Azure API clients.
@@ -145,6 +160,7 @@ func NewAzureClientSet(config AzureClientSetConfig) (*AzureClientSet, error) {
 func newDeploymentsClient(config *clientConfig) (*resources.DeploymentsClient, error) {
 	c := resources.NewDeploymentsClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	c.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
+	c.RetryAttempts = 1
 	err := c.AddToUserAgent(config.partnerIdUserAgent)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -156,6 +172,7 @@ func newDeploymentsClient(config *clientConfig) (*resources.DeploymentsClient, e
 func newDNSRecordSetsClient(config *clientConfig) (*dns.RecordSetsClient, error) {
 	c := dns.NewRecordSetsClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	c.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
+	c.RetryAttempts = 1
 	err := c.AddToUserAgent(config.partnerIdUserAgent)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -167,6 +184,7 @@ func newDNSRecordSetsClient(config *clientConfig) (*dns.RecordSetsClient, error)
 func newDNSZonesClient(config *clientConfig) (*dns.ZonesClient, error) {
 	c := dns.NewZonesClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	c.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
+	c.RetryAttempts = 1
 	err := c.AddToUserAgent(config.partnerIdUserAgent)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -178,6 +196,7 @@ func newDNSZonesClient(config *clientConfig) (*dns.ZonesClient, error) {
 func newGroupsClient(config *clientConfig) (*resources.GroupsClient, error) {
 	c := resources.NewGroupsClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	c.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
+	c.RetryAttempts = 1
 	err := c.AddToUserAgent(config.partnerIdUserAgent)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -189,6 +208,7 @@ func newGroupsClient(config *clientConfig) (*resources.GroupsClient, error) {
 func newInterfacesClient(config *clientConfig) (*network.InterfacesClient, error) {
 	c := network.NewInterfacesClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	c.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
+	c.RetryAttempts = 1
 	err := c.AddToUserAgent(config.partnerIdUserAgent)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -200,6 +220,7 @@ func newInterfacesClient(config *clientConfig) (*network.InterfacesClient, error
 func newStorageAccountsClient(config *clientConfig) (*storage.AccountsClient, error) {
 	c := storage.NewAccountsClient(config.subscriptionID)
 	c.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
+	c.RetryAttempts = 1
 	err := c.AddToUserAgent(config.partnerIdUserAgent)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -211,6 +232,7 @@ func newStorageAccountsClient(config *clientConfig) (*storage.AccountsClient, er
 func newUsageClient(config *clientConfig) (*compute.UsageClient, error) {
 	c := compute.NewUsageClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	c.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
+	c.RetryAttempts = 1
 	err := c.AddToUserAgent(config.partnerIdUserAgent)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -222,6 +244,7 @@ func newUsageClient(config *clientConfig) (*compute.UsageClient, error) {
 func newVirtualNetworkClient(config *clientConfig) (*network.VirtualNetworksClient, error) {
 	c := network.NewVirtualNetworksClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	c.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
+	c.RetryAttempts = 1
 	err := c.AddToUserAgent(config.partnerIdUserAgent)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -233,6 +256,7 @@ func newVirtualNetworkClient(config *clientConfig) (*network.VirtualNetworksClie
 func newVirtualNetworkGatewayConnectionsClient(config *clientConfig) (*network.VirtualNetworkGatewayConnectionsClient, error) {
 	c := network.NewVirtualNetworkGatewayConnectionsClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	c.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
+	c.RetryAttempts = 1
 	err := c.AddToUserAgent(config.partnerIdUserAgent)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -244,6 +268,7 @@ func newVirtualNetworkGatewayConnectionsClient(config *clientConfig) (*network.V
 func newVirtualNetworkGatewaysClient(config *clientConfig) (*network.VirtualNetworkGatewaysClient, error) {
 	c := network.NewVirtualNetworkGatewaysClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	c.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
+	c.RetryAttempts = 1
 	err := c.AddToUserAgent(config.partnerIdUserAgent)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -255,6 +280,7 @@ func newVirtualNetworkGatewaysClient(config *clientConfig) (*network.VirtualNetw
 func newVirtualMachineScaleSetsClient(config *clientConfig) (*compute.VirtualMachineScaleSetsClient, error) {
 	c := compute.NewVirtualMachineScaleSetsClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	c.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
+	c.RetryAttempts = 1
 	err := c.AddToUserAgent(config.partnerIdUserAgent)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -266,6 +292,7 @@ func newVirtualMachineScaleSetsClient(config *clientConfig) (*compute.VirtualMac
 func newVirtualMachineScaleSetVMsClient(config *clientConfig) (*compute.VirtualMachineScaleSetVMsClient, error) {
 	c := compute.NewVirtualMachineScaleSetVMsClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	c.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
+	c.RetryAttempts = 1
 	err := c.AddToUserAgent(config.partnerIdUserAgent)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -277,6 +304,7 @@ func newVirtualMachineScaleSetVMsClient(config *clientConfig) (*compute.VirtualM
 func newVnetPeeringClient(config *clientConfig) (*network.VirtualNetworkPeeringsClient, error) {
 	c := network.NewVirtualNetworkPeeringsClientWithBaseURI(config.resourceManagerEndpoint, config.subscriptionID)
 	c.Authorizer = autorest.NewBearerAuthorizer(config.servicePrincipalToken)
+	c.RetryAttempts = 1
 	err := c.AddToUserAgent(config.partnerIdUserAgent)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/client/azure_client_set_test.go
+++ b/client/azure_client_set_test.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_removeElementFromSlice(t *testing.T) {
+	testCases := []struct {
+		name       string
+		xs         []int
+		x          int
+		expectedXs []int
+	}{
+		{
+
+			name:       "case 0: simple case, remove number from slice",
+			xs:         []int{0, 1, 2, 3},
+			x:          2,
+			expectedXs: []int{0, 1, 3},
+		},
+		{
+
+			name:       "case 1: remove number from empty slice",
+			xs:         []int{},
+			x:          2,
+			expectedXs: []int{},
+		},
+		{
+			name:       "case 2: remove number from nil slice",
+			xs:         nil,
+			x:          2,
+			expectedXs: nil,
+		},
+		{
+			name:       "case 3: remove first number from slice",
+			xs:         []int{0, 1, 2, 3, 4},
+			x:          0,
+			expectedXs: []int{1, 2, 3, 4},
+		},
+		{
+			name:       "case 4: remove last number from slice",
+			xs:         []int{0, 1, 2, 3, 4},
+			x:          4,
+			expectedXs: []int{0, 1, 2, 3},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Log(tc.name)
+
+			xs := removeElementFromSlice(tc.xs, tc.x)
+
+			if !cmp.Equal(xs, tc.expectedXs) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(tc.expectedXs, xs))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Never retry on HTTP 429 (TooManyRequests) and in other cases retry only once in
Azure SDK clients.