### PR TITLE
Wait for new VMSS workers to be ready before draining

### DIFF
--- a/service/controller/resource/instance/create.go
+++ b/service/controller/resource/instance/create.go
@@ -23,6 +23,8 @@ func (r *Resource) configureStateMachine() {
 		ClusterUpgradeRequirementCheck: r.clusterUpgradeRequirementCheckTransition,
 		ScaleUpWorkerVMSS:              r.scaleUpWorkerVMSSTransition,
 
+		WaitNewVMSSWorkers: r.waitNewVMSSWorkersTransition,
+
 		CordonOldVMSS:    r.cordonOldVMSSTransition,
 		CordonOldWorkers: r.cordonOldWorkersTransition,
 

--- a/service/controller/resource/instance/create_scale_workers.go
+++ b/service/controller/resource/instance/create_scale_workers.go
@@ -46,7 +46,7 @@ func (r *Resource) scaleUpWorkerVMSSTransition(ctx context.Context, obj interfac
 		if legacyVmssHasInstancesRunning {
 			// The legacy VMSS has still instances running, skip scaling up.
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("The legacy VMSS %s has %d instances: skipping scale up", key.LegacyWorkerVMSSName(cr), *legacyVmss.Sku.Capacity)) // nolint: errcheck
-			return CordonOldVMSS, nil
+			return WaitNewVMSSWorkers, nil
 		}
 
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("The legacy VMSS %s has 0 instances", key.LegacyWorkerVMSSName(cr))) // nolint: errcheck

--- a/service/controller/resource/instance/create_wait_new_vmss_workers.go
+++ b/service/controller/resource/instance/create_wait_new_vmss_workers.go
@@ -34,6 +34,11 @@ func (r *Resource) waitNewVMSSWorkersTransition(ctx context.Context, obj interfa
 		return "", microerror.Mask(err)
 	}
 
+	if numReadyNodes == 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "There are no new VMSS workers ready. Waiting")
+		return currentState, nil
+	}
+
 	if int64(numReadyNodes) != *vmss.Sku.Capacity {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Found that only %d out of the expected %d workers from the new VMSS are ready. Waiting.", numReadyNodes, *vmss.Sku.Capacity))
 		return currentState, nil

--- a/service/controller/resource/instance/create_wait_new_vmss_workers.go
+++ b/service/controller/resource/instance/create_wait_new_vmss_workers.go
@@ -1,0 +1,59 @@
+package instance
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/azure-operator/pkg/project"
+	"github.com/giantswarm/azure-operator/service/controller/internal/state"
+	"github.com/giantswarm/azure-operator/service/controller/key"
+)
+
+func (r *Resource) waitNewVMSSWorkersTransition(ctx context.Context, obj interface{}, currentState state.State) (state.State, error) {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "checking if the new VMSS workers are ready")
+	cr, err := key.ToCustomResource(obj)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	// Get the count of new VMSS instances.
+	vmss, err := r.getScaleSet(ctx, key.ResourceGroupName(cr), key.WorkerVMSSName(cr))
+	// Even in case of a NotFound error, this is unexpected and we should start from scratch.
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	numReadyNodes, err := countReadyNodes(ctx, isNewVMSSWorker)
+	if IsClientNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster client not available yet")
+		return currentState, nil
+	} else if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	if int64(numReadyNodes) != *vmss.Sku.Capacity {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Found that only %d out of the expected %d workers from the new VMSS are ready. Waiting.", numReadyNodes, *vmss.Sku.Capacity))
+		return currentState, nil
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "New workers are all ready")
+
+	return CordonOldVMSS, nil
+}
+
+func isNewVMSSWorker(n corev1.Node) bool {
+	if !isWorker(n) {
+		return false
+	}
+
+	v, ok := n.Labels[key.LabelOperatorVersion]
+	if !ok {
+		// The version label was not found.
+		return false
+	}
+
+	return v == project.Version()
+}

--- a/service/controller/resource/instance/status.go
+++ b/service/controller/resource/instance/status.go
@@ -29,6 +29,7 @@ const (
 	TerminateOldVMSS               = "TerminateOldVMSS"
 	TerminateOldWorkerInstances    = "TerminateOldWorkerInstances"
 	WaitForWorkersToBecomeReady    = "WaitForWorkersToBecomeReady"
+	WaitNewVMSSWorkers             = "WaitNewVMSSWorkers"
 )
 
 func (r *Resource) setResourceStatus(customObject providerv1alpha1.AzureConfig, t string, s string) error {


### PR DESCRIPTION
Wait for new VMSS workers to be ready before draining old ones during flatcar migration.