### PR TITLE
Use single tenant service principal if secret is labeled

### DIFF
--- a/pkg/credential/credential.go
+++ b/pkg/credential/credential.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/azure-operator/v4/pkg/label"
 	"github.com/giantswarm/azure-operator/v4/service/controller/key"
 )
 
@@ -18,7 +19,6 @@ const (
 	clientSecretKey   = "azure.azureoperator.clientsecret"
 	defaultAzureGUID  = "37f13270-5c7a-56ff-9211-8426baaeaabd"
 	partnerIDKey      = "azure.azureoperator.partnerid"
-	singleTenantLabel = "giantswarm.io/single-tenant-service-principal"
 	subscriptionIDKey = "azure.azureoperator.subscriptionid"
 	tenantIDKey       = "azure.azureoperator.tenantid"
 )
@@ -62,7 +62,7 @@ func GetOrganizationAzureCredentials(ctx context.Context, k8sClient k8sclient.In
 		partnerID = defaultAzureGUID
 	}
 
-	if _, exists := credential.GetLabels()[singleTenantLabel]; exists || tenantID == gsTenantID {
+	if _, exists := credential.GetLabels()[label.SingleTenantSP]; exists || tenantID == gsTenantID {
 		// The tenant cluster resources will belong to a subscription linked to the same Tenant ID used for authentication.
 		credentials := auth.NewClientCredentialsConfig(clientID, clientSecret, tenantID)
 		return credentials, subscriptionID, partnerID, nil

--- a/pkg/credential/credential_test.go
+++ b/pkg/credential/credential_test.go
@@ -14,6 +14,15 @@ import (
 	"github.com/giantswarm/azure-operator/v4/service/unittest"
 )
 
+const (
+	clientIDFromCredentialSecret     = "clientIDFromCredentialSecret"
+	clientSecretFromCredentialSecret = "clientSecretFromCredentialSecret"
+)
+
+var (
+	noLabels = map[string]string{}
+)
+
 func TestParametersOverwriteCredentialsFromEnvironment(t *testing.T) {
 	expectedClientID := "parameterClientID"
 	expectedClientSecret := "parameterClientSecret"
@@ -140,17 +149,17 @@ func TestCredentialsAreConfiguredUsingOrganizationSecretWithSingleTenantServiceP
 	fakeK8sClient := unittest.FakeK8sClient()
 	ctx := context.Background()
 	tenantID := "sameTenantIDForAuthenticationAndManagingAzureResources"
-	expectedClientID := "clientIDFromCredentialSecret"
-	expectedClientSecret := "clientSecretFromCredentialSecret"
+	expectedClientID := clientIDFromCredentialSecret
+	expectedClientSecret := clientSecretFromCredentialSecret
 	expectedTenantID := tenantID
 
-	organizationCredentialSecret, err := createOrganizationCredentialSecret(fakeK8sClient, ctx, expectedClientID, expectedClientSecret, expectedTenantID)
+	organizationCredentialSecret, err := createOrganizationCredentialSecret(fakeK8sClient, ctx, expectedClientID, expectedClientSecret, expectedTenantID, noLabels)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	azureConfig := createAzureConfigUsingThisOrganizationCredentialSecret("test-cluster", "giantswarm", organizationCredentialSecret)
-	clientCredentialsConfig, _, _, err := GetOrganizationAzureCredentials(fakeK8sClient, *azureConfig, tenantID)
+	clientCredentialsConfig, _, _, err := GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, tenantID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,18 +181,18 @@ func TestCredentialsAreConfiguredUsingOrganizationSecretWithSingleTenantServiceP
 func TestCredentialsAreConfiguredUsingOrganizationSecretWithMultiTenantServicePrincipal(t *testing.T) {
 	fakeK8sClient := unittest.FakeK8sClient()
 	ctx := context.Background()
-	expectedClientID := "clientIDFromCredentialSecret"
-	expectedClientSecret := "clientSecretFromCredentialSecret"
+	expectedClientID := clientIDFromCredentialSecret
+	expectedClientSecret := clientSecretFromCredentialSecret
 	expectedTenantID := "giantswarmTenantID"
 	organizationTenantID := "differentTenantID"
 
-	organizationCredentialSecret, err := createOrganizationCredentialSecret(fakeK8sClient, ctx, expectedClientID, expectedClientSecret, organizationTenantID)
+	organizationCredentialSecret, err := createOrganizationCredentialSecret(fakeK8sClient, ctx, expectedClientID, expectedClientSecret, organizationTenantID, noLabels)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	azureConfig := createAzureConfigUsingThisOrganizationCredentialSecret("test-cluster", "giantswarm", organizationCredentialSecret)
-	clientCredentialsConfig, _, _, err := GetOrganizationAzureCredentials(fakeK8sClient, *azureConfig, "giantswarmTenantID")
+	clientCredentialsConfig, _, _, err := GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, "giantswarmTenantID")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -204,9 +213,10 @@ func TestCredentialsAreConfiguredUsingOrganizationSecretWithMultiTenantServicePr
 
 func TestWhenOrganizationSecretDoesntExistThenCredentialsFailToCreate(t *testing.T) {
 	fakeK8sClient := unittest.FakeK8sClient()
+	ctx := context.Background()
 
 	azureConfig := createAzureConfigUsingThisOrganizationCredentialSecret("test-cluster", "giantswarm", &v1.Secret{})
-	_, _, _, err := GetOrganizationAzureCredentials(fakeK8sClient, *azureConfig, "giantswarmTenantID")
+	_, _, _, err := GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, "giantswarmTenantID")
 	if err == nil {
 		t.Fatalf("it should fail when organization credential secret is missing")
 	}
@@ -223,7 +233,7 @@ func TestFailsToCreateCredentialsUsingOrganizationSecretWhenMissingConfigFromSec
 	}
 
 	azureConfig := createAzureConfigUsingThisOrganizationCredentialSecret("test-cluster", "giantswarm", organizationCredentialSecret)
-	_, _, _, err = GetOrganizationAzureCredentials(fakeK8sClient, *azureConfig, "giantswarmTenantID")
+	_, _, _, err = GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, "giantswarmTenantID")
 	if err == nil {
 		t.Fatalf("it should fail when key is missing from credential secret: client id is missing")
 	}
@@ -234,7 +244,7 @@ func TestFailsToCreateCredentialsUsingOrganizationSecretWhenMissingConfigFromSec
 		t.Fatal(err)
 	}
 	azureConfig.Spec.Azure.CredentialSecret.Name = organizationCredentialSecret.GetName()
-	_, _, _, err = GetOrganizationAzureCredentials(fakeK8sClient, *azureConfig, "giantswarmTenantID")
+	_, _, _, err = GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, "giantswarmTenantID")
 	if err == nil {
 		t.Fatalf("it should fail when key is missing from credential secret: client secret is missing")
 	}
@@ -245,7 +255,7 @@ func TestFailsToCreateCredentialsUsingOrganizationSecretWhenMissingConfigFromSec
 		t.Fatal(err)
 	}
 	azureConfig.Spec.Azure.CredentialSecret.Name = organizationCredentialSecret.GetName()
-	_, _, _, err = GetOrganizationAzureCredentials(fakeK8sClient, *azureConfig, "giantswarmTenantID")
+	_, _, _, err = GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, "giantswarmTenantID")
 	if err == nil {
 		t.Fatalf("it should fail when key is missing from credential secret: tenant id is missing")
 	}
@@ -256,13 +266,49 @@ func TestFailsToCreateCredentialsUsingOrganizationSecretWhenMissingConfigFromSec
 		t.Fatal(err)
 	}
 	azureConfig.Spec.Azure.CredentialSecret.Name = organizationCredentialSecret.GetName()
-	_, _, _, err = GetOrganizationAzureCredentials(fakeK8sClient, *azureConfig, "giantswarmTenantID")
+	_, _, _, err = GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, "giantswarmTenantID")
 	if err == nil {
 		t.Fatalf("it should fail when key is missing from credential secret: subscription ID is missing")
 	}
 }
 
-func createOrganizationCredentialSecret(k8sclient k8sclient.Interface, ctx context.Context, clientID, clientSecret, tenantID string) (*v1.Secret, error) {
+func TestCredentialsAreConfiguredUsingOrganizationSecretWithSingleTenantServicePrincipalWhenSecretIsLabeled(t *testing.T) {
+	fakeK8sClient := unittest.FakeK8sClient()
+	ctx := context.Background()
+	expectedClientID := clientIDFromCredentialSecret
+	expectedClientSecret := clientSecretFromCredentialSecret
+	expectedTenantID := "TenantIDFromCredentialSecret"
+
+	labels := map[string]string{
+		singleTenantLabel: "true",
+	}
+
+	organizationCredentialSecret, err := createOrganizationCredentialSecret(fakeK8sClient, ctx, expectedClientID, expectedClientSecret, expectedTenantID, labels)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	azureConfig := createAzureConfigUsingThisOrganizationCredentialSecret("test-cluster", "giantswarm", organizationCredentialSecret)
+	clientCredentialsConfig, _, _, err := GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, "giantswarmTenantID")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if clientCredentialsConfig.ClientID != expectedClientID {
+		t.Fatalf("clientID has the wrong value: expected %#q, got %#q", expectedClientID, clientCredentialsConfig.ClientID)
+	}
+	if clientCredentialsConfig.ClientSecret != expectedClientSecret {
+		t.Fatalf("clientSecret has the wrong value: expected %#q, got %#q", expectedClientSecret, clientCredentialsConfig.ClientSecret)
+	}
+	if clientCredentialsConfig.TenantID != expectedTenantID {
+		t.Fatalf("tenantID has the wrong value: expected %#q, got %#q", expectedTenantID, clientCredentialsConfig.TenantID)
+	}
+	if len(clientCredentialsConfig.AuxTenants) != 0 {
+		t.Fatalf("there shouldn't be an auxiliary tenant id when secret is labeled as single tenant: expected 0, got %#q auxiliary tenants", clientCredentialsConfig.AuxTenants)
+	}
+}
+
+func createOrganizationCredentialSecret(k8sclient k8sclient.Interface, ctx context.Context, clientID, clientSecret, tenantID string, labels map[string]string) (*v1.Secret, error) {
 	data := map[string][]byte{
 		clientIDKey:       []byte(clientID),
 		clientSecretKey:   []byte(clientSecret),
@@ -270,7 +316,7 @@ func createOrganizationCredentialSecret(k8sclient k8sclient.Interface, ctx conte
 		subscriptionIDKey: []byte("1a2b3c4d-5e6f-7g8h9i"),
 		partnerIDKey:      []byte("9i8h7g-6g5e-4d3c2b1a"),
 	}
-	organizationCredentialSecret, err := createSecret(k8sclient, ctx, "credential-secret", nil, data)
+	organizationCredentialSecret, err := createSecret(k8sclient, ctx, "credential-secret", labels, data)
 	if err != nil {
 		return &v1.Secret{}, microerror.Mask(err)
 	}

--- a/pkg/credential/credential_test.go
+++ b/pkg/credential/credential_test.go
@@ -11,6 +11,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/azure-operator/v4/pkg/label"
 	"github.com/giantswarm/azure-operator/v4/service/unittest"
 )
 
@@ -280,7 +281,7 @@ func TestCredentialsAreConfiguredUsingOrganizationSecretWithSingleTenantServiceP
 	expectedTenantID := "TenantIDFromCredentialSecret"
 
 	labels := map[string]string{
-		singleTenantLabel: "true",
+		label.SingleTenantSP: "true",
 	}
 
 	organizationCredentialSecret, err := createOrganizationCredentialSecret(fakeK8sClient, ctx, expectedClientID, expectedClientSecret, expectedTenantID, labels)

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -14,4 +14,5 @@ const (
 const (
 	OperatorVersion = "azure-operator.giantswarm.io/version"
 	ReleaseVersion  = "release.giantswarm.io/version"
+	SingleTenantSP  = "giantswarm.io/single-tenant-service-principal"
 )

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -127,7 +127,7 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 					return nil, microerror.Mask(err)
 				}
 
-				organizationAzureClientCredentialsConfig, subscriptionID, partnerID, err := credential.GetOrganizationAzureCredentials(config.K8sClient, cr, config.GSClientCredentialsConfig.TenantID)
+				organizationAzureClientCredentialsConfig, subscriptionID, partnerID, err := credential.GetOrganizationAzureCredentials(ctx, config.K8sClient, cr, config.GSClientCredentialsConfig.TenantID)
 				if err != nil {
 					return nil, microerror.Mask(err)
 				}

--- a/service/controller/resource/ipam/subnet_collector.go
+++ b/service/controller/resource/ipam/subnet_collector.go
@@ -148,7 +148,7 @@ func (c *SubnetCollector) getSubnetsFromAllSubscriptions(ctx context.Context) ([
 	var doneSubscriptions []string
 	var ret []net.IPNet
 	for _, cluster := range tenantClusterList.Items {
-		organizationAzureClientCredentialsConfig, subscriptionID, partnerID, err := credential.GetOrganizationAzureCredentials(c.k8sclient, cluster, c.gsClientCredentialsConfig.TenantID)
+		organizationAzureClientCredentialsConfig, subscriptionID, partnerID, err := credential.GetOrganizationAzureCredentials(ctx, c.k8sclient, cluster, c.gsClientCredentialsConfig.TenantID)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}


### PR DESCRIPTION
When migrating to multi tenant service principals, the code will fail to manage tenant cluster resources unless the Service Principal passed as parameter has been invited to customer's Active Directory, and assigned the `Owner` IAM role.

This PR changes the code so that if the credential secret has a label/annotation, all fields (clientid, clientsecret, tenantid...) are used to authenticate, to make it work like before. When service principals migration is over we can remove the label/annotation.