### PR TITLE
Use Local as NGINX external traffic policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
 
+- Use Local as NGINX NodePort Service external traffic policy.
 
 
 ## [4.0.0] 2020-05-05

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "4.1.0-dev"
+	version            = "4.0.1-dev"
 )
 
 func Description() string {

--- a/service/controller/templates/ignition/ingress_lb.go
+++ b/service/controller/templates/ignition/ingress_lb.go
@@ -20,4 +20,5 @@ spec:
     port: 443
   selector:
     k8s-app: nginx-ingress-controller
+  externalTrafficPolicy: Local
 `


### PR DESCRIPTION
Towards giantswarm/giantswarm#8877

TODO:
- [x] functional test
- [x] decide if breaking change from Cluster to Local with tradeoff is acceptable or we have to make it  external traffic policy configurable
  - discussed with @piontec and agreed it should be Local by default but configurable https://gigantic.slack.com/archives/CR99LSZ1N/p1588857693154200?thread_ts=1588847814.148600&cid=CR99LSZ1N
  - we'd prefer to make external traffic policy as well as external(public) / internal configurable just like any other nginx app feature via user values ConfigMap - to make that possible we need to change nginx LB Service ownership on Azure from azure-operator to nginx app, which may cause temporary downtime during migration of ownership; it may be acceptable to customers; it would enable also future changes like making nginx optional for Azure (consistently with latest AWS), as well as supporting multiple nginx per TC https://github.com/giantswarm/giantswarm/issues/9060
  - @whites11 is helping driving it forward, among other things because he's interested in shipping external(public) / internal support https://github.com/giantswarm/giantswarm/issues/9332
  - SEs have been pinged for feedback if downtime is acceptable to customers https://gigantic.slack.com/archives/C02EVLE9W/p1588862864492800 - @piontec may be needed there to put together design doc if customers and/or SEs request it as further input
- [ ] make external traffic policy configurable i.e. migrate nginx LB Service from azure-operator to nginx app
- [ ] load testing