### PR TITLE
Get rid of LastModelApplied checks

### DIFF
--- a/service/controller/resource/instance/create_cordon_old_workers.go
+++ b/service/controller/resource/instance/create_cordon_old_workers.go
@@ -200,8 +200,8 @@ func (r *Resource) isWorkerInstanceFromPreviousRelease(ctx context.Context, cust
 	}
 
 	if n == nil {
-		// Kubernetes node related to this instance not found, we don't know if it's old or new.
-		return nil, nil
+		// Kubernetes node related to this instance not found, we consider the node old.
+		return &t, nil
 	}
 
 	myVersion := semver.New(project.Version())

--- a/service/controller/resource/instance/create_cordon_old_workers.go
+++ b/service/controller/resource/instance/create_cordon_old_workers.go
@@ -199,6 +199,11 @@ func (r *Resource) isWorkerInstanceFromPreviousRelease(ctx context.Context, cust
 		return nil, err
 	}
 
+	if n == nil {
+		// Kubernetes node related to this instance not found, we don't know if it's old or new.
+		return nil, nil
+	}
+
 	myVersion := semver.New(project.Version())
 
 	v, exists := n.GetLabels()[label.OperatorVersion]

--- a/service/controller/resource/instance/create_drain_old_worker_nodes.go
+++ b/service/controller/resource/instance/create_drain_old_worker_nodes.go
@@ -53,7 +53,12 @@ func (r *Resource) drainOldWorkerNodesTransition(ctx context.Context, obj interf
 
 	var nodesPendingDraining int
 	for _, i := range allWorkerInstances {
-		if *i.LatestModelApplied {
+		old, err := r.isWorkerInstanceFromPreviousRelease(ctx, cr, i)
+		if err != nil {
+			return DeploymentUninitialized, nil
+		}
+
+		if old != nil && *old {
 			continue
 		}
 

--- a/service/controller/resource/instance/create_drain_old_worker_nodes.go
+++ b/service/controller/resource/instance/create_drain_old_worker_nodes.go
@@ -58,7 +58,8 @@ func (r *Resource) drainOldWorkerNodesTransition(ctx context.Context, obj interf
 			return DeploymentUninitialized, nil
 		}
 
-		if old != nil && *old {
+		if old == nil || !*old {
+			// Node is a new one or we weren't able to check it's status, don't drain it.
 			continue
 		}
 

--- a/service/controller/resource/instance/create_terminate_old_workers.go
+++ b/service/controller/resource/instance/create_terminate_old_workers.go
@@ -47,7 +47,12 @@ func (r *Resource) terminateOldWorkersTransition(ctx context.Context, obj interf
 	{
 		var strIds []string
 		for _, i := range allWorkerInstances {
-			if !*i.LatestModelApplied {
+			old, err := r.isWorkerInstanceFromPreviousRelease(ctx, cr, i)
+			if err != nil {
+				return DeploymentUninitialized, nil
+			}
+
+			if old != nil && *old {
 				strIds = append(strIds, *i.InstanceID)
 			}
 		}


### PR DESCRIPTION
This PR removes all usages of the LastModelApplied field of the VMSS Instance type because it proved to be unreliable, at least on germany west central.

There is only one usage for it at the moment (in the update phase) but I guess we can't remove it from there.

