### PR TITLE
No need to send to metrics channel already registered metrics

### DIFF
--- a/service/collector/rate_limit.go
+++ b/service/collector/rate_limit.go
@@ -196,7 +196,6 @@ func (u *RateLimit) Collect(ch chan<- prometheus.Metric) error {
 				u.logger.Log("level", "warning", "message", "an error occurred parsing to float the value inside the rate limiting header for write requests", "stack", microerror.Stack(microerror.Mask(err)))
 				writes = 0
 				writesErrorCounter.Inc()
-				ch <- writesErrorCounter
 			}
 
 			ch <- prometheus.MustNewConstMetric(
@@ -221,7 +220,6 @@ func (u *RateLimit) Collect(ch chan<- prometheus.Metric) error {
 				u.logger.Log("level", "warning", "message", "an error occurred parsing to float the value inside the rate limiting header for read requests", "stack", microerror.Stack(microerror.Mask(err)))
 				reads = 0
 				readsErrorCounter.Inc()
-				ch <- readsErrorCounter
 			}
 
 			ch <- prometheus.MustNewConstMetric(

--- a/service/collector/usage.go
+++ b/service/collector/usage.go
@@ -149,7 +149,6 @@ func (u *Usage) Collect(ch chan<- prometheus.Metric) error {
 		if err != nil {
 			u.logger.Log("level", "warning", "message", "an error occurred during the scraping of current compute resource usage information", "stack", fmt.Sprintf("%v", err))
 			u.usageScrapeError.Inc()
-			ch <- u.usageScrapeError
 		} else {
 			for r.NotDone() {
 				for _, v := range r.Values() {

--- a/service/collector/vmss_rate_limit.go
+++ b/service/collector/vmss_rate_limit.go
@@ -183,7 +183,6 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 				// Header not found, we consider this an error.
 				if len(headers) == 0 {
 					vmssVMListErrorCounter.Inc()
-					ch <- vmssVMListErrorCounter
 					continue
 				}
 
@@ -196,7 +195,6 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 						if len(kv) != 2 {
 							// We expect exactly two tokens, otherwise we consider this a parsing error.
 							vmssVMListErrorCounter.Inc()
-							ch <- vmssVMListErrorCounter
 							continue
 						}
 
@@ -204,7 +202,6 @@ func (u *VMSSRateLimit) Collect(ch chan<- prometheus.Metric) error {
 						val, err := strconv.ParseFloat(kv[1], 64)
 						if err != nil {
 							vmssVMListErrorCounter.Inc()
-							ch <- vmssVMListErrorCounter
 							continue
 						}
 


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/9298

Backported https://github.com/giantswarm/azure-operator/pull/722