### PR TITLE
update-k8s-network-setup image to 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Calculate CIDR for a new Tenant Cluster using a local resource rather than getting it from `kubernetesd`.
 - Migrate the `vmsscheck` guards to use the Azure client factory.
 - Use `0.1.0` tag for `k8s-api-heahtz` image.
-- Use `0.1.0` tag for `k8s-setup-network-env` image.
+- Use `0.2.0` tag for `k8s-setup-network-env` image.
 
 ### Removed
 

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -65,7 +65,7 @@ const (
 	kubernetesAPIHealthzVersion = "0.1.0"
 
 	// k8s-setup-network-environment.
-	kubernetesNetworkSetupDocker = "0.1.0"
+	kubernetesNetworkSetupDocker = "0.2.0"
 )
 
 var (


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/11585

changes in `k8s-setup-network-env` are here https://github.com/giantswarm/giantswarm/issues/11585

for azure its mostly cosmetic change

## Checklist

- [x] Update changelog in CHANGELOG.md.
