### PR TITLE
Release name in annotation may or may not contain a leading 'v'

### DIFF
--- a/service/controller/resource/release/create.go
+++ b/service/controller/resource/release/create.go
@@ -3,6 +3,7 @@ package release
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
 	"github.com/giantswarm/microerror"
@@ -26,8 +27,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	var release *v1alpha1.Release
 	{
 		releaseVersion := cr.Labels[label.ReleaseVersion]
-		releaseName := fmt.Sprintf("v%s", releaseVersion)
-		release, err = r.g8sClient.ReleaseV1alpha1().Releases().Get(releaseName, metav1.GetOptions{})
+		if !strings.HasPrefix(releaseVersion, "v") {
+			releaseVersion = fmt.Sprintf("v%s", releaseVersion)
+		}
+
+		release, err = r.g8sClient.ReleaseV1alpha1().Releases().Get(releaseVersion, metav1.GetOptions{})
 		if err != nil {
 			return microerror.Mask(err)
 		}


### PR DESCRIPTION
It would be cool to always use the same formatting when talking about releases. Our releases are named like `vX.Y.Z`, so for consistency sake, we should aim to always use that format.

Our operator was expecting the format `X.Y.Z`, without the leading "v", so I'm changing it to make it work with both.

In the future, when we don't have older azure-operator versions, we can change our frontends to use the leading "v" format everywhere.