### PR TITLE
CHeck for VMSS rates before scaling up worker nodes

### DIFF
--- a/service/controller/resource/instance/create_scale_workers.go
+++ b/service/controller/resource/instance/create_scale_workers.go
@@ -39,6 +39,12 @@ func (r *Resource) scaleUpWorkerVMSSTransition(ctx context.Context, obj interfac
 
 	allReady, err := vmsscheck.InstancesAreRunning(ctx, r.logger, key.ResourceGroupName(cr), key.WorkerVMSSName(cr))
 	if err != nil {
+		// VMSS rate limits are not safe, let's wait for next reconciliation loop.
+		if vmsscheck.IsVMSSUnsafeError(err) {
+			return ScaleUpWorkerVMSS, nil
+		}
+
+		// Unexpected error.
 		return "", microerror.Mask(err)
 	}
 	// Not all workers are Running in Azure, wait for next reconciliation loop.

--- a/service/controller/resource/instance/internal/vmsscheck/error.go
+++ b/service/controller/resource/instance/internal/vmsscheck/error.go
@@ -10,3 +10,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var vmssUnsafeError = &microerror.Error{
+	Kind: "vmssUnsafeError",
+}
+
+// IsVMSSUnsafeError asserts vmssUnsafeError.
+func IsVMSSUnsafeError(err error) bool {
+	return microerror.Cause(err) == vmssUnsafeError
+}

--- a/service/controller/resource/instance/internal/vmsscheck/guard_job.go
+++ b/service/controller/resource/instance/internal/vmsscheck/guard_job.go
@@ -12,29 +12,6 @@ import (
 const (
 	provisioningStateFailed    = "Failed"
 	provisioningStateSucceeded = "Succeeded"
-
-	// Key used to extract remaining number of calls for 30 minutes from remainingCallsHeaderName
-	remainingCallsHeaderKey30m = "Microsoft.Compute/HighCostGetVMScaleSet30Min"
-
-	// Key used to extract remaining number of calls for 3 minutes from remainingCallsHeaderName
-	remainingCallsHeaderKey3m = "Microsoft.Compute/HighCostGetVMScaleSet3Min"
-
-	// Response header name that has info about remaining number of HighCostGetVMScaleSet calls.
-	// Header example:
-	// Microsoft.Compute/HighCostGetVMScaleSet3Min;107,Microsoft.Compute/HighCostGetVMScaleSet30Min;827
-	remainingCallsHeaderName = "X-Ms-Ratelimit-Remaining-Resource"
-
-	// Max number of HighCostGetVMScaleSet calls that can be made during a 30-minute period
-	remainingCallsMax30m = 900
-
-	// Max number of HighCostGetVMScaleSet calls that can be made during a 3-minute period
-	remainingCallsMax3m = 190
-
-	// If the number of remaining calls for 30min drops below this threshold, we do not proceed
-	remainingCallsThreshold30m = remainingCallsMax30m * 0.5
-
-	// If the number of remaining calls for 3min drops below this threshold, we do not proceed
-	remainingCallsThreshold3m = remainingCallsMax3m * 0.5
 )
 
 type guardJob struct {
@@ -92,13 +69,6 @@ func (gj *guardJob) reimageFailedInstances(ctx context.Context, rg string, vmssN
 	iterator, err := c.ListComplete(ctx, rg, vmssName, "", "", "")
 	if err != nil {
 		return false, microerror.Mask(err)
-	}
-
-	// Check for rate limit. If current remaining API calls are less than the desired threshold, we don't proceed.
-	rl3m, rl30m := rateLimitThresholdsFromResponse(iterator.Response().Response)
-	if rl3m < remainingCallsThreshold3m || rl30m < remainingCallsThreshold30m {
-		gj.logger.LogCtx(ctx, "level", "warmomg", "message", fmt.Sprintf("The VMSS API remaining calls are not safe to continue (3m %d/%d, 30m %d/%d)", rl3m, remainingCallsMax3m, rl30m, remainingCallsMax30m))
-		return false, nil
 	}
 
 	allSucceeded := true

--- a/service/controller/resource/instance/internal/vmsscheck/vmss.go
+++ b/service/controller/resource/instance/internal/vmsscheck/vmss.go
@@ -14,6 +14,31 @@ import (
 	"github.com/giantswarm/azure-operator/service/controller/controllercontext"
 )
 
+const (
+	// Max number of HighCostGetVMScaleSet calls that can be made during a 30-minute period
+	remainingCallsMax30m = 900
+
+	// Max number of HighCostGetVMScaleSet calls that can be made during a 3-minute period
+	remainingCallsMax3m = 190
+
+	// Key used to extract remaining number of calls for 30 minutes from remainingCallsHeaderName
+	remainingCallsHeaderKey30m = "Microsoft.Compute/HighCostGetVMScaleSet30Min"
+
+	// Key used to extract remaining number of calls for 3 minutes from remainingCallsHeaderName
+	remainingCallsHeaderKey3m = "Microsoft.Compute/HighCostGetVMScaleSet3Min"
+
+	// Response header name that has info about remaining number of HighCostGetVMScaleSet calls.
+	// Header example:
+	// Microsoft.Compute/HighCostGetVMScaleSet3Min;107,Microsoft.Compute/HighCostGetVMScaleSet30Min;827
+	remainingCallsHeaderName = "X-Ms-Ratelimit-Remaining-Resource"
+
+	// If the number of remaining calls for 30min drops below this threshold, we do not proceed
+	remainingCallsThreshold30m = remainingCallsMax30m * 0.5
+
+	// If the number of remaining calls for 3min drops below this threshold, we do not proceed
+	remainingCallsThreshold3m = remainingCallsMax3m * 0.5
+)
+
 // Find out provisioning state of all VMSS instances and return true if all are
 // Succeeded.
 func InstancesAreRunning(ctx context.Context, logger micrologger.Logger, rg string, vmssName string) (bool, error) {
@@ -45,6 +70,16 @@ func InstancesAreRunning(ctx context.Context, logger micrologger.Logger, rg stri
 
 		if err := iterator.Next(); err != nil {
 			return false, microerror.Mask(err)
+		}
+	}
+
+	if allSucceeded {
+		// All instances are succeeded, let's check the VMSS rate is safe.
+		// If current remaining API calls are less than the desired threshold, we don't proceed.
+		rl3m, rl30m := rateLimitThresholdsFromResponse(iterator.Response().Response)
+		if rl3m < remainingCallsThreshold3m || rl30m < remainingCallsThreshold30m {
+			logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("The VMSS API remaining calls are not safe to continue (3m %d/%d, 30m %d/%d)", rl3m, remainingCallsMax3m, rl30m, remainingCallsMax30m)) // nolint: errcheck
+			return false, nil
 		}
 	}
 

--- a/service/controller/resource/instance/internal/vmsscheck/vmss.go
+++ b/service/controller/resource/instance/internal/vmsscheck/vmss.go
@@ -79,7 +79,7 @@ func InstancesAreRunning(ctx context.Context, logger micrologger.Logger, rg stri
 		rl3m, rl30m := rateLimitThresholdsFromResponse(iterator.Response().Response)
 		if rl3m < remainingCallsThreshold3m || rl30m < remainingCallsThreshold30m {
 			logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("The VMSS API remaining calls are not safe to continue (3m %d/%d, 30m %d/%d)", rl3m, remainingCallsMax3m, rl30m, remainingCallsMax30m)) // nolint: errcheck
-			return false, nil
+			return false, vmssUnsafeError
 		}
 	}
 


### PR DESCRIPTION
I moved the VMSS rate limit check from inside the guard job to just before the upscaling of worker vmss.
The most critical moment during an upgrade in terms of VMSS API calls is when a new node is added.
That's the moment when we need to check for the API to be in a safe state.