### PR TITLE
Update NGINX LB migration script

### DIFF
--- a/scripts/migrate-nginx-ingress-controller.sh
+++ b/scripts/migrate-nginx-ingress-controller.sh
@@ -49,113 +49,27 @@ echo -n "Creating kubeconfig for $cluster @ $installation: "
 output="$(gsctl create kubeconfig --cluster=$cluster --certificate-organizations system:masters -e $installation --ttl 1d 2>&1)"
 check_err $? "${output}"
 
-# 1) Deploy the new nginx ingress app (1.6.10) with the following custom user config:
-
-echo "Installing the nginx ingress controller app"
-
-appname="nginx-ingress-controller-app"
-appversion="1.6.10-a0c46e931fd99bd75eb7f3677b9c5ccd74e09598"
-
-read -r -d '' APP << EOM
-apiVersion: v1
-data:
-  values: |
-    controller:
-      name: ${appname}
-      configmap:
-        name: ${appname}
-      role:
-        name: ${appname}
-      service:
-        enabled: false
-    ingressController:
-      legacy: false
-    provider: azure
-kind: ConfigMap
-metadata:
-  name: ${appname}-user-values
-  namespace: ${cluster}
----
-apiVersion: application.giantswarm.io/v1alpha1
-kind: App
-metadata:
-  annotations:
-    chart-operator.giantswarm.io/force-helm-upgrade: "false"
-  labels:
-    app: ${appname}
-    app-operator.giantswarm.io/version: 1.0.0
-    giantswarm.io/cluster: ${cluster}
-    giantswarm.io/organization: giantswarm
-    giantswarm.io/service-type: managed
-  name: ${appname}
-  namespace: ${cluster}
-spec:
-  catalog: default-test
-  config:
-    configMap:
-      name: ingress-controller-values
-      namespace: ${cluster}
-    secret:
-      name: ""
-      namespace: ""
-  kubeConfig:
-    context:
-      name: ${cluster}
-    inCluster: false
-    secret:
-      name: ${cluster}-kubeconfig
-      namespace: ${cluster}
-  name: ${appname}
-  namespace: kube-system
-  userConfig:
-    configMap:
-      name: "${appname}-user-values"
-      namespace: "${cluster}"
-    secret:
-      name: ""
-      namespace: ""
-  version: "${appversion}"
-EOM
-
-echo "$APP" | kubectl --context=giantswarm-${installation} apply -f -
-
-echo "Waiting for ${appname} chart to be deployed"
-
-status=""
-while [ "$status" != "DEPLOYED" ]
-do
-  if [ "$status" != "" ]
-  then
-    echo "Expecting the state to be DEPLOYED but it is $status"
-  fi
-  status=$(kubectl --context=giantswarm-${cluster} --namespace=giantswarm get chart ${appname} -o json |jq -r '.status.release.status')
-  sleep 5
-done
-
-echo "Chart is deployed"
-echo ""
-
-# 2) Wait for the new load balancer to come up, communicate the public IP address to the customer
+# 1) Ensure the new load balancer is up, communicate the public IP address to the customer
 
 echo "Waiting for LoadBalancer to have a public IP"
 
 ip=""
 while [ "$ip" == "" ] || [ "$ip" == "null" ]
 do
-  ip="$(kubectl --context=giantswarm-${cluster} --namespace=kube-system get svc nginx-ingress-controller-app -o json| jq -r '.status.loadBalancer.ingress[0].ip')"
+  ip="$(kubectl --context=giantswarm-${cluster} --namespace=kube-system get svc nginx-ingress-controller -o json| jq -r '.status.loadBalancer.ingress[0].ip')"
   sleep 5
 done
 
 read -p "IP is $ip. Ping the customer to inform him about the public IP change. Click enter to continue or ctrl+c to abort."
 
-# 3) kubectl --context=giantswarm-ami5q --namespace=kube-system edit svc ingress-loadbalancer
+# 2) Switch DNS records to the new load balancer IP, to allow old LoadBalancer Service from being deleted
 echo -n "Removing external dns annotation from ingress-loadbalancer svc: "
 output="$(kubectl --context=giantswarm-${cluster} --namespace=kube-system annotate svc ingress-loadbalancer 'external-dns.alpha.kubernetes.io/hostname'- 2>&1)"
 check_err $? "$output"
 
-# 4) wait until the external-dns updates the value of the ingress. ... DNS record.
+# 3) wait until the external-dns updates the value of the ingress. ... DNS record.
 
-hostname="$(kubectl --context=giantswarm-godsmack get azureconfig ${cluster} -o json |jq -r '.spec.cluster.kubernetes.ingressController.domain')"
+hostname="$(kubectl --context=giantswarm-${installation} get azureconfig ${cluster} -o json |jq -r '.spec.cluster.kubernetes.ingressController.domain')"
 
 if [ "$hostname" == "null" ]
 then
@@ -180,7 +94,3 @@ done
 
 echo "$hostname resolves as $res as expected"
 echo ""
-
-# 5) upgrade the cluster
-
-echo "You can now upgrade the cluster"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9962

The NGINX LB migration script was introduced as part of https://github.com/giantswarm/azure-operator/pull/827

Now it has further been tested, and nature changed so that it's intended to be run after tenant cluster upgrade (say from 11.3.3 to 11.4.0) instead of before the upgrade as was the initial intention. With this, scope of the script changed too.

Script is still not complete/sufficient, it may be extended to automate cleanup of old LB Service, ensure Azure LB backend pool is unchanged and still works after the removal. @whites11 is looking into that. For now I'll cover those old LB Service cleanup steps separately, with migration steps instructions in the 11.4.0 release notes.