### PR TITLE
Azure clients factory

### DIFF
--- a/client/error.go
+++ b/client/error.go
@@ -1,0 +1,9 @@
+package client
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}

--- a/client/factory.go
+++ b/client/factory.go
@@ -1,0 +1,181 @@
+package client
+
+import (
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/azure-operator/v4/pkg/credential"
+	"github.com/giantswarm/azure-operator/v4/service/controller/key"
+)
+
+type FactoryConfig struct {
+	K8sClient  k8sclient.Interface
+	GSTenantID string
+}
+
+type Factory struct {
+	mutex      sync.Mutex
+	k8sClient  k8sclient.Interface
+	gsTenantID string
+
+	clients map[string]*AzureClientSet
+}
+
+type clientCreatorFunc func(autorest.Authorizer, string, string) (interface{}, error)
+
+// call NewFactory in EnsureCreated, so it's used in only a single reconciliation loop
+func NewFactory(config FactoryConfig) (*Factory, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if len(config.GSTenantID) == 0 {
+		return nil, microerror.Maskf(invalidConfigError, "%T.GSTenantID must not be empty", config)
+	}
+
+	factory := &Factory{
+		k8sClient:  config.K8sClient,
+		gsTenantID: config.GSTenantID,
+		clients:    make(map[string]*AzureClientSet),
+	}
+
+	return factory, nil
+}
+
+// GetDeploymentsClient returns DeploymentsClient that is used for management of deployments and
+// ARM templates.
+func (f *Factory) GetDeploymentsClient(cr v1alpha1.AzureConfig) (*resources.DeploymentsClient, error) {
+	clientSetKey := key.CredentialName(cr)
+
+	f.mutex.Lock()
+	if _, ok := f.clients[clientSetKey]; !ok {
+		f.clients[clientSetKey] = &AzureClientSet{}
+	}
+	if f.clients[clientSetKey].DeploymentsClient == nil {
+		deploymentClient, err := f.createClient(cr, func(authorizer autorest.Authorizer, subscriptionID string, partnerID string) (interface{}, error) {
+			return newDeploymentsClient(authorizer, subscriptionID, partnerID)
+		})
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		f.clients[clientSetKey].DeploymentsClient = deploymentClient.(*resources.DeploymentsClient)
+	}
+	f.mutex.Unlock()
+
+	return f.clients[clientSetKey].DeploymentsClient, nil
+}
+
+// GetGroupsClient returns GroupsClient that is used for management of resource groups.
+func (f *Factory) GetGroupsClient(cr v1alpha1.AzureConfig) (*resources.GroupsClient, error) {
+	clientSetKey := key.CredentialName(cr)
+
+	f.mutex.Lock()
+	if _, ok := f.clients[clientSetKey]; !ok {
+		f.clients[clientSetKey] = &AzureClientSet{}
+	}
+	if f.clients[clientSetKey].GroupsClient == nil {
+		groupClient, err := f.createClient(cr, func(authorizer autorest.Authorizer, subscriptionID string, partnerID string) (interface{}, error) {
+			return newGroupsClient(authorizer, subscriptionID, partnerID)
+		})
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		f.clients[clientSetKey].GroupsClient = groupClient.(*resources.GroupsClient)
+	}
+	f.mutex.Unlock()
+
+	return f.clients[clientSetKey].GroupsClient, nil
+}
+
+// GetVirtualMachineScaleSetsClient returns VirtualMachineScaleSetsClient that is used for
+// management of virtual machine scale sets.
+func (f *Factory) GetVirtualMachineScaleSetsClient(cr v1alpha1.AzureConfig) (*compute.VirtualMachineScaleSetsClient, error) {
+	clientSetKey := key.CredentialName(cr)
+
+	f.mutex.Lock()
+	if _, ok := f.clients[clientSetKey]; !ok {
+		f.clients[clientSetKey] = &AzureClientSet{}
+	}
+	if f.clients[clientSetKey].VirtualMachineScaleSetsClient == nil {
+		vmssClient, err := f.createClient(cr, func(authorizer autorest.Authorizer, subscriptionID string, partnerID string) (interface{}, error) {
+			return newVirtualMachineScaleSetsClient(authorizer, subscriptionID, partnerID)
+		})
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		f.clients[clientSetKey].VirtualMachineScaleSetsClient = vmssClient.(*compute.VirtualMachineScaleSetsClient)
+	}
+	f.mutex.Unlock()
+
+	return f.clients[clientSetKey].VirtualMachineScaleSetsClient, nil
+}
+
+// GetVirtualMachineScaleSetVMsClient returns GetVirtualMachineScaleSetVMsClient that is used for
+// management of virtual machine scale set instances.
+func (f *Factory) GetVirtualMachineScaleSetVMsClient(cr v1alpha1.AzureConfig) (*compute.VirtualMachineScaleSetVMsClient, error) {
+	clientSetKey := key.CredentialName(cr)
+
+	f.mutex.Lock()
+	if _, ok := f.clients[clientSetKey]; !ok {
+		f.clients[clientSetKey] = &AzureClientSet{}
+	}
+	if f.clients[clientSetKey].VirtualMachineScaleSetVMsClient == nil {
+		vmssClient, err := f.createClient(cr, func(authorizer autorest.Authorizer, subscriptionID string, partnerID string) (interface{}, error) {
+			return newVirtualMachineScaleSetVMsClient(authorizer, subscriptionID, partnerID)
+		})
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		f.clients[clientSetKey].VirtualMachineScaleSetVMsClient = vmssClient.(*compute.VirtualMachineScaleSetVMsClient)
+	}
+	f.mutex.Unlock()
+
+	return f.clients[clientSetKey].VirtualMachineScaleSetVMsClient, nil
+}
+
+// GetStorageAccountsClient returns *storage.AccountsClient that is used for management of Azure
+// storage accounts. The client (for specified cluster) is cached after creation, so the same
+// client is returned every time.
+func (f *Factory) GetStorageAccountsClient(cr v1alpha1.AzureConfig) (*storage.AccountsClient, error) {
+	clientSetKey := key.CredentialName(cr)
+
+	f.mutex.Lock()
+	if _, ok := f.clients[clientSetKey]; !ok {
+		f.clients[clientSetKey] = &AzureClientSet{}
+	}
+	if f.clients[clientSetKey].StorageAccountsClient == nil {
+		storageAccountsClient, err := f.createClient(cr, func(authorizer autorest.Authorizer, subscriptionID string, partnerID string) (interface{}, error) {
+			return newStorageAccountsClient(authorizer, subscriptionID, partnerID)
+		})
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		f.clients[clientSetKey].StorageAccountsClient = storageAccountsClient.(*storage.AccountsClient)
+	}
+	f.mutex.Unlock()
+
+	return f.clients[clientSetKey].StorageAccountsClient, nil
+}
+
+func (f *Factory) createClient(cr v1alpha1.AzureConfig, createClient clientCreatorFunc) (interface{}, error) {
+	organizationCredentialsConfig, subscriptionID, partnerID, err := credential.GetOrganizationAzureCredentials(f.k8sClient, cr, f.gsTenantID)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	authorizer, err := organizationCredentialsConfig.Authorizer()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	client, err := createClient(authorizer, subscriptionID, partnerID)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return client, nil
+}

--- a/service/controller/resource/instance/create_cordon_old_vmss_transition.go
+++ b/service/controller/resource/instance/create_cordon_old_vmss_transition.go
@@ -31,7 +31,7 @@ func (r *Resource) cordonOldVMSSTransition(ctx context.Context, obj interface{},
 
 	// If the legacy VMSS still exists with at least one replica, we want to cordon its replicas.
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Checking if the legacy VMSS %s is still present", key.LegacyWorkerVMSSName(cr))) // nolint: errcheck
-	vmss, err := r.getScaleSet(ctx, key.ResourceGroupName(cr), key.LegacyWorkerVMSSName(cr))
+	vmss, err := r.getScaleSet(ctx, cr, key.ResourceGroupName(cr), key.LegacyWorkerVMSSName(cr))
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_deployment_completed.go
+++ b/service/controller/resource/instance/create_deployment_completed.go
@@ -17,7 +17,7 @@ func (r *Resource) deploymentCompletedTransition(ctx context.Context, obj interf
 	if err != nil {
 		return DeploymentUninitialized, microerror.Mask(err)
 	}
-	deploymentsClient, err := r.GetDeploymentsClient(ctx)
+	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(cr)
 	if err != nil {
 		return DeploymentUninitialized, microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_deployment_completed.go
+++ b/service/controller/resource/instance/create_deployment_completed.go
@@ -21,7 +21,7 @@ func (r *Resource) deploymentCompletedTransition(ctx context.Context, obj interf
 	if err != nil {
 		return DeploymentUninitialized, microerror.Mask(err)
 	}
-	groupsClient, err := r.GetGroupsClient(ctx)
+	groupsClient, err := r.ClientFactory.GetGroupsClient(cr)
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_deployment_initialized.go
+++ b/service/controller/resource/instance/create_deployment_initialized.go
@@ -15,7 +15,7 @@ func (r *Resource) deploymentInitializedTransition(ctx context.Context, obj inte
 	if err != nil {
 		return DeploymentUninitialized, microerror.Mask(err)
 	}
-	deploymentsClient, err := r.GetDeploymentsClient(ctx)
+	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(cr)
 	if err != nil {
 		return DeploymentUninitialized, microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_deployment_uninitialized.go
+++ b/service/controller/resource/instance/create_deployment_uninitialized.go
@@ -20,7 +20,7 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}
-	deploymentsClient, err := r.GetDeploymentsClient(ctx)
+	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(cr)
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_deployment_uninitialized.go
+++ b/service/controller/resource/instance/create_deployment_uninitialized.go
@@ -24,7 +24,7 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}
-	groupsClient, err := r.GetGroupsClient(ctx)
+	groupsClient, err := r.ClientFactory.GetGroupsClient(cr)
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_scale_workers.go
+++ b/service/controller/resource/instance/create_scale_workers.go
@@ -31,7 +31,7 @@ func (r *Resource) scaleUpWorkerVMSSTransition(ctx context.Context, obj interfac
 
 	// If the old VMSS is still present, we should skip this step.
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Checking if the legacy VMSS %s is still present", key.LegacyWorkerVMSSName(cr))) // nolint: errcheck
-	legacyVmss, err := r.getScaleSet(ctx, key.ResourceGroupName(cr), key.LegacyWorkerVMSSName(cr))
+	legacyVmss, err := r.getScaleSet(ctx, cr, key.ResourceGroupName(cr), key.LegacyWorkerVMSSName(cr))
 	if IsScaleSetNotFound(err) {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("The legacy VMSS %s is not present", key.LegacyWorkerVMSSName(cr))) // nolint: errcheck
 	} else if err != nil {
@@ -93,7 +93,7 @@ func (r *Resource) scaleUpWorkerVMSSTransition(ctx context.Context, obj interfac
 }
 
 func (r *Resource) getInstancesCount(ctx context.Context, customObject providerv1alpha1.AzureConfig, deploymentNameFunc func(customObject providerv1alpha1.AzureConfig) string) (int64, error) {
-	c, err := r.GetScaleSetsClient(ctx)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(customObject)
 	if err != nil {
 		return -1, microerror.Mask(err)
 	}
@@ -106,8 +106,8 @@ func (r *Resource) getInstancesCount(ctx context.Context, customObject providerv
 	return *vmss.Sku.Capacity, nil
 }
 
-func (r *Resource) getScaleSet(ctx context.Context, resourceGroup string, scaleSetName string) (*compute.VirtualMachineScaleSet, error) {
-	c, err := r.GetScaleSetsClient(ctx)
+func (r *Resource) getScaleSet(ctx context.Context, customObject providerv1alpha1.AzureConfig, resourceGroup string, scaleSetName string) (*compute.VirtualMachineScaleSet, error) {
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(customObject)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -142,7 +142,7 @@ func (r *Resource) scaleDownWorkerVMSSTransition(ctx context.Context, obj interf
 }
 
 func (r *Resource) scaleVMSS(ctx context.Context, customObject providerv1alpha1.AzureConfig, deploymentNameFunc func(customObject providerv1alpha1.AzureConfig) string, nodeCount int64) error {
-	c, err := r.GetScaleSetsClient(ctx)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(customObject)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_terminate_old_vmss.go
+++ b/service/controller/resource/instance/create_terminate_old_vmss.go
@@ -20,7 +20,7 @@ func (r *Resource) terminateOldVmssTransition(ctx context.Context, obj interface
 		return "", microerror.Mask(err)
 	}
 
-	c, err := r.GetScaleSetsClient(ctx)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(cr)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_terminate_old_vmss.go
+++ b/service/controller/resource/instance/create_terminate_old_vmss.go
@@ -35,7 +35,7 @@ func (r *Resource) terminateOldVmssTransition(ctx context.Context, obj interface
 
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting the legacy VMSS deployment %s", legacyVMSSDeploymentName)) // nolint: errcheck
 
-	dc, err := r.GetDeploymentsClient(ctx)
+	dc, err := r.ClientFactory.GetDeploymentsClient(cr)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_terminate_old_workers.go
+++ b/service/controller/resource/instance/create_terminate_old_workers.go
@@ -34,7 +34,7 @@ func (r *Resource) terminateOldWorkersTransition(ctx context.Context, obj interf
 
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d worker VMSS instances", len(allWorkerInstances)))
 
-	c, err := r.GetScaleSetsClient(ctx)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(cr)
 	if err != nil {
 		return DeploymentUninitialized, microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_wait_for_nodes_to_become_ready.go
+++ b/service/controller/resource/instance/create_wait_for_nodes_to_become_ready.go
@@ -38,7 +38,7 @@ func (r *Resource) waitForWorkersToBecomeReadyTransition(ctx context.Context, ob
 
 	// If the old VMSS still exists, we want to go to a different state.
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Checking if the legacy VMSS %s is still present", key.LegacyWorkerVMSSName(cr))) // nolint: errcheck
-	vmss, err := r.getScaleSet(ctx, key.ResourceGroupName(cr), key.LegacyWorkerVMSSName(cr))
+	vmss, err := r.getScaleSet(ctx, cr, key.ResourceGroupName(cr), key.LegacyWorkerVMSSName(cr))
 	if IsScaleSetNotFound(err) {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("The legacy VMSS %s was not found", key.LegacyWorkerVMSSName(cr)))
 		return DrainOldWorkerNodes, nil

--- a/service/controller/resource/instance/create_wait_new_vmss_workers.go
+++ b/service/controller/resource/instance/create_wait_new_vmss_workers.go
@@ -20,7 +20,7 @@ func (r *Resource) waitNewVMSSWorkersTransition(ctx context.Context, obj interfa
 	}
 
 	// Get the count of new VMSS instances.
-	vmss, err := r.getScaleSet(ctx, key.ResourceGroupName(cr), key.WorkerVMSSName(cr))
+	vmss, err := r.getScaleSet(ctx, cr, key.ResourceGroupName(cr), key.WorkerVMSSName(cr))
 	// Even in case of a NotFound error, this is unexpected and we should start from scratch.
 	if err != nil {
 		return "", microerror.Mask(err)

--- a/service/controller/resource/instance/deployment.go
+++ b/service/controller/resource/instance/deployment.go
@@ -63,7 +63,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 	encryptionKey := encrypter.GetEncryptionKey()
 	initialVector := encrypter.GetInitialVector()
 
-	storageAccountsClient, err := r.GetStorageAccountsClient(ctx)
+	storageAccountsClient, err := r.ClientFactory.GetStorageAccountsClient(obj)
 	if err != nil {
 		return azureresource.Deployment{}, microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_check_flatcar_migration_needed.go
+++ b/service/controller/resource/masters/create_check_flatcar_migration_needed.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/internal/state"
@@ -17,7 +18,7 @@ func (r *Resource) checkFlatcarMigrationNeededTransition(ctx context.Context, ob
 		return Empty, microerror.Mask(err)
 	}
 
-	legacyExists, err := r.vmssExistsAndHasActiveInstance(ctx, key.ResourceGroupName(cr), key.LegacyMasterVMSSName(cr))
+	legacyExists, err := r.vmssExistsAndHasActiveInstance(ctx, cr, key.ResourceGroupName(cr), key.LegacyMasterVMSSName(cr))
 	if err != nil {
 		return Empty, microerror.Mask(err)
 	}
@@ -28,7 +29,7 @@ func (r *Resource) checkFlatcarMigrationNeededTransition(ctx context.Context, ob
 		return DeploymentUninitialized, nil
 	}
 
-	newExists, err := r.vmssExistsAndHasActiveInstance(ctx, key.ResourceGroupName(cr), key.MasterVMSSName(cr))
+	newExists, err := r.vmssExistsAndHasActiveInstance(ctx, cr, key.ResourceGroupName(cr), key.MasterVMSSName(cr))
 	if err != nil {
 		return Empty, microerror.Mask(err)
 	}
@@ -43,10 +44,10 @@ func (r *Resource) checkFlatcarMigrationNeededTransition(ctx context.Context, ob
 	return WaitForBackupConfirmation, nil
 }
 
-func (r *Resource) vmssExistsAndHasActiveInstance(ctx context.Context, resourceGroup string, vmssName string) (bool, error) {
+func (r *Resource) vmssExistsAndHasActiveInstance(ctx context.Context, cr providerv1alpha1.AzureConfig, resourceGroup string, vmssName string) (bool, error) {
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Checking if the VMSS %s exists in resource group %s", vmssName, resourceGroup)) // nolint: errcheck
 
-	runningInstances, err := r.getRunningInstances(ctx, resourceGroup, vmssName)
+	runningInstances, err := r.getRunningInstances(ctx, cr, resourceGroup, vmssName)
 	if IsScaleSetNotFound(err) {
 		return false, nil
 	} else if err != nil {

--- a/service/controller/resource/masters/create_cluster_upgrade_requirement_check.go
+++ b/service/controller/resource/masters/create_cluster_upgrade_requirement_check.go
@@ -22,7 +22,7 @@ func (r *Resource) clusterUpgradeRequirementCheckTransition(ctx context.Context,
 		// The kubernetes API is down.
 		// We check if the Legacy Master VMSS exists and in that case
 		// we assume this is because we're migrating to Flatcar.
-		exists, err := r.vmssExists(ctx, key.ResourceGroupName(cr), key.LegacyMasterVMSSName(cr))
+		exists, err := r.vmssExists(ctx, cr, key.ResourceGroupName(cr), key.LegacyMasterVMSSName(cr))
 		if err != nil || !exists {
 			return "", microerror.Mask(err)
 		}

--- a/service/controller/resource/masters/create_deallocate_legacy_instance.go
+++ b/service/controller/resource/masters/create_deallocate_legacy_instance.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/internal/state"
@@ -118,8 +119,8 @@ func (r *Resource) getRunningInstances(ctx context.Context, resourceGroup string
 	return instancesRunning, nil
 }
 
-func (r *Resource) getVMSS(ctx context.Context, resourceGroup string, vmssName string) (*compute.VirtualMachineScaleSet, error) {
-	c, err := r.GetScaleSetsClient(ctx)
+func (r *Resource) getVMSS(ctx context.Context, customObject providerv1alpha1.AzureConfig, resourceGroup string, vmssName string) (*compute.VirtualMachineScaleSet, error) {
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(customObject)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_delete_legacy_vmss.go
+++ b/service/controller/resource/masters/create_delete_legacy_vmss.go
@@ -3,6 +3,7 @@ package masters
 import (
 	"context"
 
+	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/internal/state"
@@ -16,7 +17,7 @@ func (r *Resource) deleteLegacyVMSSTransition(ctx context.Context, obj interface
 	}
 
 	// Delete the scaleset
-	err = r.deleteScaleSet(ctx, key.ResourceGroupName(cr), key.LegacyMasterVMSSName(cr))
+	err = r.deleteScaleSet(ctx, cr, key.ResourceGroupName(cr), key.LegacyMasterVMSSName(cr))
 	if IsScaleSetNotFound(err) {
 		// Scale set not found, all good.
 		return DeploymentCompleted, nil
@@ -27,8 +28,8 @@ func (r *Resource) deleteLegacyVMSSTransition(ctx context.Context, obj interface
 	return UnblockAPICalls, nil
 }
 
-func (r *Resource) deleteScaleSet(ctx context.Context, resourceGroup string, vmssName string) error {
-	c, err := r.GetScaleSetsClient(ctx)
+func (r *Resource) deleteScaleSet(ctx context.Context, customObject providerv1alpha1.AzureConfig, resourceGroup string, vmssName string) error {
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(customObject)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_deployment_completed.go
+++ b/service/controller/resource/masters/create_deployment_completed.go
@@ -21,7 +21,7 @@ func (r *Resource) deploymentCompletedTransition(ctx context.Context, obj interf
 	if err != nil {
 		return Empty, microerror.Mask(err)
 	}
-	groupsClient, err := r.GetGroupsClient(ctx)
+	groupsClient, err := r.ClientFactory.GetGroupsClient(cr)
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_deployment_completed.go
+++ b/service/controller/resource/masters/create_deployment_completed.go
@@ -17,7 +17,7 @@ func (r *Resource) deploymentCompletedTransition(ctx context.Context, obj interf
 	if err != nil {
 		return Empty, microerror.Mask(err)
 	}
-	deploymentsClient, err := r.GetDeploymentsClient(ctx)
+	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(cr)
 	if err != nil {
 		return Empty, microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_deployment_initialized.go
+++ b/service/controller/resource/masters/create_deployment_initialized.go
@@ -15,7 +15,7 @@ func (r *Resource) deploymentInitializedTransition(ctx context.Context, obj inte
 	if err != nil {
 		return Empty, microerror.Mask(err)
 	}
-	deploymentsClient, err := r.GetDeploymentsClient(ctx)
+	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(cr)
 	if err != nil {
 		return Empty, microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_deployment_uninitialized.go
+++ b/service/controller/resource/masters/create_deployment_uninitialized.go
@@ -20,7 +20,7 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}
-	deploymentsClient, err := r.GetDeploymentsClient(ctx)
+	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(cr)
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_deployment_uninitialized.go
+++ b/service/controller/resource/masters/create_deployment_uninitialized.go
@@ -24,7 +24,7 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}
-	groupsClient, err := r.GetGroupsClient(ctx)
+	groupsClient, err := r.ClientFactory.GetGroupsClient(cr)
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_master_instances_upgrading.go
+++ b/service/controller/resource/masters/create_master_instances_upgrading.go
@@ -203,7 +203,7 @@ func (r *Resource) reimageInstance(ctx context.Context, customObject providerv1a
 
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("ensuring instance '%s' to be reimaged", instanceName))
 
-	c, err := r.GetScaleSetsClient(ctx)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(customObject)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -239,7 +239,7 @@ func (r *Resource) updateInstance(ctx context.Context, customObject providerv1al
 
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("ensuring instance '%s' to be updated", instanceName))
 
-	c, err := r.GetScaleSetsClient(ctx)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(customObject)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_restart_kubelets.go
+++ b/service/controller/resource/masters/create_restart_kubelets.go
@@ -42,7 +42,7 @@ func (r *Resource) restartKubeletOnWorkersTransition(ctx context.Context, obj in
 		return currentState, microerror.Mask(err)
 	}
 
-	vmssVMsClient, err := r.GetVMsClient(ctx)
+	vmssVMsClient, err := r.ClientFactory.GetVirtualMachineScaleSetVMsClient(cr)
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_restart_kubelets.go
+++ b/service/controller/resource/masters/create_restart_kubelets.go
@@ -32,7 +32,7 @@ func (r *Resource) restartKubeletOnWorkersTransition(ctx context.Context, obj in
 		return "", microerror.Mask(err)
 	}
 
-	groupsClient, err := r.GetGroupsClient(ctx)
+	groupsClient, err := r.ClientFactory.GetGroupsClient(cr)
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_wait_for_restore.go
+++ b/service/controller/resource/masters/create_wait_for_restore.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/internal/state"
@@ -17,7 +18,7 @@ func (r *Resource) waitForRestoreTransition(ctx context.Context, obj interface{}
 	}
 
 	// Check if the Legacy master VMSS exists
-	legacyExists, err := r.vmssExists(ctx, key.ResourceGroupName(cr), key.LegacyMasterVMSSName(cr))
+	legacyExists, err := r.vmssExists(ctx, cr, key.ResourceGroupName(cr), key.LegacyMasterVMSSName(cr))
 	if err != nil {
 		return Empty, microerror.Mask(err)
 	}
@@ -31,10 +32,10 @@ func (r *Resource) waitForRestoreTransition(ctx context.Context, obj interface{}
 	return currentState, nil
 }
 
-func (r *Resource) vmssExists(ctx context.Context, resourceGroup string, vmssName string) (bool, error) {
+func (r *Resource) vmssExists(ctx context.Context, customObject providerv1alpha1.AzureConfig, resourceGroup string, vmssName string) (bool, error) {
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Checking if the VMSS %s exists in resource group %s", vmssName, resourceGroup)) // nolint: errcheck
 
-	_, err := r.getVMSS(ctx, resourceGroup, vmssName)
+	_, err := r.getVMSS(ctx, customObject, resourceGroup, vmssName)
 	if IsScaleSetNotFound(err) {
 		return false, nil
 	} else if err != nil {

--- a/service/controller/resource/masters/deployment.go
+++ b/service/controller/resource/masters/deployment.go
@@ -63,7 +63,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 	encryptionKey := encrypter.GetEncryptionKey()
 	initialVector := encrypter.GetInitialVector()
 
-	storageAccountsClient, err := r.GetStorageAccountsClient(ctx)
+	storageAccountsClient, err := r.ClientFactory.GetStorageAccountsClient(obj)
 	if err != nil {
 		return azureresource.Deployment{}, microerror.Mask(err)
 	}

--- a/service/controller/resource/nodes/clients.go
+++ b/service/controller/resource/nodes/clients.go
@@ -1,1 +1,0 @@
-package nodes

--- a/service/controller/resource/nodes/clients.go
+++ b/service/controller/resource/nodes/clients.go
@@ -4,21 +4,11 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
-	azureresource "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/controllercontext"
 )
-
-func (r *Resource) GetGroupsClient(ctx context.Context) (*azureresource.GroupsClient, error) {
-	cc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	return cc.AzureClientSet.GroupsClient, nil
-}
 
 func (r *Resource) GetScaleSetsClient(ctx context.Context) (*compute.VirtualMachineScaleSetsClient, error) {
 	cc, err := controllercontext.FromContext(ctx)

--- a/service/controller/resource/nodes/clients.go
+++ b/service/controller/resource/nodes/clients.go
@@ -11,15 +11,6 @@ import (
 	"github.com/giantswarm/azure-operator/v4/service/controller/controllercontext"
 )
 
-func (r *Resource) GetDeploymentsClient(ctx context.Context) (*azureresource.DeploymentsClient, error) {
-	cc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	return cc.AzureClientSet.DeploymentsClient, nil
-}
-
 func (r *Resource) GetGroupsClient(ctx context.Context) (*azureresource.GroupsClient, error) {
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {

--- a/service/controller/resource/nodes/clients.go
+++ b/service/controller/resource/nodes/clients.go
@@ -10,15 +10,6 @@ import (
 	"github.com/giantswarm/azure-operator/v4/service/controller/controllercontext"
 )
 
-func (r *Resource) GetScaleSetsClient(ctx context.Context) (*compute.VirtualMachineScaleSetsClient, error) {
-	cc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	return cc.AzureClientSet.VirtualMachineScaleSetsClient, nil
-}
-
 func (r *Resource) GetStorageAccountsClient(ctx context.Context) (*storage.AccountsClient, error) {
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {

--- a/service/controller/resource/nodes/clients.go
+++ b/service/controller/resource/nodes/clients.go
@@ -1,19 +1,1 @@
 package nodes
-
-import (
-	"context"
-
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
-	"github.com/giantswarm/microerror"
-
-	"github.com/giantswarm/azure-operator/v4/service/controller/controllercontext"
-)
-
-func (r *Resource) GetVMsClient(ctx context.Context) (*compute.VirtualMachineScaleSetVMsClient, error) {
-	cc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	return cc.AzureClientSet.VirtualMachineScaleSetVMsClient, nil
-}

--- a/service/controller/resource/nodes/clients.go
+++ b/service/controller/resource/nodes/clients.go
@@ -4,20 +4,10 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/controllercontext"
 )
-
-func (r *Resource) GetStorageAccountsClient(ctx context.Context) (*storage.AccountsClient, error) {
-	cc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	return cc.AzureClientSet.StorageAccountsClient, nil
-}
 
 func (r *Resource) GetVMsClient(ctx context.Context) (*compute.VirtualMachineScaleSetVMsClient, error) {
 	cc, err := controllercontext.FromContext(ctx)

--- a/service/controller/resource/nodes/instances.go
+++ b/service/controller/resource/nodes/instances.go
@@ -14,7 +14,7 @@ import (
 func (r *Resource) AllInstances(ctx context.Context, customObject providerv1alpha1.AzureConfig, deploymentNameFunc func(customObject providerv1alpha1.AzureConfig) string) ([]compute.VirtualMachineScaleSetVM, error) {
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("looking for the scale set '%s'", deploymentNameFunc(customObject)))
 
-	c, err := r.GetVMsClient(ctx)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetVMsClient(customObject)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/nodes/resource.go
+++ b/service/controller/resource/nodes/resource.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/giantswarm/azure-operator/v4/client"
 	"github.com/giantswarm/azure-operator/v4/service/controller/encrypter"
 	"github.com/giantswarm/azure-operator/v4/service/controller/key"
 
@@ -25,6 +26,7 @@ type Config struct {
 	Logger    micrologger.Logger
 
 	Azure            setting.Azure
+	ClientFactory    *client.Factory
 	InstanceWatchdog vmsscheck.InstanceWatchdog
 	Name             string
 }
@@ -37,6 +39,7 @@ type Resource struct {
 	StateMachine state.Machine
 
 	Azure            setting.Azure
+	ClientFactory    *client.Factory
 	InstanceWatchdog vmsscheck.InstanceWatchdog
 	name             string
 }
@@ -56,6 +59,9 @@ func New(config Config) (*Resource, error) {
 	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.ClientFactory == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ClientFactory must not be empty", config)
 	}
 
 	if err := config.Azure.Validate(); err != nil {

--- a/service/controller/resource/nodes/resource.go
+++ b/service/controller/resource/nodes/resource.go
@@ -79,6 +79,7 @@ func New(config Config) (*Resource, error) {
 		Logger:    config.Logger,
 
 		Azure:            config.Azure,
+		ClientFactory:    config.ClientFactory,
 		InstanceWatchdog: config.InstanceWatchdog,
 		name:             config.Name,
 	}

--- a/service/controller/resource_set.go
+++ b/service/controller/resource_set.go
@@ -82,6 +82,19 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 
 	var err error
 
+	var clientFactory *client.Factory
+	{
+		c := client.FactoryConfig{
+			K8sClient: config.K8sClient,
+			GSTenantID: config.GSClientCredentialsConfig.TenantID,
+		}
+
+		clientFactory, err = client.NewFactory(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var certsSearcher certs.Interface
 	{
 		c := certs.Config{
@@ -317,6 +330,7 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		Logger:    config.Logger,
 
 		Azure:            config.Azure,
+		ClientFactory:    clientFactory,
 		InstanceWatchdog: iwd,
 	}
 


### PR DESCRIPTION
What's in the box:
- Azure clients factory for creating:
  - `DeploymentsClient`
  - `GroupsClient`
  - `VirtualMachineScaleSetsClient`
  - `VirtualMachineScaleSetVMsClient`
  - `StorageAccountsClient`
- `masters` and `instance` resources are now using the factory to create clients instead of using `controllercontext`

Out of scope of this pull request:
- Using Azure clients factory in all resources (as this pull request is towards refactoring of `masters` and `instance` resources)

Still WIP, so TBA:
- Removal of cached clients when the tenant cluster is deleted.