### PR TITLE
Hardcode selector label since it can't be changed when using apps/v1 apiversion

### DIFF
--- a/helm/azure-operator-chart/templates/deployment.yaml
+++ b/helm/azure-operator-chart/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     app: azure-operator
+    version: thiccc
   annotations:
     checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 spec:
@@ -13,7 +14,7 @@ spec:
   selector:
     matchLabels:
       app: azure-operator
-      version: {{ .Chart.Version }}
+      version: thiccc
   strategy:
     type: RollingUpdate
   template:
@@ -22,7 +23,7 @@ spec:
         releasetime: {{ $.Release.Time }}
       labels:
         app: azure-operator
-        version: {{ .Chart.Version }}
+        version: thiccc
     spec:
       volumes:
       - name: azure-operator-configmap

--- a/helm/azure-operator-chart/templates/service.yaml
+++ b/helm/azure-operator-chart/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     app: azure-operator
-    version: {{ .Chart.Version }}
+    version: thiccc
   annotations:
     prometheus.io/scrape: "true"
 spec:
@@ -14,4 +14,4 @@ spec:
   - port: 8000
   selector:
     app: azure-operator
-    version: {{ .Chart.Version }}
+    version: thiccc


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/9440

When redeploying `thiccc` branch, kubernetes complained because the label `version` is immutable using `apps/v1` apiVersion. Instead of using the git sha as version just harcode the `thiccc` string, since there will be only one `thiccc` deployment.