### PR TITLE
Centralize methods to gather info from Release

### DIFF
--- a/integration/setup/catalog.go
+++ b/integration/setup/catalog.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	CatalogStorageURL     = "https://giantswarm.github.io/control-plane-catalog/"
-	TestCatalogStorageURL = "https://giantswarm.github.io/control-plane-test-catalog/"
+	CatalogStorageURL     = "https://giantswarm.github.io/control-plane-catalog"
+	TestCatalogStorageURL = "https://giantswarm.github.io/control-plane-test-catalog"
 )
 
 var (

--- a/integration/setup/catalog.go
+++ b/integration/setup/catalog.go
@@ -109,8 +109,8 @@ func installChartPackageBeingTested(ctx context.Context, config Config, values s
 		}
 	}
 
-	releaseName := fmt.Sprintf("%s-wip", project.Name())
-	return installChart(ctx, config, releaseName, values, chartPackagePath)
+	helmReleaseName := fmt.Sprintf("%s-wip", project.Name())
+	return installChart(ctx, config, helmReleaseName, values, chartPackagePath)
 }
 
 func installChart(ctx context.Context, config Config, releaseName, values, chartPackagePath string) error {

--- a/integration/setup/common.go
+++ b/integration/setup/common.go
@@ -92,7 +92,7 @@ func installComponentsFromRelease(ctx context.Context, config Config, release re
 }
 
 func installCertOperator(ctx context.Context, config Config, version string) error {
-	chartName := "cluster-operator"
+	chartName := "cert-operator"
 	tarballURL := fmt.Sprintf("https://giantswarm.github.com/control-plane-catalog/%s-%s.tgz", chartName, version)
 	certOperatorValues := `Installation:
   V1:
@@ -200,7 +200,6 @@ func installNodeOperator(ctx context.Context, config Config) error {
 	return nil
 }
 
-// We can't install cluster-operator "normally" until we use ClusterAPI.
 func installClusterOperator(ctx context.Context, config Config, version string) error {
 	chartName := "cluster-operator"
 	tarballURL := fmt.Sprintf("https://giantswarm.github.com/control-plane-catalog/%s-%s.tgz", chartName, version)
@@ -275,14 +274,14 @@ Installation:
 	}
 
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("tarball URL for latest %s release is %s", chartName, tarballURL))
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("pulling tarball for latest %s release", chartName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("tarball URL for %#q release is %#q", chartName, tarballURL))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("pulling tarball for %#q release", chartName))
 		chartPackagePath, err := config.HelmClient.PullChartTarball(ctx, tarballURL)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
-		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("tarball path for latest %s release is %s", chartName, chartPackagePath))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("tarball path for %#q release is %#q", chartName, chartPackagePath))
 		err = installChart(ctx, config, chartName, fmt.Sprintf(chartValues, env.AzureCalicoSubnetCIDR(), env.AzureCalicoSubnetCIDR(), ClusterIPRange, env.CommonDomain()), chartPackagePath)
 		if err != nil {
 			return microerror.Mask(err)

--- a/integration/setup/common.go
+++ b/integration/setup/common.go
@@ -24,7 +24,7 @@ const (
 )
 
 // common installs components required to run the operator.
-func common(ctx context.Context, config Config, GiantSwarmRelease releasev1alpha1.Release) error {
+func common(ctx context.Context, config Config, giantSwarmRelease releasev1alpha1.Release) error {
 	{
 		err := config.K8s.EnsureNamespaceCreated(ctx, namespace)
 		if err != nil {
@@ -51,7 +51,7 @@ func common(ctx context.Context, config Config, GiantSwarmRelease releasev1alpha
 	}
 
 	{
-		err := installComponentsFromRelease(ctx, config, GiantSwarmRelease)
+		err := installComponentsFromRelease(ctx, config, giantSwarmRelease)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -67,8 +67,8 @@ func common(ctx context.Context, config Config, GiantSwarmRelease releasev1alpha
 	return nil
 }
 
-func installComponentsFromRelease(ctx context.Context, config Config, release releasev1alpha1.Release) error {
-	clusterOperatorVersion, err := key2.ComponentVersion(release, "cluster-operator")
+func installComponentsFromRelease(ctx context.Context, config Config, giantSwarmRelease releasev1alpha1.Release) error {
+	clusterOperatorVersion, err := key2.ComponentVersion(giantSwarmRelease, "cluster-operator")
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -78,7 +78,7 @@ func installComponentsFromRelease(ctx context.Context, config Config, release re
 		return microerror.Mask(err)
 	}
 
-	certOperatorVersion, err := key2.ComponentVersion(release, "cert-operator")
+	certOperatorVersion, err := key2.ComponentVersion(giantSwarmRelease, "cert-operator")
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/integration/setup/release.go
+++ b/integration/setup/release.go
@@ -1,0 +1,107 @@
+package setup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	releasev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/microerror"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/azure-operator/v3/pkg/project"
+)
+
+const (
+	ReleaseName = "1.0.0"
+)
+
+func createGSReleaseContainingOperatorVersion(ctx context.Context, config Config) (*releasev1alpha1.Release, error) {
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensuring Release CRD exists")
+
+		err := config.K8sClients.CRDClient().EnsureCreated(ctx, releasev1alpha1.NewReleaseCRD(), backoff.NewMaxRetries(7, 1*time.Second))
+		if err != nil {
+			return &releasev1alpha1.Release{}, microerror.Mask(err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensured Release CRD exists")
+	}
+
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensuring ReleaseCycle CRD exists")
+
+		err := config.K8sClients.CRDClient().EnsureCreated(ctx, releasev1alpha1.NewReleaseCycleCRD(), backoff.NewMaxRetries(7, 1*time.Second))
+		if err != nil {
+			return &releasev1alpha1.Release{}, microerror.Mask(err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensured ReleaseCycle CRD exists")
+	}
+
+	var release *releasev1alpha1.Release
+	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensuring Release exists", "release", fmt.Sprintf("v%s", ReleaseName))
+		release = &releasev1alpha1.Release{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("v%s", ReleaseName),
+				Namespace: "default",
+				Labels: map[string]string{
+					"giantswarm.io/managed-by": "release-operator",
+					"giantswarm.io/provider":   "azure",
+				},
+			},
+			Spec: releasev1alpha1.ReleaseSpec{
+				Apps: []releasev1alpha1.ReleaseSpecApp{},
+				Components: []releasev1alpha1.ReleaseSpecComponent{
+					{
+						Name:    project.Name(),
+						Version: project.Version(),
+					},
+					{
+						Name:    "cluster-operator",
+						Version: "0.23.8",
+					},
+					{
+						Name:    "cert-operator",
+						Version: "0.1.0",
+					},
+					{
+						Name:    "app-operator",
+						Version: "1.0.0",
+					},
+					{
+						Name:    "calico",
+						Version: "3.10.1",
+					},
+					{
+						Name:    "containerlinux",
+						Version: "2345.3.1",
+					},
+					{
+						Name:    "coredns",
+						Version: "1.6.5",
+					},
+					{
+						Name:    "etcd",
+						Version: "3.3.17",
+					},
+					{
+						Name:    "kubernetes",
+						Version: "1.16.8",
+					},
+				},
+				Date:  &metav1.Time{Time: time.Unix(10, 0)},
+				State: "active",
+			},
+		}
+		_, err := config.K8sClients.G8sClient().ReleaseV1alpha1().Releases().Create(release)
+		if err != nil {
+			return &releasev1alpha1.Release{}, microerror.Mask(err)
+		}
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensured Release exists", "release", fmt.Sprintf("v%s", ReleaseName))
+	}
+
+	return release, nil
+}

--- a/integration/setup/release.go
+++ b/integration/setup/release.go
@@ -2,7 +2,6 @@ package setup
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	releasev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
@@ -14,7 +13,7 @@ import (
 )
 
 const (
-	ReleaseName = "1.0.0"
+	ReleaseName = "v1.0.0"
 )
 
 func createGSReleaseContainingOperatorVersion(ctx context.Context, config Config) (*releasev1alpha1.Release, error) {
@@ -42,10 +41,10 @@ func createGSReleaseContainingOperatorVersion(ctx context.Context, config Config
 
 	var release *releasev1alpha1.Release
 	{
-		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensuring Release exists", "release", fmt.Sprintf("v%s", ReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensuring Release exists", "release", ReleaseName)
 		release = &releasev1alpha1.Release{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("v%s", ReleaseName),
+				Name:      ReleaseName,
 				Namespace: "default",
 				Labels: map[string]string{
 					"giantswarm.io/managed-by": "release-operator",
@@ -100,7 +99,7 @@ func createGSReleaseContainingOperatorVersion(ctx context.Context, config Config
 		if err != nil {
 			return &releasev1alpha1.Release{}, microerror.Mask(err)
 		}
-		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensured Release exists", "release", fmt.Sprintf("v%s", ReleaseName))
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensured Release exists", "release", ReleaseName)
 	}
 
 	return release, nil

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -40,12 +40,17 @@ func WrapTestMain(m *testing.M, c Config) {
 func Setup(ctx context.Context, c Config) error {
 	var err error
 
-	err = common(ctx, c)
+	release, err := createGSReleaseContainingOperatorVersion(ctx, c)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = provider(ctx, c)
+	err = common(ctx, c, *release)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = provider(ctx, c, *release)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/controllercontext/context.go
+++ b/service/controller/controllercontext/context.go
@@ -30,7 +30,7 @@ type Context struct {
 }
 
 type ContextRelease struct {
-	Components []v1alpha1.ReleaseSpecComponent
+	Release v1alpha1.Release
 }
 
 func (c *Context) Validate() error {

--- a/service/controller/key/error.go
+++ b/service/controller/key/error.go
@@ -23,6 +23,15 @@ func IsMissingOutputValue(err error) bool {
 	return microerror.Cause(err) == missingOutputValueError
 }
 
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
 var wrongTypeError = &microerror.Error{
 	Kind: "wrongTypeError",
 }

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -273,7 +273,11 @@ func MasterSecurityGroupName(customObject providerv1alpha1.AzureConfig) string {
 
 // OSVersion returns the version of the operating system.
 func OSVersion(release releasev1alpha1.Release) (string, error) {
-	return ComponentVersion(release, ContainerLinuxComponentName)
+	v, err := ComponentVersion(release, ContainerLinuxComponentName)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	return v, nil
 }
 
 // WorkerSecurityGroupName returns name of the security group attached to worker subnet.

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/to"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	releasev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
 	"github.com/giantswarm/k8scloudconfig/v6/v_6_0_0"
 	"github.com/giantswarm/microerror"
 
@@ -161,6 +162,16 @@ func ClusterTags(customObject providerv1alpha1.AzureConfig, installationName str
 	return tags
 }
 
+// ComponentVersion returns the version of the given component in the Release.
+func ComponentVersion(release releasev1alpha1.Release, componentName string) (string, error) {
+	for _, component := range release.Spec.Components {
+		if component.Name == componentName {
+			return component.Version, nil
+		}
+	}
+	return "", microerror.Maskf(notFoundError, "version for component %#v not found on release %#v", componentName, release.Name)
+}
+
 // CredentialName returns name of the credential secret.
 func CredentialName(customObject providerv1alpha1.AzureConfig) string {
 	return customObject.Spec.Azure.CredentialSecret.Name
@@ -258,6 +269,11 @@ func IsSucceededProvisioningState(s string) bool {
 // MasterSecurityGroupName returns name of the security group attached to master subnet.
 func MasterSecurityGroupName(customObject providerv1alpha1.AzureConfig) string {
 	return fmt.Sprintf("%s-%s", ClusterID(customObject), masterSecurityGroupSuffix)
+}
+
+// OSVersion returns the version of the operating system.
+func OSVersion(release releasev1alpha1.Release) (string, error) {
+	return ComponentVersion(release, ContainerLinuxComponentName)
 }
 
 // WorkerSecurityGroupName returns name of the security group attached to worker subnet.

--- a/service/controller/resource/blobobject/desired.go
+++ b/service/controller/resource/blobobject/desired.go
@@ -49,7 +49,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 
 	var ignitionTemplateData cloudconfig.IgnitionTemplateData
 	{
-		versions, err := v_6_0_0.ExtractComponentVersions(cc.Release.Components)
+		versions, err := v_6_0_0.ExtractComponentVersions(cc.Release.Release.Spec.Components)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/service/controller/resource/instance/deployment.go
+++ b/service/controller/resource/instance/deployment.go
@@ -35,14 +35,9 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 		workerBlobName,
 	}
 
-	var distroVersion string
-	{
-		for _, component := range cc.Release.Components {
-			if component.Name == key.ContainerLinuxComponentName {
-				distroVersion = component.Version
-				break
-			}
-		}
+	distroVersion, err := key.OSVersion(cc.Release.Release)
+	if err != nil {
+		return azureresource.Deployment{}, microerror.Mask(err)
 	}
 
 	for _, key := range cloudConfigURLs {

--- a/service/controller/resource/masters/deployment.go
+++ b/service/controller/resource/masters/deployment.go
@@ -35,14 +35,9 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 		masterBlobName,
 	}
 
-	var distroVersion string
-	{
-		for _, component := range cc.Release.Components {
-			if component.Name == key.ContainerLinuxComponentName {
-				distroVersion = component.Version
-				break
-			}
-		}
+	distroVersion, err := key.OSVersion(cc.Release.Release)
+	if err != nil {
+		return azureresource.Deployment{}, microerror.Mask(err)
 	}
 
 	for _, k := range cloudConfigURLs {

--- a/service/controller/resource/release/create.go
+++ b/service/controller/resource/release/create.go
@@ -37,7 +37,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 	}
 
-	cc.Release.Components = release.Spec.Components
+	cc.Release.Release = *release
 
 	return nil
 }


### PR DESCRIPTION
We want an easy way to fetch info from a `Release`.

This also allows us to use it during e2e tests. I'm not changing the logic much, but with these changes we are reading components versions from the `Release` that we install during e2e tests, so that all the info about components is self-contained in the `Release` CR.
I create the `Release` as the first step of the setup and then pass it to other steps, so every step can fetch information from the `Release`.