### PR TITLE
Bump to v3.0.5 for release v11.2.2

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "3.0.5-dev"
+	version            = "3.0.5"
 )
 
 func Description() string {


### PR DESCRIPTION
See [releases pull request](https://github.com/giantswarm/releases/pull/216) for more details.