### PR TITLE
Fix isReady() when ensuring node is ready during instance upgrades

### DIFF
--- a/service/controller/resource/instance/create_wait_for_nodes_to_become_ready.go
+++ b/service/controller/resource/instance/create_wait_for_nodes_to_become_ready.go
@@ -124,7 +124,7 @@ func isWorker(n corev1.Node) bool {
 
 func isReady(n corev1.Node) bool {
 	for _, c := range n.Status.Conditions {
-		if c.Type == corev1.NodeReady {
+		if c.Type == corev1.NodeReady && c.Reason == "KubeletReady" {
 			return true
 		}
 	}

--- a/service/controller/resource/instance/create_wait_for_nodes_to_become_ready.go
+++ b/service/controller/resource/instance/create_wait_for_nodes_to_become_ready.go
@@ -124,7 +124,7 @@ func isWorker(n corev1.Node) bool {
 
 func isReady(n corev1.Node) bool {
 	for _, c := range n.Status.Conditions {
-		if c.Type == corev1.NodeReady && c.Reason == "KubeletReady" {
+		if c.Type == corev1.NodeReady && c.Status == corev1.ConditionTrue && c.Reason == "KubeletReady" {
 			return true
 		}
 	}


### PR DESCRIPTION
Node status conditions have type and reason and both must be matched correctly
in order to detect node readiness correctly. This change mainly affects cluster
upgrade.