### PR TITLE
Disable AZs from GWC because they're not supported.

### DIFF
--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -52,10 +52,14 @@ const (
 	CertificateEncryptionIVName    = "encryptioniv"
 
 	CoreosVersion = "2303.4.0"
+
+	ClusterIDLabel = "giantswarm.io/cluster"
 )
 
-const (
-	ClusterIDLabel = "giantswarm.io/cluster"
+var (
+	LocationsThatDontSupportAZs = []string{
+		"germanywestcentral",
+	}
 )
 
 func AdminUsername(customObject providerv1alpha1.AzureConfig) string {
@@ -314,7 +318,13 @@ func RouteTableName(customObject providerv1alpha1.AzureConfig) string {
 }
 
 // AvailabilityZones returns the availability zones where the cluster will be created.
-func AvailabilityZones(customObject providerv1alpha1.AzureConfig) []int {
+func AvailabilityZones(customObject providerv1alpha1.AzureConfig, location string) []int {
+	for _, l := range LocationsThatDontSupportAZs {
+		if l == location {
+			return []int{}
+		}
+	}
+
 	if customObject.Spec.Azure.AvailabilityZones == nil {
 		return []int{}
 	}

--- a/service/controller/resource/instance/create_deployment_completed.go
+++ b/service/controller/resource/instance/create_deployment_completed.go
@@ -34,7 +34,7 @@ func (r *Resource) deploymentCompletedTransition(ctx context.Context, obj interf
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deployment is in state '%s'", s))
 
 	if key.IsSucceededProvisioningState(s) {
-		computedDeployment, err := r.newDeployment(ctx, cr, nil)
+		computedDeployment, err := r.newDeployment(ctx, cr, nil, *d.Location)
 		if blobclient.IsBlobNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "ignition blob not found")
 			return currentState, nil

--- a/service/controller/resource/instance/create_deployment_uninitialized.go
+++ b/service/controller/resource/instance/create_deployment_uninitialized.go
@@ -23,10 +23,19 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}
+	groupsClient, err := r.getGroupsClient(ctx)
+	if err != nil {
+		return currentState, microerror.Mask(err)
+	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring deployment")
 
-	computedDeployment, err := r.newDeployment(ctx, cr, nil)
+	group, err := groupsClient.Get(ctx, key.ClusterID(cr))
+	if err != nil {
+		return currentState, microerror.Mask(err)
+	}
+
+	computedDeployment, err := r.newDeployment(ctx, cr, nil, *group.Location)
 	if controllercontext.IsInvalidContext(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "missing dispatched output values in controller context")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "did not ensure deployment")

--- a/service/controller/resource/instance/deployment.go
+++ b/service/controller/resource/instance/deployment.go
@@ -18,7 +18,7 @@ import (
 	"github.com/giantswarm/azure-operator/service/controller/templates"
 )
 
-func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureConfig, overwrites map[string]interface{}) (azureresource.Deployment, error) {
+func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureConfig, overwrites map[string]interface{}, location string) (azureresource.Deployment, error) {
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return azureresource.Deployment{}, microerror.Mask(err)
@@ -110,7 +110,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 		"workerCloudConfigData": workerCloudConfig,
 		"workerNodes":           getWorkerNodesConfiguration(obj),
 		"workerSubnetID":        cc.WorkerSubnetID,
-		"zones":                 key.AvailabilityZones(obj),
+		"zones":                 key.AvailabilityZones(obj, location),
 	}
 
 	d := azureresource.Deployment{

--- a/service/controller/resource/instance/resource.go
+++ b/service/controller/resource/instance/resource.go
@@ -94,6 +94,15 @@ func (r *Resource) getDeploymentsClient(ctx context.Context) (*azureresource.Dep
 	return cc.AzureClientSet.DeploymentsClient, nil
 }
 
+func (r *Resource) getGroupsClient(ctx context.Context) (*azureresource.GroupsClient, error) {
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return cc.AzureClientSet.GroupsClient, nil
+}
+
 func (r *Resource) getScaleSetsClient(ctx context.Context) (*compute.VirtualMachineScaleSetsClient, error) {
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {


### PR DESCRIPTION
This PR disables the multi AZ feature for the germanywestcentral region, because AZs are not supported in there.

Note: e2e tests are failing for a different reason, Celestial is working to fix that.
Note2: this has been tested in both GWC and in another region and it seems to be working just fine.