### PR TITLE
DO NOT MERGE - use custom container images for azure 429

### DIFF
--- a/vendor/github.com/giantswarm/k8scloudconfig/v_4_9_0/cloudconfig.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_4_9_0/cloudconfig.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultRegistryDomain            = "quay.io"
 	defaultImagePullProgressDeadline = "1m"
-	kubernetesImage                  = "giantswarm/hyperkube:v1.15.5"
+	kubernetesImage                  = "giantswarm/hyperkube:v1.15.5-429-retry-disabled"
 	etcdImage                        = "giantswarm/etcd:v3.3.15"
 	etcdPort                         = 443
 )

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_4_9_0/cloudconfig.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_4_9_0/cloudconfig.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultRegistryDomain            = "quay.io"
 	defaultImagePullProgressDeadline = "1m"
-	kubernetesImage                  = "giantswarm/hyperkube:v1.15.11-429-retry-disabled"
+	kubernetesImage                  = "giantswarm/hyperkube:v1.15.11"
 	etcdImage                        = "giantswarm/etcd:v3.3.15"
 	etcdPort                         = 443
 )

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_4_9_0/cloudconfig.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_4_9_0/cloudconfig.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultRegistryDomain            = "quay.io"
 	defaultImagePullProgressDeadline = "1m"
-	kubernetesImage                  = "giantswarm/hyperkube:v1.15.5-429-retry-disabled"
+	kubernetesImage                  = "giantswarm/hyperkube:v1.15.11-429-retry-disabled"
 	etcdImage                        = "giantswarm/etcd:v3.3.15"
 	etcdPort                         = 443
 )

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/cloudconfig.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/cloudconfig.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultRegistryDomain            = "quay.io"
 	defaultImagePullProgressDeadline = "1m"
-	kubernetesImage                  = "giantswarm/hyperkube:v1.16.3"
+	kubernetesImage                  = "giantswarm/hyperkube:v1.16.3-429-retry-disabled"
 	etcdImage                        = "giantswarm/etcd:v3.3.17"
 	etcdPort                         = 443
 )

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/cloudconfig.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/cloudconfig.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultRegistryDomain            = "quay.io"
 	defaultImagePullProgressDeadline = "1m"
-	kubernetesImage                  = "giantswarm/hyperkube:v1.16.3-429-retry-disabled"
+	kubernetesImage                  = "giantswarm/hyperkube:v1.16.8-429-retry-disabled"
 	etcdImage                        = "giantswarm/etcd:v3.3.17"
 	etcdPort                         = 443
 )

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/cloudconfig.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_0_0/cloudconfig.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultRegistryDomain            = "quay.io"
 	defaultImagePullProgressDeadline = "1m"
-	kubernetesImage                  = "giantswarm/hyperkube:v1.16.8-429-retry-disabled"
+	kubernetesImage                  = "giantswarm/hyperkube:v1.16.8"
 	etcdImage                        = "giantswarm/etcd:v3.3.17"
 	etcdPort                         = 443
 )

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_1_0/cloudconfig.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_1_0/cloudconfig.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultRegistryDomain            = "quay.io"
 	defaultImagePullProgressDeadline = "1m"
-	kubernetesImage                  = "giantswarm/hyperkube:v1.16.3"
+	kubernetesImage                  = "giantswarm/hyperkube:v1.16.3-429-retry-disabled"
 	etcdImage                        = "giantswarm/etcd:v3.3.17"
 	etcdPort                         = 443
 )

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_1_0/cloudconfig.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_1_0/cloudconfig.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultRegistryDomain            = "quay.io"
 	defaultImagePullProgressDeadline = "1m"
-	kubernetesImage                  = "giantswarm/hyperkube:v1.16.3-429-retry-disabled"
+	kubernetesImage                  = "giantswarm/hyperkube:v1.16.8-429-retry-disabled"
 	etcdImage                        = "giantswarm/etcd:v3.3.17"
 	etcdPort                         = 443
 )

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_5_1_0/cloudconfig.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_5_1_0/cloudconfig.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultRegistryDomain            = "quay.io"
 	defaultImagePullProgressDeadline = "1m"
-	kubernetesImage                  = "giantswarm/hyperkube:v1.16.8-429-retry-disabled"
+	kubernetesImage                  = "giantswarm/hyperkube:v1.16.8"
 	etcdImage                        = "giantswarm/etcd:v3.3.17"
 	etcdPort                         = 443
 )


### PR DESCRIPTION
This is brute force PR to build `azure-operator` with custom images in order to try 429 mitigation in autorest library. It has basically removal of `HTTP 429` from retryable error list. 