### PR TITLE
Add Metrics SendDecorator for Azure SDK clients

### DIFF
--- a/client/senddecorator/configurator.go
+++ b/client/senddecorator/configurator.go
@@ -2,19 +2,21 @@ package senddecorator
 
 import (
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/giantswarm/azure-operator/pkg/backpressure"
 )
 
-// ConfigureClient accepts backpressure instance and configures given autorest
-// Client instance with all local `autorest.SendDecorator` implementations in this
-// package.
+// ConfigureClient accepts backpressure and prometheus summary vector instances
+// and configures given autorest Client instance with all local
+// `autorest.SendDecorator` implementations in this package.
 //
 // Existing SendDecorators are preserved, but moved to end of slice.
-func ConfigureClient(g *backpressure.Backpressure, c *autorest.Client) {
+func ConfigureClient(g *backpressure.Backpressure, s *prometheus.SummaryVec, c *autorest.Client) {
 	c.SendDecorators = append([]autorest.SendDecorator{
 		// NOTE: Order matters here since these decorators are executed in
 		// order. See: https://godoc.org/github.com/Azure/go-autorest/autorest#Client
+		MetricsCollector(s),
 		RateLimitCircuitBreaker(g),
 	}, c.SendDecorators...)
 }

--- a/client/senddecorator/metrics.go
+++ b/client/senddecorator/metrics.go
@@ -1,0 +1,29 @@
+package senddecorator
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// MetricsCollector returns decorator that collects API call metrics.
+func MetricsCollector(m *prometheus.SummaryVec) autorest.SendDecorator {
+	return func(s autorest.Sender) autorest.Sender {
+		return autorest.SenderFunc(func(r *http.Request) (*http.Response, error) {
+
+			start := time.Now()
+
+			// Pass the request to next SendDecorator.
+			resp, err := s.Do(r)
+
+			elapsed := time.Since(start)
+
+			// Record latency as milliseconds.
+			m.WithLabelValues(string(resp.StatusCode)).Observe(elapsed.Seconds() * 1000)
+
+			return resp, err
+		})
+	}
+}


### PR DESCRIPTION
Add send decorator to Azure SDK clients that records API call's latency and
status code.