### PR TITLE
Version bump to v3.1.0-dev

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "3.0.7"
+	version            = "3.1.0-dev"
 )
 
 func Description() string {


### PR DESCRIPTION
Bump to [`4.0.0-dev`](https://github.com/giantswarm/azure-operator/pull/807) or to `3.1.0-dev`, pick your favourite.