### PR TITLE
Revert cloudconfig 5.1.1 added to use k8s 1.16.7

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -407,7 +407,7 @@
   name = "github.com/giantswarm/k8scloudconfig"
   packages = [
     "ignition/v_2_2_0",
-    "v_5_1_1",
+    "v_5_1_0",
   ]
   pruneopts = "T"
   revision = "a952556a3a7ed07f8d126f095f996d5c0378a3a8"
@@ -2044,7 +2044,7 @@
     "github.com/giantswarm/ipam",
     "github.com/giantswarm/k8sclient",
     "github.com/giantswarm/k8sclient/k8srestconfig",
-    "github.com/giantswarm/k8scloudconfig/v_5_1_1",
+    "github.com/giantswarm/k8scloudconfig/v_5_1_0",
     "github.com/giantswarm/microendpoint/endpoint/healthz",
     "github.com/giantswarm/microendpoint/endpoint/version",
     "github.com/giantswarm/microendpoint/service/version",

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -35,7 +35,7 @@ func NewVersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "kubernetes",
-				Version: "1.16.7",
+				Version: "1.16.3",
 			},
 		},
 		Name:    Name(),

--- a/service/controller/cloudconfig/cloud_config.go
+++ b/service/controller/cloudconfig/cloud_config.go
@@ -3,7 +3,7 @@ package cloudconfig
 import (
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_5_1_1"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_5_1_0"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/randomkeys"

--- a/service/controller/cloudconfig/master_template.go
+++ b/service/controller/cloudconfig/master_template.go
@@ -6,7 +6,7 @@ import (
 
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_5_1_1"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_5_1_0"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/azure-operator/service/controller/encrypter"

--- a/service/controller/cloudconfig/worker_template.go
+++ b/service/controller/cloudconfig/worker_template.go
@@ -5,7 +5,7 @@ import (
 
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_5_1_1"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_5_1_0"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/azure-operator/service/controller/encrypter"


### PR DESCRIPTION
This doesn't make sense anymore since we are going with cloudconfig 6.x.x.

Removing also from cloudconfig https://github.com/giantswarm/k8scloudconfig/pull/669