### PR TITLE
Create cloud-config handler for CAPI types

### DIFF
--- a/service/controller/cloudconfig/types.go
+++ b/service/controller/cloudconfig/types.go
@@ -5,6 +5,10 @@ import (
 	"github.com/giantswarm/certs"
 	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v6/pkg/template"
 	"github.com/giantswarm/randomkeys"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 )
 
 type templateData struct {
@@ -49,8 +53,12 @@ type ingressLBFileParams struct {
 }
 
 type IgnitionTemplateData struct {
-	CustomObject providerv1alpha1.AzureConfig
-	ClusterCerts certs.Cluster
-	ClusterKeys  randomkeys.Cluster
-	Images       k8scloudconfig.Images
+	AzureMachinePool *expcapzv1alpha3.AzureMachinePool
+	AzureCluster     *capzv1alpha3.AzureCluster
+	Cluster          *capiv1alpha3.Cluster
+	ClusterCerts     certs.Cluster
+	ClusterKeys      randomkeys.Cluster
+	CustomObject     providerv1alpha1.AzureConfig
+	Images           k8scloudconfig.Images
+	MachinePool      *expcapiv1alpha3.MachinePool
 }

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -118,16 +118,16 @@ func BlobContainerName() string {
 	return blobContainerName
 }
 
-func BlobName(customObject providerv1alpha1.AzureConfig, role string) string {
-	return fmt.Sprintf("%s-%s-%s", OperatorVersion(&customObject), cloudConfigVersion, role)
+func BlobName(customObject LabelsGetter, role string) string {
+	return fmt.Sprintf("%s-%s-%s", OperatorVersion(customObject), cloudConfigVersion, role)
 }
 
 func CalicoCIDR(customObject providerv1alpha1.AzureConfig) string {
 	return customObject.Spec.Azure.VirtualNetwork.CalicoSubnetCIDR
 }
 
-func CertificateEncryptionSecretName(customObject providerv1alpha1.AzureConfig) string {
-	return fmt.Sprintf("%s-certificate-encryption", customObject.Spec.Cluster.ID)
+func CertificateEncryptionSecretName(customObject LabelsGetter) string {
+	return fmt.Sprintf("%s-certificate-encryption", ClusterID(customObject))
 }
 
 func CloudConfigSmallTemplates() []string {
@@ -377,13 +377,13 @@ func AvailabilityZones(customObject providerv1alpha1.AzureConfig, location strin
 	return customObject.Spec.Azure.AvailabilityZones
 }
 
-func StorageAccountName(customObject providerv1alpha1.AzureConfig) string {
+func StorageAccountName(customObject LabelsGetter) string {
 	// In integration tests we use hyphens which are not allowed. We also
 	// need to keep the name globaly unique and within 24 character limit.
 	//
 	//	See https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions#storage
 	//
-	storageAccountName := fmt.Sprintf("%s%s", storageAccountSuffix, ClusterID(&customObject))
+	storageAccountName := fmt.Sprintf("%s%s", storageAccountSuffix, ClusterID(customObject))
 	return strings.Replace(storageAccountName, "-", "", -1)
 }
 

--- a/service/controller/resource/cloudconfig/create.go
+++ b/service/controller/resource/cloudconfig/create.go
@@ -1,0 +1,62 @@
+package cloudconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/azure-operator/v4/service/controller/blobclient"
+	"github.com/giantswarm/azure-operator/v4/service/controller/controllercontext"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	containerObjectToCreate, err := toContainerObjectState(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for _, containerObject := range containerObjectToCreate {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating container object %#q", containerObject.Key))
+
+		_, err := blobclient.PutBlockBlob(ctx, containerObject.Key, containerObject.Body, cc.ContainerURL)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created container object %#q", containerObject.Key))
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, currentState, desiredState interface{}) (interface{}, error) {
+	currentContainerObjects, err := toContainerObjectState(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredContainerObjects, err := toContainerObjectState(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the container objects should be created")
+
+	createState := []ContainerObjectState{}
+
+	for _, desiredContainerObject := range desiredContainerObjects {
+		if objectInSliceByKey(desiredContainerObject, currentContainerObjects) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("container object %#q should not be created", desiredContainerObject.Key))
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("container object %#q should be created", desiredContainerObject.Key))
+			createState = append(createState, desiredContainerObject)
+		}
+	}
+
+	return createState, nil
+}

--- a/service/controller/resource/cloudconfig/current.go
+++ b/service/controller/resource/cloudconfig/current.go
@@ -1,4 +1,4 @@
-package blobobject
+package cloudconfig
 
 import (
 	"context"
@@ -12,7 +12,7 @@ import (
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
-	cr, err := key.ToCustomResource(obj)
+	cr, err := key.ToAzureMachinePool(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/cloudconfig/delete.go
+++ b/service/controller/resource/cloudconfig/delete.go
@@ -1,0 +1,19 @@
+package cloudconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/operatorkit/resource/crud"
+)
+
+// ApplyDeleteChange not in use as blobobject deleted
+// with container delete.
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, change interface{}) error {
+	return nil
+}
+
+// NewDeletePatch is not in use as blobobject deleted
+// with container delete.
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*crud.Patch, error) {
+	return nil, nil
+}

--- a/service/controller/resource/cloudconfig/desired.go
+++ b/service/controller/resource/cloudconfig/desired.go
@@ -1,4 +1,4 @@
-package blobobject
+package cloudconfig
 
 import (
 	"context"
@@ -8,6 +8,12 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/cloudconfig"
 	"github.com/giantswarm/azure-operator/v4/service/controller/controllercontext"
@@ -15,7 +21,22 @@ import (
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
-	cr, err := key.ToCustomResource(obj)
+	cr, err := key.ToAzureMachinePool(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	machinePool, err := r.getOwnerMachinePool(ctx, cr.ObjectMeta)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	cluster, err := util.GetClusterFromMetadata(ctx, r.ctrlClient, cr.ObjectMeta)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	azureCluster, err := r.getAzureClusterFromCluster(ctx, cluster)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -60,9 +81,12 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		images := k8scloudconfig.BuildImages(r.registryDomain, versions)
 
 		ignitionTemplateData = cloudconfig.IgnitionTemplateData{
-			CustomObject: cr,
-			ClusterCerts: clusterCerts,
-			Images:       images,
+			AzureMachinePool: &cr,
+			MachinePool:      machinePool,
+			Cluster:          cluster,
+			AzureCluster:     azureCluster,
+			ClusterCerts:     clusterCerts,
+			Images:           images,
 		}
 	}
 
@@ -100,4 +124,41 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	}
 
 	return output, nil
+}
+
+// getOwnerMachinePool returns the MachinePool object owning the current resource.
+func (r *Resource) getOwnerMachinePool(ctx context.Context, obj metav1.ObjectMeta) (*v1alpha3.MachinePool, error) {
+	for _, ref := range obj.OwnerReferences {
+		if ref.Kind == "MachinePool" && ref.APIVersion == v1alpha3.GroupVersion.String() {
+			return r.getMachinePoolByName(ctx, obj.Namespace, ref.Name)
+		}
+	}
+
+	return nil, nil
+}
+
+// getMachinePoolByName finds and return a MachinePool object using the specified params.
+func (r *Resource) getMachinePoolByName(ctx context.Context, namespace, name string) (*v1alpha3.MachinePool, error) {
+	machinePool := &v1alpha3.MachinePool{}
+	objectKey := ctrlclient.ObjectKey{Name: name, Namespace: namespace}
+	if err := r.ctrlClient.Get(ctx, objectKey, machinePool); err != nil {
+		return nil, err
+	}
+
+	return machinePool, nil
+}
+
+func (r *Resource) getAzureClusterFromCluster(ctx context.Context, cluster *capiv1alpha3.Cluster) (*capzv1alpha3.AzureCluster, error) {
+	azureCluster := &capzv1alpha3.AzureCluster{}
+	azureClusterName := ctrlclient.ObjectKey{
+		Namespace: cluster.Spec.InfrastructureRef.Namespace,
+		Name:      cluster.Spec.InfrastructureRef.Name,
+	}
+
+	err := r.ctrlClient.Get(ctx, azureClusterName, azureCluster)
+	if err != nil {
+		return azureCluster, microerror.Mask(err)
+	}
+
+	return azureCluster, nil
 }

--- a/service/controller/resource/cloudconfig/error.go
+++ b/service/controller/resource/cloudconfig/error.go
@@ -1,0 +1,52 @@
+package cloudconfig
+
+import (
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if c == notFoundError {
+		return true
+	}
+
+	{
+		dErr, ok := c.(autorest.DetailedError)
+		if ok {
+			if dErr.StatusCode == 404 {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/resource/cloudconfig/mock.go
+++ b/service/controller/resource/cloudconfig/mock.go
@@ -1,0 +1,20 @@
+package cloudconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/azure-operator/v4/service/controller/cloudconfig"
+	"github.com/giantswarm/azure-operator/v4/service/controller/encrypter"
+)
+
+type CloudConfigMock struct {
+	template string
+}
+
+func (c *CloudConfigMock) NewMasterTemplate(ctx context.Context, data cloudconfig.IgnitionTemplateData, encrypter encrypter.Interface) (string, error) {
+	return c.template, nil
+}
+
+func (c *CloudConfigMock) NewWorkerTemplate(ctx context.Context, data cloudconfig.IgnitionTemplateData, encrypter encrypter.Interface) (string, error) {
+	return c.template, nil
+}

--- a/service/controller/resource/cloudconfig/resource.go
+++ b/service/controller/resource/cloudconfig/resource.go
@@ -1,0 +1,140 @@
+package cloudconfig
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/certs"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-operator/v4/service/controller/encrypter"
+	"github.com/giantswarm/azure-operator/v4/service/controller/key"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "cloudconfig"
+)
+
+type Config struct {
+	CertsSearcher         certs.Interface
+	CtrlClient            ctrlclient.Client
+	G8sClient             versioned.Interface
+	K8sClient             kubernetes.Interface
+	Logger                micrologger.Logger
+	RegistryDomain        string
+	StorageAccountsClient *storage.AccountsClient
+}
+
+type Resource struct {
+	certsSearcher  certs.Interface
+	ctrlClient     ctrlclient.Client
+	g8sClient      versioned.Interface
+	k8sClient      kubernetes.Interface
+	logger         micrologger.Logger
+	registryDomain string
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CertsSearcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CertsSearcher must not be empty", config)
+	}
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.RegistryDomain == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.RegistryDomain must not be empty", config)
+	}
+
+	r := &Resource{
+		certsSearcher:  config.CertsSearcher,
+		ctrlClient:     config.CtrlClient,
+		g8sClient:      config.G8sClient,
+		k8sClient:      config.K8sClient,
+		logger:         config.Logger,
+		registryDomain: config.RegistryDomain,
+	}
+
+	return r, nil
+}
+
+// Name returns the resource name.
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) toEncrypterObject(ctx context.Context, secretName string) (encrypter.Interface, error) {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "retrieving encryptionkey")
+
+	secret, err := r.k8sClient.CoreV1().Secrets(key.CertificateEncryptionNamespace).Get(secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var enc *encrypter.Encrypter
+	{
+		if _, ok := secret.Data[key.CertificateEncryptionKeyName]; !ok {
+			return nil, microerror.Maskf(invalidConfigError, "encryption key not found in secret %q", secret.Name)
+		}
+		if _, ok := secret.Data[key.CertificateEncryptionIVName]; !ok {
+			return nil, microerror.Maskf(invalidConfigError, "encryption iv not found in secret %q", secret.Name)
+		}
+		c := encrypter.Config{
+			Key: secret.Data[key.CertificateEncryptionKeyName],
+			IV:  secret.Data[key.CertificateEncryptionIVName],
+		}
+
+		enc, err = encrypter.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+
+		}
+	}
+
+	return enc, nil
+}
+
+func toContainerObjectState(v interface{}) ([]ContainerObjectState, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	containerObjectState, ok := v.([]ContainerObjectState)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", containerObjectState, v)
+	}
+
+	return containerObjectState, nil
+}
+
+func objectInSliceByKey(obj ContainerObjectState, list []ContainerObjectState) bool {
+	for _, item := range list {
+		if obj.Key == item.Key {
+			return true
+		}
+	}
+	return false
+}
+
+func objectInSliceByKeyAndBody(obj ContainerObjectState, list []ContainerObjectState) bool {
+	for _, item := range list {
+		if obj.Key == item.Key && obj.Body == item.Body {
+			return true
+		}
+	}
+	return false
+}

--- a/service/controller/resource/cloudconfig/types.go
+++ b/service/controller/resource/cloudconfig/types.go
@@ -1,0 +1,13 @@
+package cloudconfig
+
+const (
+	prefixMaster = "master"
+	prefixWorker = "worker"
+)
+
+type ContainerObjectState struct {
+	ContainerName      string
+	Body               string
+	Key                string
+	StorageAccountName string
+}

--- a/service/controller/resource/cloudconfig/update.go
+++ b/service/controller/resource/cloudconfig/update.go
@@ -1,0 +1,81 @@
+package cloudconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/resource/crud"
+
+	"github.com/giantswarm/azure-operator/v4/service/controller/blobclient"
+	"github.com/giantswarm/azure-operator/v4/service/controller/controllercontext"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	cc, err := controllercontext.FromContext(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	containerObjectToUpdate, err := toContainerObjectState(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	for _, containerObject := range containerObjectToUpdate {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating container object %#q", containerObject.Key))
+
+		_, err := blobclient.PutBlockBlob(ctx, containerObject.Key, containerObject.Body, cc.ContainerURL)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated container object %#q", containerObject.Key))
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*crud.Patch, error) {
+	create, err := r.newCreateChange(ctx, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := crud.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, currentState, desiredState interface{}) (interface{}, error) {
+	currentContainerObjects, err := toContainerObjectState(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredContainerObjects, err := toContainerObjectState(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the container objects should be updated")
+
+	updateState := []ContainerObjectState{}
+
+	for _, desiredContainerObject := range desiredContainerObjects {
+		if objectInSliceByKeyAndBody(desiredContainerObject, currentContainerObjects) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("container object %#q should not be updated", desiredContainerObject.Key))
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("container object %#q should be updated", desiredContainerObject.Key))
+			updateState = append(updateState, desiredContainerObject)
+		}
+	}
+
+	return updateState, nil
+}

--- a/service/controller/resource/cloudconfig/update_test.go
+++ b/service/controller/resource/cloudconfig/update_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/controllercontext"
+	"github.com/giantswarm/azure-operator/v4/service/unittest"
 )
 
 const (
@@ -164,6 +165,7 @@ func Test_Resource_ContainerObject_newUpdate(t *testing.T) {
 			{
 				c := Config{
 					CertsSearcher:         certstest.NewSearcher(certstest.Config{}),
+					CtrlClient:            unittest.FakeK8sClient().CtrlClient(),
 					G8sClient:             g8sfake.NewSimpleClientset(),
 					K8sClient:             fake.NewSimpleClientset(),
 					Logger:                microloggertest.New(),

--- a/service/controller/resource/cloudconfig/update_test.go
+++ b/service/controller/resource/cloudconfig/update_test.go
@@ -1,0 +1,202 @@
+package cloudconfig
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
+	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	g8sfake "github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
+	"github.com/giantswarm/certs/certstest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/azure-operator/v4/service/controller/controllercontext"
+)
+
+const (
+	storageAccountNameTest = "storageaccountnametest"
+	containerNameTest      = "containernametest"
+)
+
+func Test_Resource_ContainerObject_newUpdate(t *testing.T) {
+	t.Parallel()
+	clusterTpo := providerv1alpha1.AzureConfig{
+		Spec: providerv1alpha1.AzureConfigSpec{
+			Cluster: providerv1alpha1.Cluster{
+				ID: "test-cluster",
+			},
+		},
+	}
+
+	testCases := []struct {
+		description   string
+		obj           providerv1alpha1.AzureConfig
+		currentState  []ContainerObjectState
+		desiredState  []ContainerObjectState
+		expectedState []ContainerObjectState
+	}{
+		{
+			description:   "current state empty, desired state empty, empty update change",
+			obj:           clusterTpo,
+			currentState:  []ContainerObjectState{},
+			desiredState:  []ContainerObjectState{},
+			expectedState: []ContainerObjectState{},
+		},
+		{
+			description:  "current state empty, desired state not empty, not-empty update change",
+			obj:          clusterTpo,
+			currentState: []ContainerObjectState{},
+			desiredState: []ContainerObjectState{
+				{
+					Body:               "master-body",
+					ContainerName:      containerNameTest,
+					Key:                prefixMaster,
+					StorageAccountName: storageAccountNameTest,
+				},
+			},
+			expectedState: []ContainerObjectState{
+				{
+					Body:               "master-body",
+					ContainerName:      containerNameTest,
+					Key:                prefixMaster,
+					StorageAccountName: storageAccountNameTest,
+				},
+			},
+		},
+		{
+			description: "current state matches desired state, empty update change",
+			obj:         clusterTpo,
+			currentState: []ContainerObjectState{
+				{
+					Body:               "master-body",
+					ContainerName:      containerNameTest,
+					Key:                prefixMaster,
+					StorageAccountName: storageAccountNameTest,
+				},
+			},
+			desiredState: []ContainerObjectState{
+				{
+					Body:               "master-body",
+					ContainerName:      containerNameTest,
+					Key:                prefixMaster,
+					StorageAccountName: storageAccountNameTest,
+				},
+			},
+			expectedState: []ContainerObjectState{},
+		},
+		{
+			description: "current state does not match desired state, update container object",
+			obj:         clusterTpo,
+			currentState: []ContainerObjectState{
+				{
+					Body:               "master-body",
+					ContainerName:      containerNameTest,
+					Key:                prefixMaster,
+					StorageAccountName: storageAccountNameTest,
+				},
+			},
+			desiredState: []ContainerObjectState{
+				{
+					Body:               "master-new-body",
+					ContainerName:      containerNameTest,
+					Key:                prefixMaster,
+					StorageAccountName: storageAccountNameTest,
+				},
+			},
+			expectedState: []ContainerObjectState{
+				{
+					Body:               "master-new-body",
+					ContainerName:      containerNameTest,
+					Key:                prefixMaster,
+					StorageAccountName: storageAccountNameTest,
+				},
+			},
+		},
+		{
+			description: "current state does not match desired state, update container object",
+			obj:         clusterTpo,
+			currentState: []ContainerObjectState{
+				{
+					Body:               "master-body",
+					ContainerName:      containerNameTest,
+					Key:                prefixMaster,
+					StorageAccountName: storageAccountNameTest,
+				},
+				{
+					Body:               "worker-body",
+					ContainerName:      containerNameTest,
+					Key:                prefixWorker,
+					StorageAccountName: storageAccountNameTest,
+				},
+			},
+			desiredState: []ContainerObjectState{
+				{
+					Body:               "master-new-body",
+					ContainerName:      containerNameTest,
+					Key:                prefixMaster,
+					StorageAccountName: storageAccountNameTest,
+				},
+				{
+					Body:               "worker-body",
+					ContainerName:      containerNameTest,
+					Key:                prefixWorker,
+					StorageAccountName: storageAccountNameTest,
+				},
+			},
+			expectedState: []ContainerObjectState{
+				{
+					Body:               "master-new-body",
+					ContainerName:      containerNameTest,
+					Key:                prefixMaster,
+					StorageAccountName: storageAccountNameTest,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+
+			var err error
+			var newResource *Resource
+			{
+				c := Config{
+					CertsSearcher:         certstest.NewSearcher(certstest.Config{}),
+					G8sClient:             g8sfake.NewSimpleClientset(),
+					K8sClient:             fake.NewSimpleClientset(),
+					Logger:                microloggertest.New(),
+					RegistryDomain:        "quay.io",
+					StorageAccountsClient: &storage.AccountsClient{},
+				}
+
+				newResource, err = New(c)
+				if err != nil {
+					t.Fatal("expected", nil, "got", err)
+				}
+			}
+
+			cloudconfig := &CloudConfigMock{}
+
+			ctx := context.TODO()
+			c := controllercontext.Context{
+				CloudConfig: cloudconfig,
+			}
+			ctx = controllercontext.NewContext(ctx, c)
+
+			result, err := newResource.newUpdateChange(ctx, tc.currentState, tc.desiredState)
+			if err != nil {
+				t.Errorf("expected '%v' got '%#v'", nil, err)
+			}
+			updateChange, ok := result.([]ContainerObjectState)
+			if !ok {
+				t.Errorf("expected '%T', got '%T'", updateChange, result)
+			}
+
+			if !reflect.DeepEqual(tc.expectedState, updateChange) {
+				t.Error("expected", tc.expectedState, "got", updateChange)
+			}
+		})
+	}
+}

--- a/service/controller/resource/containerurl/create.go
+++ b/service/controller/resource/containerurl/create.go
@@ -19,7 +19,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	containerName := key.BlobContainerName()
 	groupName := key.ClusterID(&cr)
-	storageAccountName := key.StorageAccountName(cr)
+	storageAccountName := key.StorageAccountName(&cr)
 
 	storageAccountsClient, err := r.getStorageAccountsClient(ctx)
 	if err != nil {

--- a/service/controller/resource/deployment/deployment.go
+++ b/service/controller/resource/deployment/deployment.go
@@ -40,7 +40,7 @@ func (r Resource) newDeployment(ctx context.Context, customObject providerv1alph
 		"hostClusterCidr":            r.azure.HostCluster.CIDR,
 		"kubernetesAPISecurePort":    key.APISecurePort(customObject),
 		"masterSubnetCidr":           key.MastersSubnetCIDR(customObject),
-		"storageAccountName":         key.StorageAccountName(customObject),
+		"storageAccountName":         key.StorageAccountName(&customObject),
 		"virtualNetworkCidr":         key.VnetCIDR(customObject),
 		"virtualNetworkName":         key.VnetName(customObject),
 		"vnetGatewaySubnetName":      key.VNetGatewaySubnetName(),

--- a/service/controller/resource/encryptionkey/create.go
+++ b/service/controller/resource/encryptionkey/create.go
@@ -36,7 +36,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	secret = &corev1.Secret{
 		Type: corev1.SecretTypeOpaque,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      key.CertificateEncryptionSecretName(cr),
+			Name:      key.CertificateEncryptionSecretName(&cr),
 			Namespace: key.CertificateEncryptionNamespace,
 			Labels: map[string]string{
 				key.LabelCluster:      key.ClusterID(&cr),

--- a/service/controller/resource/encryptionkey/delete.go
+++ b/service/controller/resource/encryptionkey/delete.go
@@ -19,7 +19,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	{
 		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting encryptionkey secret upon delete event")
 
-		err = r.k8sClient.CoreV1().Secrets(key.CertificateEncryptionNamespace).Delete(key.CertificateEncryptionSecretName(cr), &metav1.DeleteOptions{})
+		err = r.k8sClient.CoreV1().Secrets(key.CertificateEncryptionNamespace).Delete(key.CertificateEncryptionSecretName(&cr), &metav1.DeleteOptions{})
 		if errors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "encryptionkey secret already deleted")
 		} else if err != nil {

--- a/service/controller/resource/instance/deployment.go
+++ b/service/controller/resource/instance/deployment.go
@@ -30,7 +30,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 
 	prefixWorker := key.PrefixWorker()
 
-	workerBlobName := key.BlobName(obj, prefixWorker)
+	workerBlobName := key.BlobName(&obj, prefixWorker)
 	cloudConfigURLs := []string{
 		workerBlobName,
 	}
@@ -49,7 +49,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 		}
 	}
 
-	certificateEncryptionSecretName := key.CertificateEncryptionSecretName(obj)
+	certificateEncryptionSecretName := key.CertificateEncryptionSecretName(&obj)
 	encrypter, err := r.GetEncrypterObject(ctx, certificateEncryptionSecretName)
 	if apierrors.IsNotFound(err) {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "encryptionkey secret is not found", "secretname", certificateEncryptionSecretName)
@@ -69,7 +69,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 	}
 
 	groupName := key.ResourceGroupName(obj)
-	storageAccountName := key.StorageAccountName(obj)
+	storageAccountName := key.StorageAccountName(&obj)
 	keys, err := storageAccountsClient.ListKeys(ctx, groupName, storageAccountName, "")
 	if err != nil {
 		return azureresource.Deployment{}, microerror.Mask(err)

--- a/service/controller/resource/masters/deployment.go
+++ b/service/controller/resource/masters/deployment.go
@@ -30,7 +30,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 
 	prefixMaster := key.PrefixMaster()
 
-	masterBlobName := key.BlobName(obj, prefixMaster)
+	masterBlobName := key.BlobName(&obj, prefixMaster)
 	cloudConfigURLs := []string{
 		masterBlobName,
 	}
@@ -49,7 +49,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 		}
 	}
 
-	certificateEncryptionSecretName := key.CertificateEncryptionSecretName(obj)
+	certificateEncryptionSecretName := key.CertificateEncryptionSecretName(&obj)
 	encrypter, err := r.GetEncrypterObject(ctx, certificateEncryptionSecretName)
 	if apierrors.IsNotFound(err) {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "encryptionkey secret is not found", "secretname", certificateEncryptionSecretName)
@@ -69,7 +69,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 	}
 
 	groupName := key.ResourceGroupName(obj)
-	storageAccountName := key.StorageAccountName(obj)
+	storageAccountName := key.StorageAccountName(&obj)
 	keys, err := storageAccountsClient.ListKeys(ctx, groupName, storageAccountName, "")
 	if err != nil {
 		return azureresource.Deployment{}, microerror.Mask(err)

--- a/service/service.go
+++ b/service/service.go
@@ -40,11 +40,12 @@ type Config struct {
 	Flag  *flag.Flag
 	Viper *viper.Viper
 
-	Description string
-	GitCommit   string
-	ProjectName string
-	Source      string
-	Version     string
+	Description    string
+	GitCommit      string
+	ProjectName    string
+	RegistryDomain string
+	Source         string
+	Version        string
 }
 
 type Service struct {
@@ -307,6 +308,7 @@ func New(config Config) (*Service, error) {
 			K8sClient:                 k8sClient,
 			Locker:                    kubeLockLocker,
 			Logger:                    config.Logger,
+			RegistryDomain:            config.Viper.GetString(config.Flag.Service.RegistryDomain),
 			SentryDSN:                 sentryDSN,
 		}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/11926

We have an operatorkit handler that saves an Azure blob object with the `cloud-config` files required for our nodes. In order to render these files we need some information about the cluster being created, and until now, this operatorkit resource was executed receiving the old `AzureConfig` CR which contained all the required information.

But now we want to create the `cloud-config` files when we create different node pools. So I copied the whole `blobobject` resource and call it `cloudconfig`. They are the same, but
- `cloudconfig` will be executed on `AzureMachinePool` events, using info from `AzureMachinePool`, `AzureCluster`, `MachinePool` and `Cluster`.
- `blobobject` will be executed on `AzureConfig` events, using info from `AzureConfig`.