### PR TITLE
[Demo] Just set VMSS dataDisks, instead of using copy

### DIFF
--- a/service/controller/resource/instance/template/main.json
+++ b/service/controller/resource/instance/template/main.json
@@ -113,15 +113,33 @@
             "value":[
               {
                 "name":"EtcdDisk",
-                "sizeGB":100
+                "diskSizeGB":100,
+                "lun": 0,
+                "caching": "None",
+                "createOption":"Empty",
+                "managedDisk":{
+                  "storageAccountType":"Premium_LRS"
+                }
               },
               {
                 "name":"DockerDisk",
-                "sizeGB":"[if(greater(parameters('masterNodes')[0].dockerVolumeSizeGB, 0), parameters('masterNodes')[0].dockerVolumeSizeGB, 50)]"
+                "diskSizeGB":"[if(greater(parameters('masterNodes')[0].dockerVolumeSizeGB, 0), parameters('masterNodes')[0].dockerVolumeSizeGB, 50)]",
+                "lun": 1,
+                "caching": "None",
+                "createOption":"Empty",
+                "managedDisk":{
+                  "storageAccountType":"Premium_LRS"
+                }
               },
               {
                 "name":"KubeletDisk",
-                "sizeGB":"[if(greater(parameters('masterNodes')[0].kubeletVolumeSizeGB, 0), parameters('masterNodes')[0].kubeletVolumeSizeGB, 100)]"
+                "diskSizeGB":"[if(greater(parameters('masterNodes')[0].kubeletVolumeSizeGB, 0), parameters('masterNodes')[0].kubeletVolumeSizeGB, 100)]",
+                "lun": 2,
+                "caching": "None",
+                "createOption":"Empty",
+                "managedDisk":{
+                  "storageAccountType":"Premium_LRS"
+                }
               }
             ]
           },
@@ -204,11 +222,23 @@
             "value":[
               {
                 "name":"DockerDisk",
-                "sizeGB":"[if(greater(parameters('workerNodes')[0].dockerVolumeSizeGB, 0), parameters('workerNodes')[0].dockerVolumeSizeGB, 50)]"
+                "diskSizeGB":"[if(greater(parameters('workerNodes')[0].dockerVolumeSizeGB, 0), parameters('workerNodes')[0].dockerVolumeSizeGB, 50)]",
+                "lun": 0,
+                "caching": "None",
+                "createOption":"Empty",
+                "managedDisk":{
+                  "storageAccountType":"Premium_LRS"
+                }
               },
               {
                 "name":"KubeletDisk",
-                "sizeGB":"[if(greater(parameters('workerNodes')[0].kubeletVolumeSizeGB, 0), parameters('workerNodes')[0].kubeletVolumeSizeGB, 100)]"
+                "diskSizeGB":"[if(greater(parameters('workerNodes')[0].kubeletVolumeSizeGB, 0), parameters('workerNodes')[0].kubeletVolumeSizeGB, 100)]",
+                "lun": 1,
+                "caching": "None",
+                "createOption":"Empty",
+                "managedDisk":{
+                  "storageAccountType":"Premium_LRS"
+                }
               }
             ]
           },

--- a/service/controller/resource/instance/template/vmss.json
+++ b/service/controller/resource/instance/template/vmss.json
@@ -238,21 +238,7 @@
                 "storageAccountType":"[variables('vmssStorageAccountType')]"
               }
             },
-            "copy":[
-              {
-                "name":"dataDisks",
-                "count":"[length(parameters('vmssVmDataDisks'))]",
-                "input":{
-                  "caching":"ReadWrite",
-                  "createOption":"Empty",
-                  "diskSizeGB":"[parameters('vmssVmDataDisks')[copyIndex('dataDisks')].sizeGB]",
-                  "managedDisk":{
-                    "storageAccountType":"[variables('vmssStorageAccountType')]"
-                  },
-                  "lun":"[parameters('vmssVmDataDisks')[copyIndex('dataDisks')].lun]]"
-                }
-              }
-            ]
+            "dataDisks":"[parameters('vmssVmDataDisks')]"
           },
           "networkProfile":{
             "networkInterfaceConfigurations":[


### PR DESCRIPTION
The idea here is to just set `dataDisks` field for VMSS `storageProfile`, instead of using ARM `copy` function.

Changes:
- `vmssVmDataDisks` in `main.json` has to be in exact same format as `virtualMachineProfile.storageProfile.dataDisks`.
- In `vmss.json`, `dataDisks` is just set to `vmssVmDataDisks` array.
- Setting `caching` to none, according to some advices found [here](https://stian.tech/disk-performance-on-aks-part-1/) and [here](https://github.com/jnoller/kubernaughty/issues/42)

**Just for demo purposes, some stuff is hardcoded.**