### PR TITLE
Make client factory not depend on AzureConfig

### DIFF
--- a/client/factory.go
+++ b/client/factory.go
@@ -11,20 +11,16 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
 	"github.com/Azure/go-autorest/autorest"
-	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
-	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	gocache "github.com/patrickmn/go-cache"
 
 	"github.com/giantswarm/azure-operator/v4/pkg/credential"
-	"github.com/giantswarm/azure-operator/v4/service/controller/key"
 )
 
 const (
 	cacheHitLogKey       = "cacheHit"
 	clientTypeLogKey     = "clientType"
-	clusterIDLogKey      = "clusterID"
 	credentialNameLogKey = "credentialName"
 	logLevelLogKey       = "level"
 	logLevelDebug        = "debug"
@@ -32,19 +28,17 @@ const (
 )
 
 type FactoryConfig struct {
-	CacheDuration time.Duration
-	GSTenantID    string
-	K8sClient     k8sclient.Interface
-	Logger        micrologger.Logger
+	CacheDuration      time.Duration
+	CredentialProvider credential.Provider
+	Logger             micrologger.Logger
 }
 
 // Factory is creating Azure clients for specified AzureConfig CRs, so basically for specified
 // tenant clusters. All created clients are cached.
 type Factory struct {
-	gsTenantID string
-	k8sClient  k8sclient.Interface
-	logger     micrologger.Logger
-	mutex      sync.Mutex
+	credentialProvider credential.Provider
+	logger             micrologger.Logger
+	mutex              sync.Mutex
 
 	// map [credentialName + client type] -> client
 	cachedClients *gocache.Cache
@@ -58,21 +52,17 @@ func NewFactory(config FactoryConfig) (*Factory, error) {
 	if config.CacheDuration < 5*time.Minute { // cache at least for one reconciliation loop duration
 		return nil, microerror.Maskf(invalidConfigError, "%T.CacheDuration must be at least 5 minutes", config)
 	}
-	if len(config.GSTenantID) == 0 {
-		return nil, microerror.Maskf(invalidConfigError, "%T.GSTenantID must not be empty", config)
-	}
-	if config.K8sClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	if config.CredentialProvider == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CredentialProvider must not be empty", config)
 	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
 	factory := &Factory{
-		k8sClient:     config.K8sClient,
-		logger:        config.Logger,
-		gsTenantID:    config.GSTenantID,
-		cachedClients: gocache.New(config.CacheDuration, 2*config.CacheDuration),
+		logger:             config.Logger,
+		credentialProvider: config.CredentialProvider,
+		cachedClients:      gocache.New(config.CacheDuration, 2*config.CacheDuration),
 	}
 
 	factory.cachedClients.OnEvicted(func(clientKey string, i interface{}) {
@@ -85,8 +75,8 @@ func NewFactory(config FactoryConfig) (*Factory, error) {
 // GetDeploymentsClient returns DeploymentsClient that is used for management of deployments and
 // ARM templates. The client (for specified cluster) is cached after creation, so the same client
 // is returned every time.
-func (f *Factory) GetDeploymentsClient(cr v1alpha1.AzureConfig) (*resources.DeploymentsClient, error) {
-	client, err := f.getClient(cr, "DeploymentsClient", newDeploymentsClient)
+func (f *Factory) GetDeploymentsClient(credentialNamespace, credentialName string) (*resources.DeploymentsClient, error) {
+	client, err := f.getClient(credentialNamespace, credentialName, "DeploymentsClient", newDeploymentsClient)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -97,8 +87,8 @@ func (f *Factory) GetDeploymentsClient(cr v1alpha1.AzureConfig) (*resources.Depl
 // GetGroupsClient returns GroupsClient that is used for management of resource groups for the
 // specified cluster. The created client is cached for the time period specified in the factory
 // config.
-func (f *Factory) GetGroupsClient(cr v1alpha1.AzureConfig) (*resources.GroupsClient, error) {
-	client, err := f.getClient(cr, "GroupsClient", newGroupsClient)
+func (f *Factory) GetGroupsClient(credentialNamespace, credentialName string) (*resources.GroupsClient, error) {
+	client, err := f.getClient(credentialNamespace, credentialName, "GroupsClient", newGroupsClient)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -109,8 +99,8 @@ func (f *Factory) GetGroupsClient(cr v1alpha1.AzureConfig) (*resources.GroupsCli
 // GetVirtualMachineScaleSetsClient returns VirtualMachineScaleSetsClient that is used for
 // management of virtual machine scale sets for the specified cluster. The created client is cached
 // for the time period specified in the factory config.
-func (f *Factory) GetVirtualMachineScaleSetsClient(cr v1alpha1.AzureConfig) (*compute.VirtualMachineScaleSetsClient, error) {
-	client, err := f.getClient(cr, "VirtualMachineScaleSetsClient", newVirtualMachineScaleSetsClient)
+func (f *Factory) GetVirtualMachineScaleSetsClient(credentialNamespace, credentialName string) (*compute.VirtualMachineScaleSetsClient, error) {
+	client, err := f.getClient(credentialNamespace, credentialName, "VirtualMachineScaleSetsClient", newVirtualMachineScaleSetsClient)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -121,8 +111,8 @@ func (f *Factory) GetVirtualMachineScaleSetsClient(cr v1alpha1.AzureConfig) (*co
 // GetVirtualMachineScaleSetVMsClient returns GetVirtualMachineScaleSetVMsClient that is used for
 // management of virtual machine scale set instances for the specified cluster. The created client
 // is cached for the time period specified in the factory config.
-func (f *Factory) GetVirtualMachineScaleSetVMsClient(cr v1alpha1.AzureConfig) (*compute.VirtualMachineScaleSetVMsClient, error) {
-	client, err := f.getClient(cr, "VirtualMachineScaleSetVMsClient", newVirtualMachineScaleSetVMsClient)
+func (f *Factory) GetVirtualMachineScaleSetVMsClient(credentialNamespace, credentialName string) (*compute.VirtualMachineScaleSetVMsClient, error) {
+	client, err := f.getClient(credentialNamespace, credentialName, "VirtualMachineScaleSetVMsClient", newVirtualMachineScaleSetVMsClient)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -133,8 +123,8 @@ func (f *Factory) GetVirtualMachineScaleSetVMsClient(cr v1alpha1.AzureConfig) (*
 // GetStorageAccountsClient returns *storage.AccountsClient that is used for management of Azure
 // storage accounts for the specified cluster. The created client is cached for the time period
 // specified in the factory config.
-func (f *Factory) GetStorageAccountsClient(cr v1alpha1.AzureConfig) (*storage.AccountsClient, error) {
-	client, err := f.getClient(cr, "StorageAccountsClient", newStorageAccountsClient)
+func (f *Factory) GetStorageAccountsClient(credentialNamespace, credentialName string) (*storage.AccountsClient, error) {
+	client, err := f.getClient(credentialNamespace, credentialName, "StorageAccountsClient", newStorageAccountsClient)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -142,15 +132,14 @@ func (f *Factory) GetStorageAccountsClient(cr v1alpha1.AzureConfig) (*storage.Ac
 	return toStorageAccountsClient(client), nil
 }
 
-func (f *Factory) getClient(cr v1alpha1.AzureConfig, clientType string, createClient clientCreatorFunc) (interface{}, error) {
+func (f *Factory) getClient(credentialNamespace, credentialName string, clientType string, createClient clientCreatorFunc) (interface{}, error) {
 	l := f.logger.With(
 		logLevelLogKey, logLevelDebug,
 		messageLogKey, "get client",
-		credentialNameLogKey, key.CredentialName(cr),
-		clusterIDLogKey, key.ClusterID(&cr),
+		credentialNameLogKey, credentialName,
 		clientTypeLogKey, clientType)
 
-	clientKey := getClientKey(cr, clientType)
+	clientKey := getClientKey(credentialName, clientType)
 	var client interface{}
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
@@ -162,7 +151,7 @@ func (f *Factory) getClient(cr v1alpha1.AzureConfig, clientType string, createCl
 	} else {
 		// client not found, create it, it will be saved in cache
 		l.Log(cacheHitLogKey, false)
-		newClient, err := f.createClient(cr, createClient)
+		newClient, err := f.createClient(credentialNamespace, credentialName, createClient)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -174,8 +163,8 @@ func (f *Factory) getClient(cr v1alpha1.AzureConfig, clientType string, createCl
 	return client, nil
 }
 
-func (f *Factory) createClient(cr v1alpha1.AzureConfig, createClient clientCreatorFunc) (interface{}, error) {
-	organizationCredentialsConfig, subscriptionID, partnerID, err := credential.GetOrganizationAzureCredentials(context.Background(), f.k8sClient, cr, f.gsTenantID)
+func (f *Factory) createClient(credentialNamespace, credentialName string, createClient clientCreatorFunc) (interface{}, error) {
+	organizationCredentialsConfig, subscriptionID, partnerID, err := f.credentialProvider.GetOrganizationAzureCredentials(context.Background(), credentialNamespace, credentialName)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -191,8 +180,8 @@ func (f *Factory) createClient(cr v1alpha1.AzureConfig, createClient clientCreat
 	return client, nil
 }
 
-func getClientKey(cr v1alpha1.AzureConfig, clientType string) string {
-	return fmt.Sprintf("%s.%s", key.CredentialName(cr), clientType)
+func getClientKey(credentialName string, clientType string) string {
+	return fmt.Sprintf("%s.%s", credentialName, clientType)
 }
 
 func getClientKeyParts(clientKey string) (credentialName, clientType string) {

--- a/pkg/credential/credential.go
+++ b/pkg/credential/credential.go
@@ -4,14 +4,12 @@ import (
 	"context"
 
 	"github.com/Azure/go-autorest/autorest/azure/auth"
-	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-operator/v4/pkg/label"
-	"github.com/giantswarm/azure-operator/v4/service/controller/key"
 )
 
 const (
@@ -23,37 +21,42 @@ const (
 	tenantIDKey       = "azure.azureoperator.tenantid"
 )
 
+type K8SCredential struct {
+	k8sclient  k8sclient.Interface
+	gsTenantID string
+}
+
 // GetOrganizationAzureCredentials returns the organization's credentials.
 // This means a configured `ClientCredentialsConfig` together with the subscription ID and the partner ID.
 // The Service Principals in the organizations' secrets will always belong the the GiantSwarm Tenant ID in `gsTenantID`.
-func GetOrganizationAzureCredentials(ctx context.Context, k8sClient k8sclient.Interface, cr providerv1alpha1.AzureConfig, gsTenantID string) (auth.ClientCredentialsConfig, string, string, error) {
-	credential := &v1.Secret{}
-	err := k8sClient.CtrlClient().Get(ctx, client.ObjectKey{Namespace: key.CredentialNamespace(cr), Name: key.CredentialName(cr)}, credential)
+func (k K8SCredential) GetOrganizationAzureCredentials(ctx context.Context, credentialNamespace, credentialName string) (auth.ClientCredentialsConfig, string, string, error) {
+	secret := &v1.Secret{}
+	err := k.k8sclient.CtrlClient().Get(ctx, client.ObjectKey{Namespace: credentialNamespace, Name: credentialName}, secret)
 	if err != nil {
 		return auth.ClientCredentialsConfig{}, "", "", microerror.Mask(err)
 	}
 
-	clientID, err := valueFromSecret(credential, clientIDKey)
+	clientID, err := valueFromSecret(secret, clientIDKey)
 	if err != nil {
 		return auth.ClientCredentialsConfig{}, "", "", microerror.Mask(err)
 	}
 
-	clientSecret, err := valueFromSecret(credential, clientSecretKey)
+	clientSecret, err := valueFromSecret(secret, clientSecretKey)
 	if err != nil {
 		return auth.ClientCredentialsConfig{}, "", "", microerror.Mask(err)
 	}
 
-	tenantID, err := valueFromSecret(credential, tenantIDKey)
+	tenantID, err := valueFromSecret(secret, tenantIDKey)
 	if err != nil {
 		return auth.ClientCredentialsConfig{}, "", "", microerror.Mask(err)
 	}
 
-	subscriptionID, err := valueFromSecret(credential, subscriptionIDKey)
+	subscriptionID, err := valueFromSecret(secret, subscriptionIDKey)
 	if err != nil {
 		return auth.ClientCredentialsConfig{}, "", "", microerror.Mask(err)
 	}
 
-	partnerID, err := valueFromSecret(credential, partnerIDKey)
+	partnerID, err := valueFromSecret(secret, partnerIDKey)
 	if err != nil {
 		// No having Partner ID in the secret means that customer has not
 		// upgraded yet to use the Azure Partner Program. In that case we set a
@@ -62,13 +65,13 @@ func GetOrganizationAzureCredentials(ctx context.Context, k8sClient k8sclient.In
 		partnerID = defaultAzureGUID
 	}
 
-	if _, exists := credential.GetLabels()[label.SingleTenantSP]; exists || tenantID == gsTenantID {
+	if _, exists := secret.GetLabels()[label.SingleTenantSP]; exists || tenantID == k.gsTenantID {
 		// The tenant cluster resources will belong to a subscription linked to the same Tenant ID used for authentication.
 		credentials := auth.NewClientCredentialsConfig(clientID, clientSecret, tenantID)
 		return credentials, subscriptionID, partnerID, nil
 	}
 
-	credentials := auth.NewClientCredentialsConfig(clientID, clientSecret, gsTenantID)
+	credentials := auth.NewClientCredentialsConfig(clientID, clientSecret, k.gsTenantID)
 	credentials.AuxTenants = append(credentials.AuxTenants, tenantID)
 
 	return credentials, subscriptionID, partnerID, nil

--- a/pkg/credential/credential.go
+++ b/pkg/credential/credential.go
@@ -26,6 +26,13 @@ type K8SCredential struct {
 	gsTenantID string
 }
 
+func NewK8SCredentialProvider(k8sclient k8sclient.Interface, gsTenantID string) Provider {
+	return K8SCredential{
+		k8sclient:  k8sclient,
+		gsTenantID: gsTenantID,
+	}
+}
+
 // GetOrganizationAzureCredentials returns the organization's credentials.
 // This means a configured `ClientCredentialsConfig` together with the subscription ID and the partner ID.
 // The Service Principals in the organizations' secrets will always belong the the GiantSwarm Tenant ID in `gsTenantID`.

--- a/pkg/credential/credential_test.go
+++ b/pkg/credential/credential_test.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/azure-operator/v4/pkg/label"
+	"github.com/giantswarm/azure-operator/v4/service/controller/key"
 	"github.com/giantswarm/azure-operator/v4/service/unittest"
 )
 
@@ -160,7 +161,11 @@ func TestCredentialsAreConfiguredUsingOrganizationSecretWithSingleTenantServiceP
 	}
 
 	azureConfig := createAzureConfigUsingThisOrganizationCredentialSecret("test-cluster", "giantswarm", organizationCredentialSecret)
-	clientCredentialsConfig, _, _, err := GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, tenantID)
+	credentialProvider := K8SCredential{
+		k8sclient:  fakeK8sClient,
+		gsTenantID: tenantID,
+	}
+	clientCredentialsConfig, _, _, err := credentialProvider.GetOrganizationAzureCredentials(ctx, key.CredentialNamespace(*azureConfig), key.CredentialName(*azureConfig))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +198,11 @@ func TestCredentialsAreConfiguredUsingOrganizationSecretWithMultiTenantServicePr
 	}
 
 	azureConfig := createAzureConfigUsingThisOrganizationCredentialSecret("test-cluster", "giantswarm", organizationCredentialSecret)
-	clientCredentialsConfig, _, _, err := GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, "giantswarmTenantID")
+	credentialProvider := K8SCredential{
+		k8sclient:  fakeK8sClient,
+		gsTenantID: "giantswarmTenantID",
+	}
+	clientCredentialsConfig, _, _, err := credentialProvider.GetOrganizationAzureCredentials(ctx, key.CredentialNamespace(*azureConfig), key.CredentialName(*azureConfig))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -217,7 +226,11 @@ func TestWhenOrganizationSecretDoesntExistThenCredentialsFailToCreate(t *testing
 	ctx := context.Background()
 
 	azureConfig := createAzureConfigUsingThisOrganizationCredentialSecret("test-cluster", "giantswarm", &v1.Secret{})
-	_, _, _, err := GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, "giantswarmTenantID")
+	credentialProvider := K8SCredential{
+		k8sclient:  fakeK8sClient,
+		gsTenantID: "giantswarmTenantID",
+	}
+	_, _, _, err := credentialProvider.GetOrganizationAzureCredentials(ctx, key.CredentialNamespace(*azureConfig), key.CredentialName(*azureConfig))
 	if err == nil {
 		t.Fatalf("it should fail when organization credential secret is missing")
 	}
@@ -234,7 +247,11 @@ func TestFailsToCreateCredentialsUsingOrganizationSecretWhenMissingConfigFromSec
 	}
 
 	azureConfig := createAzureConfigUsingThisOrganizationCredentialSecret("test-cluster", "giantswarm", organizationCredentialSecret)
-	_, _, _, err = GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, "giantswarmTenantID")
+	credentialProvider := K8SCredential{
+		k8sclient:  fakeK8sClient,
+		gsTenantID: "giantswarmTenantID",
+	}
+	_, _, _, err = credentialProvider.GetOrganizationAzureCredentials(ctx, key.CredentialNamespace(*azureConfig), key.CredentialName(*azureConfig))
 	if err == nil {
 		t.Fatalf("it should fail when key is missing from credential secret: client id is missing")
 	}
@@ -245,7 +262,7 @@ func TestFailsToCreateCredentialsUsingOrganizationSecretWhenMissingConfigFromSec
 		t.Fatal(err)
 	}
 	azureConfig.Spec.Azure.CredentialSecret.Name = organizationCredentialSecret.GetName()
-	_, _, _, err = GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, "giantswarmTenantID")
+	_, _, _, err = credentialProvider.GetOrganizationAzureCredentials(ctx, key.CredentialNamespace(*azureConfig), key.CredentialName(*azureConfig))
 	if err == nil {
 		t.Fatalf("it should fail when key is missing from credential secret: client secret is missing")
 	}
@@ -256,7 +273,7 @@ func TestFailsToCreateCredentialsUsingOrganizationSecretWhenMissingConfigFromSec
 		t.Fatal(err)
 	}
 	azureConfig.Spec.Azure.CredentialSecret.Name = organizationCredentialSecret.GetName()
-	_, _, _, err = GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, "giantswarmTenantID")
+	_, _, _, err = credentialProvider.GetOrganizationAzureCredentials(ctx, key.CredentialNamespace(*azureConfig), key.CredentialName(*azureConfig))
 	if err == nil {
 		t.Fatalf("it should fail when key is missing from credential secret: tenant id is missing")
 	}
@@ -267,7 +284,7 @@ func TestFailsToCreateCredentialsUsingOrganizationSecretWhenMissingConfigFromSec
 		t.Fatal(err)
 	}
 	azureConfig.Spec.Azure.CredentialSecret.Name = organizationCredentialSecret.GetName()
-	_, _, _, err = GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, "giantswarmTenantID")
+	_, _, _, err = credentialProvider.GetOrganizationAzureCredentials(ctx, key.CredentialNamespace(*azureConfig), key.CredentialName(*azureConfig))
 	if err == nil {
 		t.Fatalf("it should fail when key is missing from credential secret: subscription ID is missing")
 	}
@@ -290,7 +307,11 @@ func TestCredentialsAreConfiguredUsingOrganizationSecretWithSingleTenantServiceP
 	}
 
 	azureConfig := createAzureConfigUsingThisOrganizationCredentialSecret("test-cluster", "giantswarm", organizationCredentialSecret)
-	clientCredentialsConfig, _, _, err := GetOrganizationAzureCredentials(ctx, fakeK8sClient, *azureConfig, "giantswarmTenantID")
+	credentialProvider := K8SCredential{
+		k8sclient:  fakeK8sClient,
+		gsTenantID: "giantswarmTenantID",
+	}
+	clientCredentialsConfig, _, _, err := credentialProvider.GetOrganizationAzureCredentials(ctx, key.CredentialNamespace(*azureConfig), key.CredentialName(*azureConfig))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/credential/spec.go
+++ b/pkg/credential/spec.go
@@ -1,0 +1,11 @@
+package credential
+
+import (
+	"context"
+
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+)
+
+type Provider interface {
+	GetOrganizationAzureCredentials(ctx context.Context, credentialNamespace, credentialName string) (auth.ClientCredentialsConfig, string, string, error)
+}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.0-dev"
+	version            = "5.0.0-jose"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.0-jose"
+	version            = "5.0.0-dev"
 )
 
 func Description() string {

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -198,8 +198,9 @@ func newClusterResources(config ClusterConfig, certsSearcher certs.Interface) ([
 	var clientFactory *client.Factory
 	{
 		c := client.FactoryConfig{
-			CacheDuration: 30 * time.Minute,
-			Logger:        config.Logger,
+			CacheDuration:      30 * time.Minute,
+			CredentialProvider: config.CredentialProvider,
+			Logger:             config.Logger,
 		}
 
 		clientFactory, err = client.NewFactory(c)
@@ -487,9 +488,10 @@ func newClusterResources(config ClusterConfig, certsSearcher certs.Interface) ([
 	var subnetCollector *ipam.SubnetCollector
 	{
 		c := ipam.SubnetCollectorConfig{
-			K8sClient:        config.K8sClient,
-			InstallationName: config.InstallationName,
-			Logger:           config.Logger,
+			CredentialProvider: config.CredentialProvider,
+			K8sClient:          config.K8sClient,
+			InstallationName:   config.InstallationName,
+			Logger:             config.Logger,
 
 			NetworkRange: config.IPAMNetworkRange,
 		}

--- a/service/controller/resource/instance/create_deployment_completed.go
+++ b/service/controller/resource/instance/create_deployment_completed.go
@@ -17,11 +17,11 @@ func (r *Resource) deploymentCompletedTransition(ctx context.Context, obj interf
 	if err != nil {
 		return DeploymentUninitialized, microerror.Mask(err)
 	}
-	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(cr)
+	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return DeploymentUninitialized, microerror.Mask(err)
 	}
-	groupsClient, err := r.ClientFactory.GetGroupsClient(cr)
+	groupsClient, err := r.ClientFactory.GetGroupsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_deployment_initialized.go
+++ b/service/controller/resource/instance/create_deployment_initialized.go
@@ -15,7 +15,7 @@ func (r *Resource) deploymentInitializedTransition(ctx context.Context, obj inte
 	if err != nil {
 		return DeploymentUninitialized, microerror.Mask(err)
 	}
-	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(cr)
+	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return DeploymentUninitialized, microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_deployment_uninitialized.go
+++ b/service/controller/resource/instance/create_deployment_uninitialized.go
@@ -20,11 +20,11 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}
-	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(cr)
+	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}
-	groupsClient, err := r.ClientFactory.GetGroupsClient(cr)
+	groupsClient, err := r.ClientFactory.GetGroupsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_scale_workers.go
+++ b/service/controller/resource/instance/create_scale_workers.go
@@ -93,7 +93,7 @@ func (r *Resource) scaleUpWorkerVMSSTransition(ctx context.Context, obj interfac
 }
 
 func (r *Resource) getInstancesCount(ctx context.Context, customObject providerv1alpha1.AzureConfig, deploymentNameFunc func(customObject providerv1alpha1.AzureConfig) string) (int64, error) {
-	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(customObject)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(key.CredentialNamespace(customObject), key.CredentialName(customObject))
 	if err != nil {
 		return -1, microerror.Mask(err)
 	}
@@ -107,7 +107,7 @@ func (r *Resource) getInstancesCount(ctx context.Context, customObject providerv
 }
 
 func (r *Resource) getScaleSet(ctx context.Context, customObject providerv1alpha1.AzureConfig, resourceGroup string, scaleSetName string) (*compute.VirtualMachineScaleSet, error) {
-	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(customObject)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(key.CredentialNamespace(customObject), key.CredentialName(customObject))
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -142,7 +142,7 @@ func (r *Resource) scaleDownWorkerVMSSTransition(ctx context.Context, obj interf
 }
 
 func (r *Resource) scaleVMSS(ctx context.Context, customObject providerv1alpha1.AzureConfig, deploymentNameFunc func(customObject providerv1alpha1.AzureConfig) string, nodeCount int64) error {
-	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(customObject)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(key.CredentialNamespace(customObject), key.CredentialName(customObject))
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_terminate_old_vmss.go
+++ b/service/controller/resource/instance/create_terminate_old_vmss.go
@@ -20,7 +20,7 @@ func (r *Resource) terminateOldVmssTransition(ctx context.Context, obj interface
 		return "", microerror.Mask(err)
 	}
 
-	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(cr)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return "", microerror.Mask(err)
 	}
@@ -35,7 +35,7 @@ func (r *Resource) terminateOldVmssTransition(ctx context.Context, obj interface
 
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting the legacy VMSS deployment %s", legacyVMSSDeploymentName)) // nolint: errcheck
 
-	dc, err := r.ClientFactory.GetDeploymentsClient(cr)
+	dc, err := r.ClientFactory.GetDeploymentsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/create_terminate_old_workers.go
+++ b/service/controller/resource/instance/create_terminate_old_workers.go
@@ -35,7 +35,7 @@ func (r *Resource) terminateOldWorkersTransition(ctx context.Context, obj interf
 
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d worker VMSS instances", len(allWorkerInstances)))
 
-	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(cr)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return DeploymentUninitialized, microerror.Mask(err)
 	}

--- a/service/controller/resource/instance/deployment.go
+++ b/service/controller/resource/instance/deployment.go
@@ -63,7 +63,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 	encryptionKey := encrypter.GetEncryptionKey()
 	initialVector := encrypter.GetInitialVector()
 
-	storageAccountsClient, err := r.ClientFactory.GetStorageAccountsClient(obj)
+	storageAccountsClient, err := r.ClientFactory.GetStorageAccountsClient(key.CredentialNamespace(obj), key.CredentialName(obj))
 	if err != nil {
 		return azureresource.Deployment{}, microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_deallocate_legacy_instance.go
+++ b/service/controller/resource/masters/create_deallocate_legacy_instance.go
@@ -46,7 +46,7 @@ func (r *Resource) deallocateLegacyInstanceTransition(ctx context.Context, obj i
 }
 
 func (r *Resource) deallocateAllInstances(ctx context.Context, cr providerv1alpha1.AzureConfig, resourceGroup string, vmssName string) error {
-	vmssInstancesClient, err := r.ClientFactory.GetVirtualMachineScaleSetVMsClient(cr)
+	vmssInstancesClient, err := r.ClientFactory.GetVirtualMachineScaleSetVMsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -77,7 +77,7 @@ func (r *Resource) deallocateAllInstances(ctx context.Context, cr providerv1alph
 }
 
 func (r *Resource) getRunningInstances(ctx context.Context, cr providerv1alpha1.AzureConfig, resourceGroup string, vmssName string) ([]compute.VirtualMachineScaleSetVM, error) {
-	vmssInstancesClient, err := r.ClientFactory.GetVirtualMachineScaleSetVMsClient(cr)
+	vmssInstancesClient, err := r.ClientFactory.GetVirtualMachineScaleSetVMsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return []compute.VirtualMachineScaleSetVM{}, microerror.Mask(err)
 	}
@@ -120,7 +120,7 @@ func (r *Resource) getRunningInstances(ctx context.Context, cr providerv1alpha1.
 }
 
 func (r *Resource) getVMSS(ctx context.Context, customObject providerv1alpha1.AzureConfig, resourceGroup string, vmssName string) (*compute.VirtualMachineScaleSet, error) {
-	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(customObject)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(key.CredentialNamespace(customObject), key.CredentialName(customObject))
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_delete_legacy_vmss.go
+++ b/service/controller/resource/masters/create_delete_legacy_vmss.go
@@ -29,7 +29,7 @@ func (r *Resource) deleteLegacyVMSSTransition(ctx context.Context, obj interface
 }
 
 func (r *Resource) deleteScaleSet(ctx context.Context, customObject providerv1alpha1.AzureConfig, resourceGroup string, vmssName string) error {
-	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(customObject)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(key.CredentialNamespace(customObject), key.CredentialName(customObject))
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_deployment_completed.go
+++ b/service/controller/resource/masters/create_deployment_completed.go
@@ -17,11 +17,11 @@ func (r *Resource) deploymentCompletedTransition(ctx context.Context, obj interf
 	if err != nil {
 		return Empty, microerror.Mask(err)
 	}
-	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(cr)
+	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return Empty, microerror.Mask(err)
 	}
-	groupsClient, err := r.ClientFactory.GetGroupsClient(cr)
+	groupsClient, err := r.ClientFactory.GetGroupsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_deployment_initialized.go
+++ b/service/controller/resource/masters/create_deployment_initialized.go
@@ -15,7 +15,7 @@ func (r *Resource) deploymentInitializedTransition(ctx context.Context, obj inte
 	if err != nil {
 		return Empty, microerror.Mask(err)
 	}
-	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(cr)
+	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return Empty, microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_deployment_uninitialized.go
+++ b/service/controller/resource/masters/create_deployment_uninitialized.go
@@ -20,11 +20,11 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}
-	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(cr)
+	deploymentsClient, err := r.ClientFactory.GetDeploymentsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}
-	groupsClient, err := r.ClientFactory.GetGroupsClient(cr)
+	groupsClient, err := r.ClientFactory.GetGroupsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_master_instances_upgrading.go
+++ b/service/controller/resource/masters/create_master_instances_upgrading.go
@@ -205,7 +205,7 @@ func (r *Resource) reimageInstance(ctx context.Context, customObject providerv1a
 
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("ensuring instance '%s' to be reimaged", instanceName))
 
-	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(customObject)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(key.CredentialNamespace(customObject), key.CredentialName(customObject))
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -241,7 +241,7 @@ func (r *Resource) updateInstance(ctx context.Context, customObject providerv1al
 
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("ensuring instance '%s' to be updated", instanceName))
 
-	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(customObject)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(key.CredentialNamespace(customObject), key.CredentialName(customObject))
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/create_restart_kubelets.go
+++ b/service/controller/resource/masters/create_restart_kubelets.go
@@ -32,7 +32,7 @@ func (r *Resource) restartKubeletOnWorkersTransition(ctx context.Context, obj in
 		return "", microerror.Mask(err)
 	}
 
-	groupsClient, err := r.ClientFactory.GetGroupsClient(cr)
+	groupsClient, err := r.ClientFactory.GetGroupsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return currentState, microerror.Mask(err)
 	}
@@ -42,7 +42,7 @@ func (r *Resource) restartKubeletOnWorkersTransition(ctx context.Context, obj in
 		return currentState, microerror.Mask(err)
 	}
 
-	vmssVMsClient, err := r.ClientFactory.GetVirtualMachineScaleSetVMsClient(cr)
+	vmssVMsClient, err := r.ClientFactory.GetVirtualMachineScaleSetVMsClient(key.CredentialNamespace(cr), key.CredentialName(cr))
 	if err != nil {
 		return "", microerror.Mask(err)
 	}

--- a/service/controller/resource/masters/deployment.go
+++ b/service/controller/resource/masters/deployment.go
@@ -63,7 +63,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 	encryptionKey := encrypter.GetEncryptionKey()
 	initialVector := encrypter.GetInitialVector()
 
-	storageAccountsClient, err := r.ClientFactory.GetStorageAccountsClient(obj)
+	storageAccountsClient, err := r.ClientFactory.GetStorageAccountsClient(key.CredentialNamespace(obj), key.CredentialName(obj))
 	if err != nil {
 		return azureresource.Deployment{}, microerror.Mask(err)
 	}

--- a/service/controller/resource/nodes/instances.go
+++ b/service/controller/resource/nodes/instances.go
@@ -14,7 +14,7 @@ import (
 func (r *Resource) AllInstances(ctx context.Context, customObject providerv1alpha1.AzureConfig, deploymentNameFunc func(customObject providerv1alpha1.AzureConfig) string) ([]compute.VirtualMachineScaleSetVM, error) {
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("looking for the scale set '%s'", deploymentNameFunc(customObject)))
 
-	c, err := r.ClientFactory.GetVirtualMachineScaleSetVMsClient(customObject)
+	c, err := r.ClientFactory.GetVirtualMachineScaleSetVMsClient(key.CredentialNamespace(customObject), key.CredentialName(customObject))
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -258,6 +258,8 @@ func New(config Config) (*Service, error) {
 		return nil, microerror.Mask(err)
 	}
 
+	credentialProvider := credential.NewK8SCredentialProvider(k8sClient, config.Viper.GetString(config.Flag.Service.Azure.TenantID))
+
 	var clusterController *controller.Cluster
 	{
 		cpAzureClientSet, err := NewCPAzureClientSet(config, gsClientCredentialsConfig)
@@ -267,6 +269,7 @@ func New(config Config) (*Service, error) {
 
 		c := controller.ClusterConfig{
 			Azure:                     azure,
+			CredentialProvider:        credentialProvider,
 			CPAzureClientSet:          cpAzureClientSet,
 			GSClientCredentialsConfig: gsClientCredentialsConfig,
 			GuestSubnetMaskBits:       config.Viper.GetInt(config.Flag.Service.Installation.Guest.IPAM.Network.SubnetMaskBits),


### PR DESCRIPTION
The factory that we use to create Azure clients is coupled to our `AzureConfig` CR. If we change to CAPI types, we can't use the factory. This is blocking me for the node pools story.

I thought that one potential solution we could make it CR independant by creating a credentials provider. In our case, the provider is kubernetes (we use k8s secrets). And the factory doesn't know how to read the credentials: it asks the credentials provider.

What do you think?