### PR TITLE
Only roll nodes when they aren't in sync with provider operator

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2049,6 +2049,7 @@
     "github.com/Azure/go-autorest/autorest/adal",
     "github.com/Azure/go-autorest/autorest/azure",
     "github.com/Azure/go-autorest/autorest/to",
+    "github.com/coreos/go-semver/semver",
     "github.com/docker/distribution/reference",
     "github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1",
     "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1",

--- a/service/controller/resource/instance/create_cluster_upgrade_requirement_check.go
+++ b/service/controller/resource/instance/create_cluster_upgrade_requirement_check.go
@@ -22,7 +22,7 @@ func (r *Resource) clusterUpgradeRequirementCheckTransition(ctx context.Context,
 	}
 
 	isCreating := r.isClusterCreating(cr)
-	anyOldNodes, err := r.anyNodesOutOfDate(ctx, cr)
+	anyOldNodes, err := r.anyNodesOutOfDate(ctx)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
@@ -54,7 +54,7 @@ func (r *Resource) isClusterCreating(cr providerv1alpha1.AzureConfig) bool {
 // corresponding azure-operator version from node labels. If node doesn't have
 // this label or was created with older version than currently reconciling one,
 // then this function returns true. Otherwise (including on error) false.
-func (r *Resource) anyNodesOutOfDate(ctx context.Context, cr providerv1alpha1.AzureConfig) (bool, error) {
+func (r *Resource) anyNodesOutOfDate(ctx context.Context) (bool, error) {
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return false, microerror.Mask(err)


### PR DESCRIPTION
It is difficult to detect different change scenarious with Azure APIs /
infrastructure and that has invoked full upgrade process e.g. when creating
cluster or scaling despite of many checks that try to test for such situation.

On principal rolling of node should not be needed other than when clusters are
upgrading or when certificates need renewal. This change introduces first of
these so upgrade process only executes through when there are nodes with old
azure-operator version labels. Similar case for expiring certificates should be
added later if needed.