### PR TITLE
State machine flowchart generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ integration/test/**/logs/*.txt
 scripts/*.tar.gz
 
 telepresence.log
+*.flowchart.generated.html

--- a/scripts/flowchart.sh
+++ b/scripts/flowchart.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+#
+# Example usage:
+#   flowchart.sh azure-operator-master --tenant-cluster xyz99 --open-browser
+#
+# where 'azure-operator-master' is App CR name and 'xyz99' is tenant cluster ID
+# and '--open-browser' flag indicates that a default browser will open the
+# generated flowchart.
+#
+
+args=()
+
+while [[ $# -gt 0 ]]; do
+    flag="$1"
+    case $flag in
+        -b|--open-browser)
+            flag_open_browser=1
+            shift
+            ;;
+        -t|--tenant-cluster)
+            tenant_cluster_id="$2"
+            shift
+            shift
+            ;;
+        *)
+            args+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# restore positional arguments
+set -- "${args[@]}"
+azure_operator_app=$1
+
+if [ -z "$azure_operator_app" ]; then
+    echo [err] azure-operator CR name must be specified
+    exit 1
+fi
+
+# get logs
+logfile="azop.logs"
+if ! kubectl -n giantswarm logs deployment/${azure_operator_app} > "${logfile}"; then
+    echo "[err] azure-operator app '$azure_operator_app' not found"
+    exit 1
+fi
+
+# filter by event message, get only state change events
+query='. | select(.message | test("state changed")) '
+
+# filter by tenant cluster ID
+if ! [ -z "$tenant_cluster_id" ]; then
+    query+="| select(.object | endswith(\"/azureconfigs/$tenant_cluster_id\")) "
+fi
+
+# echo state transition in format 'stateX --> stateY'
+query+='| "    " +
+    (if (.oldState | length) > 0 then .oldState else "DeploymentUninitialized" end) +
+    " --> " +
+    (if (.newState | length) > 0 then .newState else "DeploymentUninitialized" end)'
+
+# idented transition lines: "    stateX --> stateY"
+transitions=$(cat "${logfile}" \
+    | jq -r "$query" \
+    | sort \
+    | uniq)
+
+mermaid="graph TD
+${transitions}"
+
+template=$(cat flowchart.template.html)
+generated_flowchart="${azure_operator_app}-flowchart.html"
+
+# generate flowchart
+echo "${template/_FLOWCHART_DATA_/$mermaid}" > "${generated_flowchart}"
+echo "Generated flowchart in file '${generated_flowchart}'."
+
+# open default browser
+if [ "$flag_open_browser" == 1 ]; then
+    if which xdg-open > /dev/null; then
+        xdg-open "${generated_flowchart}"
+    elif which gnome-open > /dev/null; then
+        gnome-open "${generated_flowchart}"
+    fi
+fi

--- a/scripts/flowchart.sh
+++ b/scripts/flowchart.sh
@@ -37,7 +37,12 @@ while [[ $# -gt 0 ]]; do
             kubecontext="$2"
             shift
             shift
-        ;;
+            ;;
+        -o|--output)
+            output_file="$2"
+            shift
+            shift
+            ;;
         *)
             args+=("$1")
             shift
@@ -72,9 +77,13 @@ query='. | select(.message | test("state changed")) '
 # filter by tenant cluster ID
 if ! [ -z "$tenant_cluster_id" ]; then
     query+="| select(.object | endswith(\"/azureconfigs/$tenant_cluster_id\")) "
-    generated_flowchart="${azure_operator_app}-${tenant_cluster_id}-flowchart.html"
+    generated_flowchart="${azure_operator_app}.${tenant_cluster_id}.flowchart.generated.html"
 else
-    generated_flowchart="${azure_operator_app}-flowchart.html"
+    generated_flowchart="${azure_operator_app}.flowchart.generated.html"
+fi
+
+if [ -z "$output_file" ]; then
+    output_file="${generated_flowchart}"
 fi
 
 # echo state transition in format 'stateX --> stateY'
@@ -96,14 +105,14 @@ script_dir="$( cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd )"
 template=$(cat "${script_dir}/flowchart.template.html")
 
 # generate flowchart
-echo "${template/_FLOWCHART_DATA_/$mermaid}" > "${generated_flowchart}"
-echo "Generated flowchart in file '${generated_flowchart}'."
+echo "${template/_FLOWCHART_DATA_/$mermaid}" > "${output_file}"
+echo "Generated flowchart in file '${output_file}'."
 
 # open default browser
 if [ "$flag_open_browser" == 1 ]; then
     if which xdg-open > /dev/null; then
-        xdg-open "${generated_flowchart}"
+        xdg-open "${output_file}"
     elif which gnome-open > /dev/null; then
-        gnome-open "${generated_flowchart}"
+        gnome-open "${output_file}"
     fi
 fi

--- a/scripts/flowchart.sh
+++ b/scripts/flowchart.sh
@@ -9,6 +9,16 @@
 # generated flowchart.
 #
 
+# check if required CLI tools are installed
+for required in kubectl jq
+do
+  if [ ! -x "$(command -v $required)" ]
+  then
+    echo "[err] The required command $required was not found in your system. Aborting."
+    exit 1
+  fi
+done
+
 args=()
 
 while [[ $# -gt 0 ]]; do
@@ -40,7 +50,7 @@ if [ -z "$azure_operator_app" ]; then
 fi
 
 # get logs
-logfile="azop.logs"
+logfile="/tmp/${azure_operator_app}.logs"
 if ! kubectl -n giantswarm logs deployment/${azure_operator_app} > "${logfile}"; then
     echo "[err] azure-operator app '$azure_operator_app' not found"
     exit 1
@@ -69,7 +79,8 @@ transitions=$(cat "${logfile}" \
 mermaid="graph TD
 ${transitions}"
 
-template=$(cat flowchart.template.html)
+script_dir="$( cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd )"
+template=$(cat "${script_dir}/flowchart.template.html")
 generated_flowchart="${azure_operator_app}-flowchart.html"
 
 # generate flowchart

--- a/scripts/flowchart.template.html
+++ b/scripts/flowchart.template.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+</head>
+<body>
+  <div class="mermaid">
+  _FLOWCHART_DATA_
+  </div>
+  <script src="https://unpkg.com/mermaid@8.5.1/dist/mermaid.min.js"></script>
+  <script>mermaid.initialize({startOnLoad:true});</script>
+</body>
+</html>


### PR DESCRIPTION
Two things added:
- HTML file with flowchart template
- bash script for generating flowchart

It works for release `11.4.0` and newer.

Usage of script:
```sh
./flowchart.sh azure-operator-master \
    --tenant-cluster $tenant_cluster_id \
    --open-browser \
    --kube-context $kubectl_context \
    --output $flowchart_output_path

# or
./flowchart.sh azure-operator-master -t $tenant_cluster_id -b \
    -c $kubectl_context \
    -o $flowchart_output_path
```

In the example `azure-operator-master` is the name of `App` CR. HTML file with the flowchart will be generated in the current directory and the default browser will be opened.

Notes about arguments/flags:
- `--tenant-cluster` | `-t` is optional, if it is specified the flowchart will include only state transitions for the specified tenant cluster, otherwise it will generate all possible transitions found in all tenant clusters reconciled by specified `azure-operator` `App`
- `--open-browser` | `-b` is optional, if it is specified the default browser will be opened, otherwise the browser is not opened.
- `--kube-context` | `-c` is optional, if it is specified flowchart will be generated for `App` and tenant cluster from that context, otherwise the current kube context will be used.
- `--output` | `-o` is optional, if it is specified the flowchart HTML file will be saved to the specified path, otherwise the output file is named `${azure_operator_app}.${tenant_cluster_id}.flowchart.generated.html` if tenant cluster is specified, or `${azure_operator_app}.flowchart.generated.html` if tenant cluster is not specified and it is saved in the current directory.

Example of generated flowchart:
![image](https://user-images.githubusercontent.com/5638639/82225373-696fdd80-9925-11ea-916b-513a042f8490.png)
