### PR TITLE
Add feature flag to enable MachinePool

### DIFF
--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -10,6 +10,7 @@ import (
 
 type Service struct {
 	Azure          azure.Azure
+	FeatureGates   string
 	Installation   installation.Installation
 	Kubernetes     kubernetes.Kubernetes
 	RegistryDomain string

--- a/main.go
+++ b/main.go
@@ -148,6 +148,7 @@ func mainError() error {
 	daemonCommand.PersistentFlags().String(f.Service.Tenant.Ignition.Debug.LogsToken, "", "Enable services which help debugging ignition.")
 	daemonCommand.PersistentFlags().String(f.Service.Tenant.Ignition.Path, "/opt/ignition", "Default path for the ignition base directory.")
 	daemonCommand.PersistentFlags().String(f.Service.Tenant.SSH.SSOPublicKey, "", "Public key for trusted SSO CA.")
+	daemonCommand.PersistentFlags().String(f.Service.FeatureGates, "", "Feature gates.")
 
 	return newCommand.CobraCommand().Execute()
 }

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -75,11 +75,7 @@ type ClusterConfig struct {
 	VMSSCheckWorkers int
 }
 
-type Cluster struct {
-	*controller.Controller
-}
-
-func NewCluster(config ClusterConfig) (*Cluster, error) {
+func NewCluster(config ClusterConfig) (*controller.Controller, error) {
 	var err error
 
 	var certsSearcher *certs.Searcher
@@ -184,9 +180,7 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 		}
 	}
 
-	return &Cluster{
-		Controller: operatorkitController,
-	}, nil
+	return operatorkitController, nil
 }
 
 func newClusterResources(config ClusterConfig, certsSearcher certs.Interface) ([]resource.Interface, error) {

--- a/service/controller/machine_pool.go
+++ b/service/controller/machine_pool.go
@@ -32,11 +32,7 @@ type MachinePoolConfig struct {
 	Logger                    micrologger.Logger
 }
 
-type MachinePool struct {
-	*controller.Controller
-}
-
-func NewMachinePool(config MachinePoolConfig) (*MachinePool, error) {
+func NewMachinePool(config MachinePoolConfig) (*controller.Controller, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
@@ -81,7 +77,7 @@ func NewMachinePool(config MachinePoolConfig) (*MachinePool, error) {
 		}
 	}
 
-	return &MachinePool{Controller: operatorkitController}, nil
+	return operatorkitController, nil
 }
 
 func NewMachinePoolResourceSet(config MachinePoolConfig) ([]resource.Interface, error) {


### PR DESCRIPTION
Current `master` fails if ClusterAPI CRD's are not present. We can revert back the `AzureMachinePool` controller, or disable the code that requires the CRDs.