### PR TITLE
Scale strategy

### DIFF
--- a/service/controller/resource/instance/create_scale_workers.go
+++ b/service/controller/resource/instance/create_scale_workers.go
@@ -55,7 +55,7 @@ func (r *Resource) scaleUpWorkerVMSSTransition(ctx context.Context, obj interfac
 		return ScaleUpWorkerVMSS, nil
 	}
 
-	strategy := scalestrategy.Incremental{}
+	strategy := scalestrategy.Quick{}
 
 	// All workers ready, we can scale up if needed.
 	if desiredWorkerCount > currentWorkerCount {

--- a/service/controller/resource/instance/internal/scalestrategy/incremental.go
+++ b/service/controller/resource/instance/internal/scalestrategy/incremental.go
@@ -1,0 +1,16 @@
+package scalestrategy
+
+type Incremental struct {
+}
+
+func (i Incremental) GetNodeCount(currentCount int64, desiredCount int64) int64 {
+	if currentCount < desiredCount {
+		return currentCount + 1
+	}
+
+	if currentCount > desiredCount {
+		return currentCount - 1
+	}
+
+	return currentCount
+}

--- a/service/controller/resource/instance/internal/scalestrategy/interface.go
+++ b/service/controller/resource/instance/internal/scalestrategy/interface.go
@@ -1,0 +1,5 @@
+package scalestrategy
+
+type Interface interface {
+	GetNodeCount(currentCount int64, desiredCount int64) int64
+}

--- a/service/controller/resource/instance/internal/scalestrategy/quick.go
+++ b/service/controller/resource/instance/internal/scalestrategy/quick.go
@@ -1,0 +1,8 @@
+package scalestrategy
+
+type Quick struct {
+}
+
+func (i Quick) GetNodeCount(currentCount int64, desiredCount int64) int64 {
+	return desiredCount
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/11995

This PR aims at making configurable (in the future) the strategy we use to scale up worker nodes during cluster upgrades.
Currently we add the worker nodes 1 by 1 until we double the cluster size (done to be gentle with azure APIs and avoid 429s).
With this PR we will switch back to the `quick` strategy of doubling the cluster size in one go.