### PR TITLE
New node detection

### DIFF
--- a/service/controller/resource/instance/create_cordon_old_workers.go
+++ b/service/controller/resource/instance/create_cordon_old_workers.go
@@ -144,7 +144,6 @@ func sortNodesByTenantVMState(nodes []corev1.Node, instances []compute.VirtualMa
 			// When VMSS is scaling up there might be VM instances that haven't
 			// registered as nodes in k8s yet. Hence not all instances are
 			// found from node list.
-			oldNodes = append(oldNodes, n)
 			continue
 		}
 

--- a/service/controller/resource/instance/create_cordon_old_workers.go
+++ b/service/controller/resource/instance/create_cordon_old_workers.go
@@ -149,8 +149,9 @@ func sortNodesByTenantVMState(nodes []corev1.Node, instances []compute.VirtualMa
 
 		v, exists := n.GetLabels()[label.OperatorVersion]
 		if !exists {
-			// Label does not exist, we consider node as old.
-			oldNodes = append(oldNodes, n)
+			// Label does not exist, this normally happens when a new node is coming up but did not finish
+			// its kubernetes bootstrap yet and thus doesn't have all the needed labels.
+			// We'll ignore this node for now and wait for it to bootstrap correctly.
 			continue
 		}
 

--- a/service/controller/resource/instance/deployment.go
+++ b/service/controller/resource/instance/deployment.go
@@ -12,7 +12,6 @@ import (
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/azure-operator/pkg/project"
 	"github.com/giantswarm/azure-operator/service/controller/blobclient"
 	"github.com/giantswarm/azure-operator/service/controller/controllercontext"
 	"github.com/giantswarm/azure-operator/service/controller/key"
@@ -101,7 +100,6 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 	}
 
 	defaultParams := map[string]interface{}{
-		"azureOperatorVersion":  project.Version(),
 		"apiLBBackendPoolID":    cc.APILBBackendPoolID,
 		"clusterID":             key.ClusterID(obj),
 		"etcdLBBackendPoolID":   cc.EtcdLBBackendPoolID,

--- a/service/controller/resource/instance/deployment.go
+++ b/service/controller/resource/instance/deployment.go
@@ -12,6 +12,7 @@ import (
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
+	"github.com/giantswarm/azure-operator/pkg/project"
 	"github.com/giantswarm/azure-operator/service/controller/blobclient"
 	"github.com/giantswarm/azure-operator/service/controller/controllercontext"
 	"github.com/giantswarm/azure-operator/service/controller/key"
@@ -100,6 +101,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 	}
 
 	defaultParams := map[string]interface{}{
+		"azureOperatorVersion":  project.Version(),
 		"apiLBBackendPoolID":    cc.APILBBackendPoolID,
 		"clusterID":             key.ClusterID(obj),
 		"etcdLBBackendPoolID":   cc.EtcdLBBackendPoolID,

--- a/service/controller/resource/instance/template/vmss.json
+++ b/service/controller/resource/instance/template/vmss.json
@@ -98,8 +98,8 @@
       }
     ],
     "vmssResourceId":"[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
-    "vmssSinglePlacementGroup":"true"
-    "vmssVmNamePrefix":"[concat(toLower(parameters('vmssName')), '-')]",
+    "vmssSinglePlacementGroup":"true",
+    "vmssVmNamePrefix":"[concat(toLower(parameters('vmssName')), '-')]"
   },
   "resources":[
     {

--- a/service/controller/resource/instance/template/vmss.json
+++ b/service/controller/resource/instance/template/vmss.json
@@ -98,8 +98,8 @@
       }
     ],
     "vmssResourceId":"[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
-    "vmssVmNamePrefix":"[concat(toLower(parameters('vmssName')), '-')]",
     "vmssSinglePlacementGroup":"true"
+    "vmssVmNamePrefix":"[concat(toLower(parameters('vmssName')), '-')]",
   },
   "resources":[
     {


### PR DESCRIPTION
See https://github.com/giantswarm/giantswarm/issues/9921

We try to use a different approach to distinguish between old nodes and new nodes during an upgrade.
Instead of relying on the `Latest model` field provided by azure, we use a tag we set to the VMSS containing the release version.
We hope that the tag is propagated to the instances of the VMSS only when they are upgraded to the new model.