### PR TITLE
Calculate latest operator release version using architect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 orbs:
-  architect: giantswarm/architect@0.8.14
+  architect: giantswarm/architect@0.8.17
 
 version: 2.1
 workflows:
@@ -66,6 +66,7 @@ workflows:
 
 #      - architect/integration-test:
 #          name: cluster-state-test
+#          resource_class: large
 #          setup-script: "integration/config/setup.sh"
 #          env-file: "integration/test/clusterstate/.env"
 #          test-dir: "integration/test/clusterstate"
@@ -76,6 +77,7 @@ workflows:
 
       - architect/integration-test:
           name: scaling-test
+          resource_class: large
           setup-script: "integration/config/setup.sh"
           env-file: "integration/test/scaling/.env"
           test-dir: "integration/test/scaling"
@@ -86,6 +88,7 @@ workflows:
 
       - architect/integration-test:
           name: multiaz-test
+          resource_class: large
           setup-script: "integration/config/setup.sh"
           env-file: "integration/test/multiaz/.env"
           test-dir: "integration/test/multiaz"
@@ -96,6 +99,7 @@ workflows:
 
       - architect/integration-test:
           name: cluster-deletion-test
+          resource_class: large
           setup-script: "integration/config/setup.sh"
           env-file: "integration/test/clusterdeletion/.env"
           test-dir: "integration/test/clusterdeletion"
@@ -106,6 +110,7 @@ workflows:
 
       - architect/integration-test:
           name: update-test
+          resource_class: large
           setup-script: "integration/config/setup.sh"
           env-file: "integration/test/update/.env"
           test-dir: "integration/test/update"
@@ -116,6 +121,7 @@ workflows:
 
       - architect/integration-test:
           name: cp-tc-connectivity-test
+          resource_class: large
           setup-script: "integration/config/setup.sh"
           env-file: "integration/test/cptcconnectivity/.env"
           test-dir: "integration/test/cptcconnectivity"

--- a/integration/config/setup.sh
+++ b/integration/config/setup.sh
@@ -1,20 +1,11 @@
 #!/usr/bin/env sh
 
-shipyard_dir=".e2e-harness/workdir/.shipyard"
-mkdir -p "${shipyard_dir}"
-chmod -R 777 ".e2e-harness"
-kind get kubeconfig --name="kind" | sudo tee "${shipyard_dir}/config" > /dev/null
-
-
 shipyard_dir="/workdir/.shipyard"
 sudo mkdir -p "${shipyard_dir}"
 sudo chmod -R 777 "/workdir"
-kind get kubeconfig --name="kind" > "${shipyard_dir}/config"
+kind get kubeconfig --name="kind" >"${shipyard_dir}/config"
 
-curl -L https://get.helm.sh/helm-v2.16.1-linux-amd64.tar.gz > ./helm.tar.gz
-tar xzvf helm.tar.gz
-chmod u+x linux-amd64/helm
-sudo mv linux-amd64/helm /usr/local/bin/
+GO111MODULE=on go get github.com/giantswarm/architect
 
 kubectl --kubeconfig="${shipyard_dir}/config" create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
 helm --kubeconfig="${shipyard_dir}/config" init --history-max 5 --wait

--- a/integration/env/azure.go
+++ b/integration/env/azure.go
@@ -26,6 +26,8 @@ const (
 	EnvVarBastionPublicSSHKey       = "BASTION_PUBLIC_SSH_KEY"
 
 	EnvVarCircleBuildNumber = "CIRCLE_BUILD_NUM"
+
+	EnvVarLatestOperatorRelease = "LATEST_OPERATOR_RELEASE"
 )
 
 var (
@@ -42,6 +44,8 @@ var (
 
 	commonDomainResourceGroup string
 	sshPublicKey              string
+
+	latestOperatorRelease string
 )
 
 func init() {
@@ -106,6 +110,12 @@ func init() {
 		azureCalicoSubnetCIDR = subnets.Calico.String()
 		azureMasterSubnetCIDR = subnets.Master.String()
 		azureWorkerSubnetCIDR = subnets.Worker.String()
+	}
+
+	var exists bool
+	latestOperatorRelease, exists = os.LookupEnv(EnvVarLatestOperatorRelease)
+	if !exists {
+		panic(fmt.Sprintf("env var %#q must not be empty\n", EnvVarLatestOperatorRelease))
 	}
 }
 
@@ -177,4 +187,8 @@ func CommonDomainResourceGroup() string {
 
 func SSHPublicKey() string {
 	return sshPublicKey
+}
+
+func GetLatestOperatorRelease() string {
+	return latestOperatorRelease
 }

--- a/integration/setup/catalog.go
+++ b/integration/setup/catalog.go
@@ -19,26 +19,6 @@ const (
 	TestCatalogStorageURL = "https://giantswarm.github.io/control-plane-test-catalog"
 )
 
-var (
-	latestOperatorRelease string
-)
-
-func GetLatestOperatorRelease() string {
-	return latestOperatorRelease
-}
-
-func init() {
-	fmt.Printf("calculating latest %#q release\n", project.Name())
-
-	var err error
-	latestOperatorRelease, err = appcatalog.GetLatestVersion(context.Background(), CatalogStorageURL, project.Name())
-	if err != nil {
-		panic(fmt.Sprintln("cannot calculate latest operator release from app catalog"))
-	}
-
-	fmt.Printf("latest %#q release is %#q\n", project.Name(), latestOperatorRelease)
-}
-
 func pullLatestChart(ctx context.Context, config Config, chartName string) (string, error) {
 	var err error
 
@@ -75,7 +55,7 @@ func pullLatestChart(ctx context.Context, config Config, chartName string) (stri
 
 func pullChartPackageUnderTest(ctx context.Context, config Config) (string, error) {
 	config.Logger.LogCtx(ctx, "level", "debug", "message", "getting tarball URL for azure-operator tested version")
-	operatorTarballURL, err := appcatalog.NewTarballURL(TestCatalogStorageURL, project.Name(), fmt.Sprintf("%s-%s", latestOperatorRelease, env.CircleSHA()))
+	operatorTarballURL, err := appcatalog.NewTarballURL(TestCatalogStorageURL, project.Name(), env.GetLatestOperatorRelease())
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/integration/setup/provider.go
+++ b/integration/setup/provider.go
@@ -88,7 +88,7 @@ func provider(ctx context.Context, config Config, giantSwarmRelease releasev1alp
 		if env.TestDir() == "integration/test/update" {
 			// When testing the update process, we want the latest release of the operator to reconcile the `CustomResource` and create a cluster.
 			// We can then update the label in the `CustomResource`, making the operator under test to reconcile it and update the cluster.
-			operatorVersion = GetLatestOperatorRelease()
+			operatorVersion = env.GetLatestOperatorRelease()
 		}
 	}
 

--- a/integration/test/clusterdeletion/.env
+++ b/integration/test/clusterdeletion/.env
@@ -1,2 +1,3 @@
 TEST_DIR="integration/test/clusterdeletion"
 KEEP_RESOURCES=true
+LATEST_OPERATOR_RELEASE=$(architect project version)

--- a/integration/test/clusterstate/.env
+++ b/integration/test/clusterstate/.env
@@ -1,1 +1,2 @@
 TEST_DIR="integration/test/clusterstate"
+LATEST_OPERATOR_RELEASE=$(architect project version)

--- a/integration/test/cptcconnectivity/.env
+++ b/integration/test/cptcconnectivity/.env
@@ -1,1 +1,2 @@
 TEST_DIR="integration/test/cptcconnectivity"
+LATEST_OPERATOR_RELEASE=$(architect project version)

--- a/integration/test/multiaz/.env
+++ b/integration/test/multiaz/.env
@@ -1,2 +1,3 @@
 TEST_DIR="integration/test/multiaz"
 AZURE_AZS=1
+LATEST_OPERATOR_RELEASE=$(architect project version)

--- a/integration/test/scaling/.env
+++ b/integration/test/scaling/.env
@@ -1,1 +1,2 @@
 TEST_DIR="integration/test/scaling"
+LATEST_OPERATOR_RELEASE=$(architect project version)

--- a/integration/test/update/.env
+++ b/integration/test/update/.env
@@ -1,1 +1,2 @@
 TEST_DIR="integration/test/update"
+LATEST_OPERATOR_RELEASE=$(architect project version)

--- a/integration/test/update/provider.go
+++ b/integration/test/update/provider.go
@@ -10,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/azure-operator/v4/integration/env"
-	"github.com/giantswarm/azure-operator/v4/integration/setup"
 )
 
 type ProviderConfig struct {
@@ -59,7 +58,7 @@ func (p *Provider) CurrentStatus() (v1alpha1.StatusCluster, error) {
 }
 
 func (p *Provider) CurrentVersion() (string, error) {
-	return setup.GetLatestOperatorRelease(), nil
+	return env.GetLatestOperatorRelease(), nil
 }
 
 // NextVersion returns the version which we are going to upgrade to


### PR DESCRIPTION
- Use latest architect-orb version so we don't have to install Helm during e2e tests.
- Use a bigger CircleCI machine.
- Use architect to calculate latest operator release, instead of requesting that info from catalog.