### PR TITLE
Avoid dependency with controllercontext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mapping from Cluster API & CAPZ CRs to AzureConfig. This change provides migration path towards Azure Cluster API implementation.
 - State machine flowchart generation.
 - Support to forward errors to Sentry.
+- New `cloudconfig` handler for the `AzureCluster` controller that creates the required cloudconfig files in the Storage Account.
 
 ### Changed
 

--- a/pkg/credential/spec.go
+++ b/pkg/credential/spec.go
@@ -9,3 +9,9 @@ import (
 type Provider interface {
 	GetOrganizationAzureCredentials(ctx context.Context, credentialNamespace, credentialName string) (auth.ClientCredentialsConfig, string, string, error)
 }
+type EmptyProvider struct {
+}
+
+func (p EmptyProvider) GetOrganizationAzureCredentials(ctx context.Context, credentialNamespace, credentialName string) (auth.ClientCredentialsConfig, string, string, error) {
+	return auth.ClientCredentialsConfig{}, "", "", nil
+}

--- a/service/controller/resource/cloudconfig/desired.go
+++ b/service/controller/resource/cloudconfig/desired.go
@@ -41,6 +41,11 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		return nil, microerror.Mask(err)
 	}
 
+	release, err := r.getReleaseFromMetadata(ctx, azureCluster.ObjectMeta)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -70,7 +75,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 
 	var ignitionTemplateData cloudconfig.IgnitionTemplateData
 	{
-		versions, err := k8scloudconfig.ExtractComponentVersions(cc.Release.Release.Spec.Components)
+		versions, err := k8scloudconfig.ExtractComponentVersions(release.Spec.Components)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/service/controller/resource/cloudconfig/error.go
+++ b/service/controller/resource/cloudconfig/error.go
@@ -1,9 +1,23 @@
 package cloudconfig
 
 import (
+	"strings"
+
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/giantswarm/microerror"
 )
+
+// executionFailedError is an error type for situations where Resource
+// execution cannot continue and must always fall back to operatorkit.
+//
+// This error should never be matched against and therefore there is no matcher
+// implement. For further information see:
+//
+//     https://github.com/giantswarm/fmt/blob/master/go/errors.md#matching-errors
+//
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
 
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",
@@ -49,4 +63,24 @@ var wrongTypeError = &microerror.Error{
 // IsWrongTypeError asserts wrongTypeError.
 func IsWrongTypeError(err error) bool {
 	return microerror.Cause(err) == wrongTypeError
+}
+
+// IsStorageAccountNotProvisioned asserts storage account not provisioned error from upstream's API message.
+func IsStorageAccountNotProvisioned(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(microerror.Cause(err).Error(), "StorageAccountIsNotProvisioned")
+}
+
+var tooManyCredentialsError = &microerror.Error{
+	Kind: "tooManyCredentialsError",
+}
+
+var missingOrganizationLabel = &microerror.Error{
+	Kind: "missingOrganizationLabel",
+}
+
+var missingReleaseVersionLabel = &microerror.Error{
+	Kind: "missingReleaseVersionLabel",
 }

--- a/service/service.go
+++ b/service/service.go
@@ -301,6 +301,7 @@ func New(config Config) (*Service, error) {
 	var machinePoolController *controller.MachinePool
 	{
 		c := controller.MachinePoolConfig{
+			CredentialProvider:        credentialProvider,
 			GSClientCredentialsConfig: gsClientCredentialsConfig,
 			GuestSubnetMaskBits:       config.Viper.GetInt(config.Flag.Service.Installation.Guest.IPAM.Network.SubnetMaskBits),
 			InstallationName:          config.Viper.GetString(config.Flag.Service.Installation.Name),


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12024

[The `cloudconfig` handler was copied from the `blobobject` handler](https://github.com/giantswarm/azure-operator/pull/881). The latter was depending on another handler setting values in the controller context. With these changes, the `cloudconfig` handler is independent and doesn't need other handlers.