### PR TITLE
Avoid dependency with controllercontext

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "4.2.0-dev"
+	version            = "5.0.0-cloudconfig"
 )
 
 func Description() string {

--- a/service/controller/resource/cloudconfig/create.go
+++ b/service/controller/resource/cloudconfig/create.go
@@ -7,12 +7,31 @@ import (
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/blobclient"
-	"github.com/giantswarm/azure-operator/v4/service/controller/controllercontext"
+	"github.com/giantswarm/azure-operator/v4/service/controller/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
-	cc, err := controllercontext.FromContext(ctx)
+	cr, err := key.ToAzureMachinePool(obj)
 	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	credentialSecret, err := r.getCredentialSecret(ctx, &cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	storageAccountsClient, err := r.azureClientsFactory.GetStorageAccountsClient(credentialSecret.Namespace, credentialSecret.Name)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	containerURL, err := r.getContainerURL(ctx, storageAccountsClient, key.ClusterID(&cr), key.BlobContainerName(), key.StorageAccountName(&cr))
+	if IsStorageAccountNotProvisioned(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found storage account is not provisioned")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return microerror.Mask(err)
+	} else if err != nil {
 		return microerror.Mask(err)
 	}
 
@@ -24,7 +43,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	for _, containerObject := range containerObjectToCreate {
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating container object %#q", containerObject.Key))
 
-		_, err := blobclient.PutBlockBlob(ctx, containerObject.Key, containerObject.Body, cc.ContainerURL)
+		_, err := blobclient.PutBlockBlob(ctx, containerObject.Key, containerObject.Body, containerURL)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/resource/cloudconfig/current.go
+++ b/service/controller/resource/cloudconfig/current.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/blobclient"
 	"github.com/giantswarm/azure-operator/v4/service/controller/key"
@@ -48,7 +47,6 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 	if !containerExists {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find blob object's container")
-		resourcecanceledcontext.SetCanceled(ctx)
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return nil, nil
 	}

--- a/service/controller/resource/cloudconfig/current.go
+++ b/service/controller/resource/cloudconfig/current.go
@@ -31,10 +31,10 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	containerURL, err := r.getContainerURL(ctx, storageAccountsClient, key.ClusterID(&cr), key.BlobContainerName(), key.StorageAccountName(&cr))
-	if IsStorageAccountNotProvisioned(err) {
+	if IsNotFound(err) || IsStorageAccountNotProvisioned(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "found storage account is not provisioned")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
-		return nil, microerror.Mask(err)
+		return nil, nil
 	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/cloudconfig/desired.go
+++ b/service/controller/resource/cloudconfig/desired.go
@@ -116,23 +116,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		}
 	}
 
-	output := []ContainerObjectState{}
-	{
-		b, err := cloudConfig.NewMasterTemplate(ctx, ignitionTemplateData, encrypter)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-		k := key.BlobName(&cr, prefixMaster)
-		containerObjectState := ContainerObjectState{
-			Body:               b,
-			ContainerName:      containerName,
-			Key:                k,
-			StorageAccountName: storageAccountName,
-		}
-
-		output = append(output, containerObjectState)
-	}
-
+	var output []ContainerObjectState
 	{
 		b, err := cloudConfig.NewWorkerTemplate(ctx, ignitionTemplateData, encrypter)
 		if err != nil {

--- a/service/controller/resource/cloudconfig/desired.go
+++ b/service/controller/resource/cloudconfig/desired.go
@@ -89,6 +89,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 			AzureCluster:     azureCluster,
 			ClusterCerts:     clusterCerts,
 			Images:           images,
+			Versions:         versions,
 		}
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -301,16 +301,20 @@ func New(config Config) (*Service, error) {
 	var machinePoolController *controller.MachinePool
 	{
 		c := controller.MachinePoolConfig{
+			Azure:                     azure,
 			CredentialProvider:        credentialProvider,
 			GSClientCredentialsConfig: gsClientCredentialsConfig,
 			GuestSubnetMaskBits:       config.Viper.GetInt(config.Flag.Service.Installation.Guest.IPAM.Network.SubnetMaskBits),
+			Ignition:                  Ignition,
 			InstallationName:          config.Viper.GetString(config.Flag.Service.Installation.Name),
 			IPAMNetworkRange:          ipamNetworkRange,
 			K8sClient:                 k8sClient,
 			Locker:                    kubeLockLocker,
 			Logger:                    config.Logger,
+			OIDC:                      OIDC,
 			RegistryDomain:            config.Viper.GetString(config.Flag.Service.RegistryDomain),
 			SentryDSN:                 sentryDSN,
+			SSOPublicKey:              config.Viper.GetString(config.Flag.Service.Tenant.SSH.SSOPublicKey),
 		}
 
 		machinePoolController, err = controller.NewMachinePool(c)


### PR DESCRIPTION
Following up on the work started [here](https://github.com/giantswarm/azure-operator/pull/891), I'm removing the last `controllercontext` dependency (I hope) from the `cloudconfig` handler.