### PR TITLE
Disable cluster-state e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,14 +113,14 @@ workflows:
             branches:
               ignore: master
 
-      - architect/integration-test:
-          name: cluster-state-test
-          setup-script: "integration/config/setup.sh"
-          env-file: "integration/test/clusterstate/.env"
-          test-dir: "integration/test/clusterstate"
-          test-timeout: "90m"
-          requires:
-          - hold
+#      - architect/integration-test:
+#          name: cluster-state-test
+#          setup-script: "integration/config/setup.sh"
+#          env-file: "integration/test/clusterstate/.env"
+#          test-dir: "integration/test/clusterstate"
+#          test-timeout: "90m"
+#          requires:
+#          - hold
 
       - architect/integration-test:
           name: scaling-test


### PR DESCRIPTION
Currently, azure-operator doesn't automatically handle the rollout of master instances where there are changes on the ARM template. This makes this e2e test to fail.

We will enable it back when this is fixed.