### PR TITLE
Disabled Prometheus scrapping

### DIFF
--- a/helm/azure-operator/templates/service.yaml
+++ b/helm/azure-operator/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "azure-operator.labels" . | nindent 4 }}
   annotations:
-    prometheus.io/scrape: "true"
+    prometheus.io/scrape: "false"
 spec:
   type: NodePort
   ports:


### PR DESCRIPTION
We are disabling Prometheus scrapping on `master` branch. We will keep collecting metrics from `thiccc` branch only.