### PR TITLE
Override tested operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ TODO
 !/examples/local/*.tmpl.yaml
 
 integration/test/**/*-e2e
+azure-operator-*.tgz

--- a/docs/running_e2etests_locally.md
+++ b/docs/running_e2etests_locally.md
@@ -1,4 +1,4 @@
-# Running e2e tests locally
+# Running integration tests locally
 
 Build the application, which means compiling the Go code, building the docker image and the helm chart package.
 

--- a/docs/running_e2etests_locally.md
+++ b/docs/running_e2etests_locally.md
@@ -1,0 +1,25 @@
+# Running e2e tests locally
+
+Build the application, which means compiling the Go code, building the docker image and the helm chart package.
+
+```bash
+CGO_ENABLED=0 go build -a -v -ldflags "-w -linkmode 'auto' -extldflags '-static' -X 'main.gitCommit=`git rev-parse HEAD`'" \
+  && docker build -t "quay.io/giantswarm/azure-operator:`architect project version`" . \
+  && architect helm template --dir ./helm/azure-operator \
+  && helm package helm/azure-operator \
+  && git checkout HEAD -- ./helm/azure-operator/Chart.yaml ./helm/azure-operator/values.yaml \
+```
+
+Prepare the environment using kind
+
+```bash
+(kind delete cluster || true) && kind create cluster && kind load docker-image quay.io/giantswarm/azure-operator:`architect project version` \
+  && kind get kubeconfig > kubeconfig.yaml && sudo ln -fs "${PWD}/kubeconfig.yaml" /workdir/.shipyard/config \
+  && helm init --wait && k create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
+```
+
+
+You can then run the tests passing the helm chart package that we just generated
+```bash
+OPERATOR_HELM_TARBALL_PATH="${PWD}/azure-operator-`architect project version`.tgz" AZURE_SUBSCRIPTIONID="${AZURE_SUBSCRIPTIONID}" AZURE_TENANTID="${AZURE_TENANTID}" AZURE_CLIENTID="${AZURE_CLIENTID}" AZURE_CLIENTSECRET="${AZURE_CLIENTSECRET}" CIRCLE_SHA1="`git rev-parse HEAD`" REGISTRY_PULL_SECRET="${REGISTRY_PULL_SECRET}" TEST_DIR="integration/test/multiaz" AZURE_AZS=1 go test -v -tags=k8srequired ./integration/test/multiaz
+```

--- a/integration/env/common.go
+++ b/integration/env/common.go
@@ -14,16 +14,18 @@ import (
 const (
 	DefaultTestedVersion = "wip"
 
-	EnvVarCircleSHA            = "CIRCLE_SHA1" // #nosec
-	EnvVarKeepResources        = "KEEP_RESOURCES"
-	EnvVarRegistryPullSecret   = "REGISTRY_PULL_SECRET" // #nosec
-	EnvVarTestedVersion        = "TESTED_VERSION"
-	EnvVarTestDir              = "TEST_DIR"
-	EnvVarVersionBundleVersion = "VERSION_BUNDLE_VERSION"
+	EnvVarCircleSHA               = "CIRCLE_SHA1" // #nosec
+	EnvVarKeepResources           = "KEEP_RESOURCES"
+	EnvVarRegistryPullSecret      = "REGISTRY_PULL_SECRET" // #nosec
+	EnvVarOperatorHelmTarballPath = "OPERATOR_HELM_TARBALL_PATH"
+	EnvVarTestedVersion           = "TESTED_VERSION"
+	EnvVarTestDir                 = "TEST_DIR"
+	EnvVarVersionBundleVersion    = "VERSION_BUNDLE_VERSION"
 )
 
 var (
 	circleSHA            string
+	operatorTarballPath  string
 	registryPullSecret   string
 	testDir              string
 	testedVersion        string
@@ -33,6 +35,7 @@ var (
 
 func init() {
 	keepResources = os.Getenv(EnvVarKeepResources)
+	operatorTarballPath = os.Getenv(EnvVarOperatorHelmTarballPath)
 
 	circleSHA = os.Getenv(EnvVarCircleSHA)
 	if circleSHA == "" {
@@ -74,6 +77,10 @@ func init() {
 
 func CircleSHA() string {
 	return circleSHA
+}
+
+func OperatorHelmTarballPath() string {
+	return operatorTarballPath
 }
 
 // ClusterID returns a cluster ID unique to a run integration test. It might

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -274,6 +274,18 @@ func installResources(ctx context.Context, config Config) error {
 		}
 	}
 
+	var sshUserList []providerv1alpha1.ClusterKubernetesSSHUser
+	{
+		if env.SSHPublicKey() != "" {
+			sshUserList = []providerv1alpha1.ClusterKubernetesSSHUser{
+				{
+					Name:      "test-user",
+					PublicKey: env.SSHPublicKey(),
+				},
+			}
+		}
+	}
+
 	{
 		version := env.VersionBundleVersion()
 		if env.TestDir() == "integration/test/update" {
@@ -365,12 +377,7 @@ func installResources(ctx context.Context, config Config) error {
 							Port:     10250,
 						},
 						NetworkSetup: providerv1alpha1.ClusterKubernetesNetworkSetup{Docker: providerv1alpha1.ClusterKubernetesNetworkSetupDocker{Image: "quay.io/giantswarm/k8s-setup-network-environment:1f4ffc52095ac368847ce3428ea99b257003d9b9"}},
-						SSH: providerv1alpha1.ClusterKubernetesSSH{UserList: []providerv1alpha1.ClusterKubernetesSSHUser{
-							{
-								Name:      "test-user",
-								PublicKey: env.SSHPublicKey(),
-							},
-						}},
+						SSH:          providerv1alpha1.ClusterKubernetesSSH{UserList: sshUserList},
 					},
 				},
 				VersionBundle: providerv1alpha1.AzureConfigSpecVersionBundle{Version: version},

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -148,8 +148,8 @@ func GetLatestOperatorRelease() string {
 func installResources(ctx context.Context, config Config) error {
 	var err error
 
-	var operatorTarballPath string
-	{
+	operatorTarballPath := env.OperatorHelmTarballPath()
+	if operatorTarballPath == "" {
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "getting tarball URL for tested version")
 
 		operatorVersion := fmt.Sprintf("%s-%s", latestOperatorRelease, env.CircleSHA())
@@ -166,9 +166,9 @@ func installResources(ctx context.Context, config Config) error {
 		if err != nil {
 			return microerror.Mask(err)
 		}
-
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("tarball path for tested version is %#q", operatorTarballPath))
 	}
+
+	config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("tarball path for tested version is %#q", operatorTarballPath))
 
 	var latestReleasedOperatorTarballPath string
 	{


### PR DESCRIPTION
With these changes we are able to override the chart package used to install the operator, which allows us to pass a local path so we don't have to push and wait for CI to run tests locally.

I also added documentation on how to run e2e tests locally from dev machine.