### PR TITLE
Only inspect response HTTP status code if there were no errors doing the request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
 
-
+- Only inspect response HTTP status code if there were no errors doing the request.
 
 ## [4.0.0] 2020-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
-- Only inspect response HTTP status code if there were no errors doing the request.
+- Make the rate limit circuit breaker to only inspect response HTTP status code if there were no errors doing the request.
 
 ## [4.0.0] 2020-05-05
 

--- a/client/senddecorator/ratelimit_circuitbreaker.go
+++ b/client/senddecorator/ratelimit_circuitbreaker.go
@@ -38,7 +38,7 @@ func RateLimitCircuitBreaker(g *backpressure.Backpressure) autorest.SendDecorato
 
 			// Check if rate-limiting has kicked in and Backpressure needs to be
 			// updated correspondingly.
-			if resp.StatusCode == http.StatusTooManyRequests {
+			if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
 				retryAfter, err := httputil.ParseRetryAfter(resp)
 				if err != nil {
 					// In case parsing fails, it's ok to fall back on default delay.


### PR DESCRIPTION
<details>
  <summary>While creating a new cluster I received this panic</summary>
  
```
D 05/08 15:23:00 /apis/provider.giantswarm.io/v1alpha1/namespaces/default/azureconfigs/uuqe4 containerurl finding storage account | azure-operator/v3/service/controller/resource/containerurl/create.go:18 | controller=azure-operator | event=update | loop=11 | version=149419926
E0508 15:25:28.978530       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 483 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1925540, 0x2cc2d70)
        /go/pkg/mod/k8s.io/apimachinery@v0.16.5-beta.1/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
        /go/pkg/mod/k8s.io/apimachinery@v0.16.5-beta.1/pkg/util/runtime/runtime.go:48 +0x82
panic(0x1925540, 0x2cc2d70)
        /usr/local/go/src/runtime/panic.go:967 +0x166
github.com/giantswarm/azure-operator/v3/client/senddecorator.RateLimitCircuitBreaker.func1.1(0xc000ef3c00, 0x1e93180, 0xc000a7bc20, 0x0)
        /root/project/client/senddecorator/ratelimit_circuitbreaker.go:41 +0x8e
github.com/Azure/go-autorest/autorest.SenderFunc.Do(0xc000a7bc20, 0xc000ef3c00, 0xc00000ec08, 0x1, 0x1)
        /go/pkg/mod/github.com/!azure/go-autorest/autorest@v0.10.0/sender.go:64 +0x30
github.com/Azure/go-autorest/autorest.SendWithSender(0x1e930e0, 0xc000eaab40, 0xc000ef3c00, 0xc00000ec08, 0x1, 0x1, 0x0, 0x0, 0x10)
        /go/pkg/mod/github.com/!azure/go-autorest/autorest@v0.10.0/sender.go:106 +0x75
github.com/Azure/go-autorest/autorest.Client.Send(0x1e90c40, 0xc0006f6920, 0x1e92340, 0xc0010260c0, 0x0, 0x0, 0xdf8475800, 0xd18c2e2800, 0x1, 0x6fc23ac00, ...)
        /go/pkg/mod/github.com/!azure/go-autorest/autorest@v0.10.0/client.go:322 +0x1ad
github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage.AccountsClient.GetPropertiesSender(0x1e90c40, 0xc0006f6920, 0x1e92340, 0xc0010260c0, 0x0, 0x0, 0xdf8475800, 0xd18c2e2800, 0x1, 0x6fc23ac00, ...)
        /go/pkg/mod/github.com/!azure/azure-sdk-for-go@v41.0.0+incompatible/services/storage/mgmt/2019-04-01/storage/accounts.go:509 +0xc9
github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage.AccountsClient.GetProperties(0x1e90c40, 0xc0006f6920, 0x1e92340, 0xc0010260c0, 0x0, 0x0, 0xdf8475800, 0xd18c2e2800, 0x1, 0x6fc23ac00, ...)
        /go/pkg/mod/github.com/!azure/azure-sdk-for-go@v41.0.0+incompatible/services/storage/mgmt/2019-04-01/storage/accounts.go:467 +0x804
github.com/giantswarm/azure-operator/v3/service/controller/resource/containerurl.(*Resource).EnsureCreated(0xc00057e100, 0x1ed18a0, 0xc00104e570, 0x1b1b9e0, 0xc000f9e000, 0x19c27a0, 0x138dfcc)
        /root/project/service/controller/resource/containerurl/create.go:29 +0x2c3
github.com/giantswarm/operatorkit/resource/wrapper/retryresource.(*basicResource).EnsureCreated.func1(0xc0006e4d60, 0xc000a7bac0)
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.0/resource/wrapper/retryresource/basic_resource.go:50 +0x64
github.com/cenkalti/backoff.RetryNotify(0xc001207910, 0x7f2194764880, 0xc0006e4d60, 0xc0012078f0, 0x0, 0x0)
        /go/pkg/mod/github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:37 +0xb8
github.com/giantswarm/backoff.RetryNotify(0xc000dbf910, 0x1e9f1a0, 0xc0006e4d60, 0xc000dbf8f0, 0x1a42820, 0x1ea0300)
        /go/pkg/mod/github.com/giantswarm/backoff@v0.2.0/retry.go:21 +0x71
github.com/giantswarm/operatorkit/resource/wrapper/retryresource.(*basicResource).EnsureCreated(0xc000696390, 0x1ed18a0, 0xc00104e570, 0x1b1b9e0, 0xc000f9e000, 0xc0006ee7e0, 0xc000060a80)
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.0/resource/wrapper/retryresource/basic_resource.go:62 +0x100
github.com/giantswarm/operatorkit/resource/wrapper/metricsresource.(*basicResource).EnsureCreated(0xc00057e4f0, 0x1ed18a0, 0xc00104e570, 0x1b1b9e0, 0xc000f9e000, 0x0, 0x0)
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.0/resource/wrapper/metricsresource/basic_resource.go:41 +0x236
github.com/giantswarm/operatorkit/controller.ProcessUpdate(0x1ed18a0, 0xc00104e570, 0x1b1b9e0, 0xc000f9e000, 0xc0001aef00, 0xf, 0x10, 0x0, 0x0)
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.0/controller/controller.go:615 +0x1f2
github.com/giantswarm/operatorkit/controller.(*Controller).updateFunc(0xc0005222c0, 0x1ed18a0, 0xc0010264e0, 0x1b1b9e0, 0xc000f9e000)
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.0/controller/controller.go:508 +0x85f
github.com/giantswarm/operatorkit/controller.(*Controller).reconcile(0xc0005222c0, 0x1ed18a0, 0xc000dff770, 0xc0008bb8c9, 0x7, 0xc0008bb8c4, 0x5, 0xc000dff770, 0x1d0ca9160040314a, 0x5eb57954, ...)
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.0/controller/controller.go:443 +0x8a8
github.com/giantswarm/operatorkit/controller.(*Controller).Reconcile(0xc0005222c0, 0xc0008bb8c9, 0x7, 0xc0008bb8c4, 0x5, 0x0, 0xbfa57c351d0ca07e, 0xc0005be2d0, 0xc0005be248)
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.0/controller/controller.go:217 +0x157
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000369bc0, 0x19953e0, 0xc000ba0240, 0x0)
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:256 +0x161
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000369bc0, 0x0)
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:232 +0xae
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc000369bc0)
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:211 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000441b80)
        /go/pkg/mod/k8s.io/apimachinery@v0.16.5-beta.1/pkg/util/wait/wait.go:152 +0x5f
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000441b80, 0x3b9aca00, 0x0, 0x1, 0xc000396180)
        /go/pkg/mod/k8s.io/apimachinery@v0.16.5-beta.1/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc000441b80, 0x3b9aca00, 0xc000396180)
        /go/pkg/mod/k8s.io/apimachinery@v0.16.5-beta.1/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:193 +0x305
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x15bb7ae]

goroutine 483 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
        /go/pkg/mod/k8s.io/apimachinery@v0.16.5-beta.1/pkg/util/runtime/runtime.go:55 +0x105
panic(0x1925540, 0x2cc2d70)
        /usr/local/go/src/runtime/panic.go:967 +0x166
github.com/giantswarm/azure-operator/v3/client/senddecorator.RateLimitCircuitBreaker.func1.1(0xc000ef3c00, 0x1e93180, 0xc000a7bc20, 0x0)
        /root/project/client/senddecorator/ratelimit_circuitbreaker.go:41 +0x8e
github.com/Azure/go-autorest/autorest.SenderFunc.Do(0xc000a7bc20, 0xc000ef3c00, 0xc00000ec08, 0x1, 0x1)
        /go/pkg/mod/github.com/!azure/go-autorest/autorest@v0.10.0/sender.go:64 +0x30
github.com/Azure/go-autorest/autorest.SendWithSender(0x1e930e0, 0xc000eaab40, 0xc000ef3c00, 0xc00000ec08, 0x1, 0x1, 0x0, 0x0, 0x10)
        /go/pkg/mod/github.com/!azure/go-autorest/autorest@v0.10.0/sender.go:106 +0x75
github.com/Azure/go-autorest/autorest.Client.Send(0x1e90c40, 0xc0006f6920, 0x1e92340, 0xc0010260c0, 0x0, 0x0, 0xdf8475800, 0xd18c2e2800, 0x1, 0x6fc23ac00, ...)
        /go/pkg/mod/github.com/!azure/go-autorest/autorest@v0.10.0/client.go:322 +0x1ad
github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage.AccountsClient.GetPropertiesSender(0x1e90c40, 0xc0006f6920, 0x1e92340, 0xc0010260c0, 0x0, 0x0, 0xdf8475800, 0xd18c2e2800, 0x1, 0x6fc23ac00, ...)
        /go/pkg/mod/github.com/!azure/azure-sdk-for-go@v41.0.0+incompatible/services/storage/mgmt/2019-04-01/storage/accounts.go:509 +0xc9
github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage.AccountsClient.GetProperties(0x1e90c40, 0xc0006f6920, 0x1e92340, 0xc0010260c0, 0x0, 0x0, 0xdf8475800, 0xd18c2e2800, 0x1, 0x6fc23ac00, ...)
        /go/pkg/mod/github.com/!azure/azure-sdk-for-go@v41.0.0+incompatible/services/storage/mgmt/2019-04-01/storage/accounts.go:467 +0x804
github.com/giantswarm/azure-operator/v3/service/controller/resource/containerurl.(*Resource).EnsureCreated(0xc00057e100, 0x1ed18a0, 0xc00104e570, 0x1b1b9e0, 0xc000f9e000, 0x19c27a0, 0x138dfcc)
        /root/project/service/controller/resource/containerurl/create.go:29 +0x2c3
github.com/giantswarm/operatorkit/resource/wrapper/retryresource.(*basicResource).EnsureCreated.func1(0xc0006e4d60, 0xc000a7bac0)
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.0/resource/wrapper/retryresource/basic_resource.go:50 +0x64
github.com/cenkalti/backoff.RetryNotify(0xc001207910, 0x7f2194764880, 0xc0006e4d60, 0xc0012078f0, 0x0, 0x0)
        /go/pkg/mod/github.com/cenkalti/backoff@v2.2.1+incompatible/retry.go:37 +0xb8
github.com/giantswarm/backoff.RetryNotify(0xc000dbf910, 0x1e9f1a0, 0xc0006e4d60, 0xc000dbf8f0, 0x1a42820, 0x1ea0300)
        /go/pkg/mod/github.com/giantswarm/backoff@v0.2.0/retry.go:21 +0x71
github.com/giantswarm/operatorkit/resource/wrapper/retryresource.(*basicResource).EnsureCreated(0xc000696390, 0x1ed18a0, 0xc00104e570, 0x1b1b9e0, 0xc000f9e000, 0xc0006ee7e0, 0xc000060a80)
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.0/resource/wrapper/retryresource/basic_resource.go:62 +0x100
github.com/giantswarm/operatorkit/resource/wrapper/metricsresource.(*basicResource).EnsureCreated(0xc00057e4f0, 0x1ed18a0, 0xc00104e570, 0x1b1b9e0, 0xc000f9e000, 0x0, 0x0)
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.0/resource/wrapper/metricsresource/basic_resource.go:41 +0x236
github.com/giantswarm/operatorkit/controller.ProcessUpdate(0x1ed18a0, 0xc00104e570, 0x1b1b9e0, 0xc000f9e000, 0xc0001aef00, 0xf, 0x10, 0x0, 0x0)
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.0/controller/controller.go:615 +0x1f2
github.com/giantswarm/operatorkit/controller.(*Controller).updateFunc(0xc0005222c0, 0x1ed18a0, 0xc0010264e0, 0x1b1b9e0, 0xc000f9e000)
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.0/controller/controller.go:508 +0x85f
github.com/giantswarm/operatorkit/controller.(*Controller).reconcile(0xc0005222c0, 0x1ed18a0, 0xc000dff770, 0xc0008bb8c9, 0x7, 0xc0008bb8c4, 0x5, 0xc000dff770, 0x1d0ca9160040314a, 0x5eb57954, ...)
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.0/controller/controller.go:443 +0x8a8
github.com/giantswarm/operatorkit/controller.(*Controller).Reconcile(0xc0005222c0, 0xc0008bb8c9, 0x7, 0xc0008bb8c4, 0x5, 0x0, 0xbfa57c351d0ca07e, 0xc0005be2d0, 0xc0005be248)
        /go/pkg/mod/github.com/giantswarm/operatorkit@v0.2.0/controller/controller.go:217 +0x157
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000369bc0, 0x19953e0, 0xc000ba0240, 0x0)
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:256 +0x161
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000369bc0, 0x0)
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:232 +0xae
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc000369bc0)
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:211 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000441b80)
        /go/pkg/mod/k8s.io/apimachinery@v0.16.5-beta.1/pkg/util/wait/wait.go:152 +0x5f
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000441b80, 0x3b9aca00, 0x0, 0x1, 0xc000396180)
        /go/pkg/mod/k8s.io/apimachinery@v0.16.5-beta.1/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc000441b80, 0x3b9aca00, 0xc000396180)
        /go/pkg/mod/k8s.io/apimachinery@v0.16.5-beta.1/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:193 +0x305
```
  
</details>

~I changed the code so that we only use the HTTP status code from the response if there were no errors.~

~The question is now: will `err` be `nil` when `resp.StatusCode == http.StatusTooManyRequests` or will `err` contain something when we hit 429?
Another way to fix it would be to check for the exact error that makes the `response` to be empty, but how do we know which one is the error?~

I changed it by a better implementation, checking if response contains anything.