### PR TITLE
Helm preparation to get component versions from releases

### DIFF
--- a/helm/azure-operator-chart/templates/configmap.yaml
+++ b/helm/azure-operator-chart/templates/configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: azure-operator-configmap
-  namespace: {{ .Values.namespace }}
+  name: {{ tpl .Values.resource.default.name . }}
+  namespace: {{ tpl .Values.resource.default.namespace . }}
 data:
   config.yaml: |
     server:
@@ -38,6 +38,12 @@ data:
         {{- end }}
       kubernetes:
         incluster: true
+      feature:
+        labelselector:
+          enabled: '{{ .Values.flag.service.feature.labelselector.enabled }}'
       tenant:
         ssh:
           ssoPublicKey: '{{ .Values.Installation.V1.Guest.SSH.SSOPublicKey }}'
+      test:
+        labelselector:
+          version: '{{ .Values.flag.service.test.labelselector.version }}'

--- a/helm/azure-operator-chart/templates/deployment.yaml
+++ b/helm/azure-operator-chart/templates/deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: azure-operator
-  namespace: {{ .Values.namespace }}
+  name: {{ tpl .Values.resource.default.name .}}
+  namespace: {{ tpl .Values.resource.default.namespace . }}
   labels:
-    app: azure-operator
+    app: {{ tpl .Values.resource.default.name . }}
   annotations:
     checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 spec:
@@ -12,7 +12,7 @@ spec:
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: azure-operator
+      app: {{ tpl .Values.resource.default.name . }}
       version: {{ .Chart.Version }}
   strategy:
     type: RollingUpdate
@@ -21,37 +21,37 @@ spec:
       annotations:
         releasetime: {{ $.Release.Time }}
       labels:
-        app: azure-operator
+        app: {{ tpl .Values.resource.default.name . }}
         version: {{ .Chart.Version }}
     spec:
       volumes:
-      - name: azure-operator-configmap
+      - name: {{ .Values.project.name }}-configmap
         configMap:
-          name: azure-operator-configmap
+          name: {{ tpl .Values.resource.default.name . }}
           items:
           - key: config.yaml
             path: config.yaml
-      - name: azure-operator-secret
+      - name: {{ .Values.project.name }}-secret
         secret:
-          secretName: azure-operator-secret
+          secretName: {{ tpl .Values.resource.default.name . }}
           items:
           - key: secret.yaml
             path: secret.yaml
       - name: certs
         hostPath:
           path: /etc/ssl/certs/ca-certificates.crt
-      serviceAccountName: azure-operator
+      serviceAccountName: {{ tpl .Values.resource.default.name . }}
       securityContext:
-        runAsUser: {{ .Values.userID }}
-        runAsGroup: {{ .Values.groupID }}
+        runAsUser: {{ .Values.pod.user.id }}
+        runAsGroup: {{ .Values.pod.group.id }}
       containers:
-      - name: azure-operator
-        image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+      - name: {{ .Values.project.name }}
+        image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         volumeMounts:
-        - name: azure-operator-configmap
-          mountPath: /var/run/azure-operator/configmap/
-        - name: azure-operator-secret
-          mountPath: /var/run/azure-operator/secret/
+        - name: {{ .Values.project.name }}-configmap
+          mountPath: /var/run/{{ .Values.project.name }}/configmap/
+        - name: {{ .Values.project.name }}-secret
+          mountPath: /var/run/{{ .Values.project.name }}/secret/
           readOnly: true
         - name: certs
           mountPath: /etc/ssl/certs/ca-certificates.crt
@@ -61,8 +61,8 @@ spec:
           containerPort: 8000
         args:
         - daemon
-        - --config.dirs=/var/run/azure-operator/configmap/
-        - --config.dirs=/var/run/azure-operator/secret/
+        - --config.dirs=/var/run/{{ .Values.project.name }}/configmap/
+        - --config.dirs=/var/run/{{ .Values.project.name }}/secret/
         - --config.files=config
         - --config.files=secret
         livenessProbe:
@@ -85,4 +85,4 @@ spec:
             cpu: 250m
             memory: 250Mi
       imagePullSecrets:
-      - name: azure-operator-pull-secret
+      - name: {{ tpl .Values.resource.pullSecret.name . }}

--- a/helm/azure-operator-chart/templates/psp.yaml
+++ b/helm/azure-operator-chart/templates/psp.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: azure-operator-psp
+  name: {{ tpl .Values.resource.psp.name . }}
 spec:
   privileged: false
   fsGroup:

--- a/helm/azure-operator-chart/templates/pull-secret.yml
+++ b/helm/azure-operator-chart/templates/pull-secret.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
-  name: azure-operator-pull-secret
-  namespace: {{ .Values.namespace }}
+  name: {{ tpl .Values.resource.pullSecret.name . }}
+  namespace: {{ tpl .Values.resource.pullSecret.namespace . }}
 data:
   .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}

--- a/helm/azure-operator-chart/templates/rbac.yaml
+++ b/helm/azure-operator-chart/templates/rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: azure-operator
+  name: {{ tpl .Values.resource.default.name . }}
 rules:
   - apiGroups:
       - apiextensions.k8s.io
@@ -34,6 +34,12 @@ rules:
       - patch
       - update
   - apiGroups:
+      - release.giantswarm.io
+    resources:
+      - releases
+    verbs:
+      - get
+  - apiGroups:
       - ""
     resources:
       - namespaces
@@ -58,14 +64,6 @@ rules:
       - get
       - list
       - watch
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    resourceNames:
-      - aws-operator-configmap
-    verbs:
-      - get
   - nonResourceURLs:
       - "/"
       - "/healthz"
@@ -75,20 +73,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: azure-operator
+  name: {{ tpl .Values.resource.default.name . }}
 subjects:
   - kind: ServiceAccount
-    name: azure-operator
-    namespace: {{ .Values.namespace }}
+    name: {{ tpl .Values.resource.default.name . }}
+    namespace: {{ tpl .Values.resource.default.namespace . }}
 roleRef:
   kind: ClusterRole
-  name: azure-operator
+  name: {{ tpl .Values.resource.default.name . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: azure-operator-psp
+  name: {{ tpl .Values.resource.psp.name . }}
 rules:
   - apiGroups:
       - extensions
@@ -97,17 +95,17 @@ rules:
     verbs:
       - use
     resourceNames:
-      - azure-operator-psp
+      - {{ tpl .Values.resource.psp.name . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: azure-operator-psp
+  name: {{ tpl .Values.resource.psp.name . }}
 subjects:
   - kind: ServiceAccount
-    name: azure-operator
-    namespace: {{ .Values.namespace }}
+    name: {{ tpl .Values.resource.default.name . }}
+    namespace: {{ tpl .Values.resource.default.namespace . }}
 roleRef:
   kind: ClusterRole
-  name: azure-operator-psp
+  name: {{ tpl .Values.resource.psp.name . }}
   apiGroup: rbac.authorization.k8s.io

--- a/helm/azure-operator-chart/templates/secret.yaml
+++ b/helm/azure-operator-chart/templates/secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: azure-operator-secret
-  namespace: {{ .Values.namespace }}
+  name: {{ tpl .Values.resource.default.name . }}
+  namespace: {{ tpl .Values.resource.default.namespace . }}
 data:
   secret.yaml: {{ .Values.Installation.V1.Secret.AzureOperator.SecretYaml | b64enc | quote }}

--- a/helm/azure-operator-chart/templates/service-account.yaml
+++ b/helm/azure-operator-chart/templates/service-account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ tpl .Values.default.resource.name . }}
-  namespace: {{ tpl .Values.default.resource.namespace . }}
+  name: {{ tpl .Values.resource.default.name . }}
+  namespace: {{ tpl .Values.resource.default.namespace . }}

--- a/helm/azure-operator-chart/templates/service-account.yaml
+++ b/helm/azure-operator-chart/templates/service-account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: azure-operator
-  namespace: {{ .Values.namespace }}
+  name: {{ tpl .Values.default.resource.name . }}
+  namespace: {{ tpl .Values.default.resource.namespace . }}

--- a/helm/azure-operator-chart/templates/service.yaml
+++ b/helm/azure-operator-chart/templates/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ tpl .Values.default.resource.name . }}
-  namespace: {{ tpl .Values.default.resource.namespace . }}
+  name: {{ tpl .Values.resource.default.name . }}
+  namespace: {{ tpl .Values.resource.default.namespace . }}
   labels:
-    app: {{ tpl .Values.default.resource.name . }}
+    app: {{ tpl .Values.resource.default.name . }}
     version: thiccc
   annotations:
     prometheus.io/scrape: "true"
@@ -13,5 +13,5 @@ spec:
   ports:
   - port: 8000
   selector:
-    app: {{ tpl .Values.default.resource.name . }}
+    app: {{ tpl .Values.resource.default.name . }}
     version: thiccc

--- a/helm/azure-operator-chart/templates/service.yaml
+++ b/helm/azure-operator-chart/templates/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: azure-operator
-  namespace: {{ .Values.namespace }}
+  name: {{ tpl .Values.default.resource.name . }}
+  namespace: {{ tpl .Values.default.resource.namespace . }}
   labels:
-    app: azure-operator
+    app: {{ tpl .Values.default.resource.name . }}
     version: {{ .Chart.Version }}
   annotations:
     prometheus.io/scrape: "true"
@@ -13,5 +13,5 @@ spec:
   ports:
   - port: 8000
   selector:
-    app: azure-operator
+    app: {{ tpl .Values.default.resource.name . }}
     version: {{ .Chart.Version }}

--- a/helm/azure-operator-chart/values.yaml
+++ b/helm/azure-operator-chart/values.yaml
@@ -1,9 +1,44 @@
-namespace: giantswarm
-
+flag:
+  service:
+    feature:
+      labelselector:
+        enabled: false
+    test:
+      labelselector:
+        version: ""
 image:
-  registry: "quay.io"
   name: "giantswarm/azure-operator"
   tag: "[[ .SHA ]]"
+Installation:
+  V1:
+    Registry:
+      Domain: quay.io
+pod:
+  user:
+    id: 1000
+  group:
+    id: 1000
+project:
+  name: "azure-operator"
+  version: "[[ .Version ]]"
 
-userID: 1000
-groupID: 1000
+# Resource names are truncated to 47 characters. Kubernetes allows 63 characters
+# limit for resource names. When pods for deployments are created they have
+# additional 16 characters suffix, e.g. "-957c9d6ff-pkzgw" and we want to have
+# room for those suffixes.
+#
+# NOTE: All values under resource key need to be used with `tpl` to render them
+# correctly in the templates. This is because helm doesn't template values.yaml
+# file and it has to be a valid json. Example usage:
+#
+#     {{ tpl .Values.resource.default.name . }}.
+#
+resource:
+  default:
+    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}'
+    namespace: "giantswarm"
+  psp:
+    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-psp'
+  pullSecret:
+    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-pull-secret'
+    namespace: "giantswarm"


### PR DESCRIPTION
These changes prepare Helm deployment templates to get cluster component
versions from releases instead of k8scloudconfig.

Towards https://github.com/giantswarm/giantswarm/issues/8436