### PR TITLE
Bump k8scloudconfig to support docker registry mirrors

### DIFF
--- a/flag/service/registry/registry.go
+++ b/flag/service/registry/registry.go
@@ -1,0 +1,6 @@
+package registry
+
+type Registry struct {
+	Domain  string
+	Mirrors string
+}

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -6,16 +6,17 @@ import (
 	"github.com/giantswarm/azure-operator/v4/flag/service/azure"
 	"github.com/giantswarm/azure-operator/v4/flag/service/cluster"
 	"github.com/giantswarm/azure-operator/v4/flag/service/installation"
+	"github.com/giantswarm/azure-operator/v4/flag/service/registry"
 	"github.com/giantswarm/azure-operator/v4/flag/service/sentry"
 	"github.com/giantswarm/azure-operator/v4/flag/service/tenant"
 )
 
 type Service struct {
-	Azure          azure.Azure
-	Cluster        cluster.Cluster
-	Installation   installation.Installation
-	Kubernetes     kubernetes.Kubernetes
-	RegistryDomain string
-	Tenant         tenant.Tenant
-	Sentry         sentry.Sentry
+	Azure        azure.Azure
+	Cluster      cluster.Cluster
+	Installation installation.Installation
+	Kubernetes   kubernetes.Kubernetes
+	Registry     registry.Registry
+	Tenant       tenant.Tenant
+	Sentry       sentry.Sentry
 }

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/giantswarm/k8sclient v0.2.0
 	github.com/giantswarm/k8sclient/v2 v2.0.0
 	github.com/giantswarm/k8sclient/v3 v3.1.0
-	github.com/giantswarm/k8scloudconfig/v6 v6.3.0
+	github.com/giantswarm/k8scloudconfig/v7 v7.0.0
 	github.com/giantswarm/kubelock v0.2.0
 	github.com/giantswarm/microendpoint v0.2.0
 	github.com/giantswarm/microerror v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -294,8 +294,10 @@ github.com/giantswarm/k8sclient/v2 v2.0.0 h1:vhqMIM7vxlvfkCIzPwkbRRh+O4O91g9ArBn
 github.com/giantswarm/k8sclient/v2 v2.0.0/go.mod h1:4qkgg7+wF6IrwEB1oWYUFLmhft/1pBfGV08NFJSrBb4=
 github.com/giantswarm/k8sclient/v3 v3.1.0 h1:5Zk9P0hBR3afkdFHkSne3ZwNqbvrp3KRWAyjUQ1oVm0=
 github.com/giantswarm/k8sclient/v3 v3.1.0/go.mod h1:kDOgbAQ3V8YqroN4T7RVPk+rapvT/IV2KNNbxfM2xys=
-github.com/giantswarm/k8scloudconfig/v6 v6.3.0 h1:cEy2OgoJO/FTNfgjSgiatZ4RE7vZl6PvPomZ/4OOe4U=
-github.com/giantswarm/k8scloudconfig/v6 v6.3.0/go.mod h1:nwERYPiJxyon8TQSaRbblnG+E2fAXUNEF7mUUEmL5qI=
+github.com/giantswarm/k8scloudconfig/v6 v6.4.0 h1:X9iUtxl/f3cITAnJWEwP/3F9+7pUowlJbvWaXgL968Y=
+github.com/giantswarm/k8scloudconfig/v6 v6.4.0/go.mod h1:nwERYPiJxyon8TQSaRbblnG+E2fAXUNEF7mUUEmL5qI=
+github.com/giantswarm/k8scloudconfig/v7 v7.0.0 h1:ScfhaKm5jrsl0jNqQAoETsLU5rE2xoxLIyfHJrCmMhQ=
+github.com/giantswarm/k8scloudconfig/v7 v7.0.0/go.mod h1:e7e2JOoXZGjAHApWqrfLsO51vwUL/9eyMXyzqzQHOK0=
 github.com/giantswarm/k8sportforward v0.2.0 h1:nzyKUtSWEbayvF74u3Pkr8AKKa3rk6LccxuIONDq4T8=
 github.com/giantswarm/k8sportforward v0.2.0/go.mod h1:+hyTTG0V2f3V28hDyEhJZQ341LTgSeXCgcZO2AeqLlI=
 github.com/giantswarm/kubelock v0.2.0 h1:4zSD/DSRUKuLoabheYHyHb7dEbC172GPinG0/NSIuJY=

--- a/helm/azure-operator/templates/configmap.yaml
+++ b/helm/azure-operator/templates/configmap.yaml
@@ -84,6 +84,9 @@ data:
       kubernetes:
         incluster: true
       registryDomain: '{{ .Values.Installation.V1.Registry.Domain }}'
+      registry:
+        domain: '{{ .Values.Installation.V1.Registry.Domain }}'
+        mirrors: '{{ range $i, $e := .Values.Installation.V1.Registry.Mirrors }}{{ if $i }},{{end}}{{ $e }}{{end}}'
       tenant:
         ssh:
           ssoPublicKey: '{{ .Values.Installation.V1.Guest.SSH.SSOPublicKey }}'

--- a/main.go
+++ b/main.go
@@ -171,13 +171,14 @@ func mainError() error {
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CAFile, "", "Certificate authority file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CrtFile, "", "Certificate file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.KeyFile, "", "Key file path to use to authenticate with Kubernetes.")
-	daemonCommand.PersistentFlags().String(f.Service.RegistryDomain, "quay.io", "Image registry.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Tenant.Ignition.Debug.Enabled, false, "Enable services which help debugging ignition.")
 	daemonCommand.PersistentFlags().String(f.Service.Tenant.Ignition.Debug.LogsPrefix, "", "Enable services which help debugging ignition.")
 	daemonCommand.PersistentFlags().String(f.Service.Tenant.Ignition.Debug.LogsToken, "", "Enable services which help debugging ignition.")
 	daemonCommand.PersistentFlags().String(f.Service.Tenant.Ignition.Path, "/opt/ignition", "Default path for the ignition base directory.")
 	daemonCommand.PersistentFlags().String(f.Service.Tenant.SSH.SSOPublicKey, "", "Public key for trusted SSO CA.")
 	daemonCommand.PersistentFlags().String(f.Service.Sentry.DSN, "", "DSN of the Sentry instance to forward errors to.")
+	daemonCommand.PersistentFlags().String(f.Service.Registry.Domain, "docker.io", "Image registry domain.")
+	daemonCommand.PersistentFlags().StringSlice(f.Service.Registry.Mirrors, []string{}, `Image registry mirror domains. Can be set only if registry domain is "docker.io".`)
 
 	return newCommand.CobraCommand().Execute()
 }

--- a/service/controller/cloudconfig/cloud_config.go
+++ b/service/controller/cloudconfig/cloud_config.go
@@ -4,7 +4,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v6/pkg/template"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v7/pkg/template"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/randomkeys"
@@ -31,6 +31,7 @@ type Config struct {
 	AzureClientCredentials auth.ClientCredentialsConfig
 	Ignition               setting.Ignition
 	OIDC                   setting.OIDC
+	RegistryMirrors        []string
 	SSOPublicKey           string
 	SubscriptionID         string
 }
@@ -43,6 +44,7 @@ type CloudConfig struct {
 	azureClientCredentials auth.ClientCredentialsConfig
 	ignition               setting.Ignition
 	OIDC                   setting.OIDC
+	registryMirrors        []string
 	ssoPublicKey           string
 	subscriptionID         string
 }
@@ -78,6 +80,7 @@ func New(config Config) (*CloudConfig, error) {
 		azureClientCredentials: config.AzureClientCredentials,
 		ignition:               config.Ignition,
 		OIDC:                   config.OIDC,
+		registryMirrors:        config.RegistryMirrors,
 		ssoPublicKey:           config.SSOPublicKey,
 		subscriptionID:         config.SubscriptionID,
 	}

--- a/service/controller/cloudconfig/master_template.go
+++ b/service/controller/cloudconfig/master_template.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v6/pkg/template"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v7/pkg/template"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/encrypter"
@@ -114,6 +114,7 @@ func (c CloudConfig) NewMasterTemplate(ctx context.Context, data IgnitionTemplat
 			LogsToken:  c.ignition.LogsToken,
 		}
 		params.Images = data.Images
+		params.RegistryMirrors = c.registryMirrors
 		params.Versions = data.Versions
 		params.SSOPublicKey = c.ssoPublicKey
 	}

--- a/service/controller/cloudconfig/types.go
+++ b/service/controller/cloudconfig/types.go
@@ -3,7 +3,7 @@ package cloudconfig
 import (
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v6/pkg/template"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v7/pkg/template"
 	"github.com/giantswarm/randomkeys"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"

--- a/service/controller/cloudconfig/worker_template.go
+++ b/service/controller/cloudconfig/worker_template.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v6/pkg/template"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v7/pkg/template"
 	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/encrypter"
@@ -52,6 +52,7 @@ func (c CloudConfig) NewWorkerTemplate(ctx context.Context, data IgnitionTemplat
 			LogsToken:  c.ignition.LogsToken,
 		}
 		params.Images = data.Images
+		params.RegistryMirrors = c.registryMirrors
 		params.Versions = data.Versions
 		params.SSOPublicKey = c.ssoPublicKey
 

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -67,6 +67,7 @@ type ClusterConfig struct {
 	GSClientCredentialsConfig auth.ClientCredentialsConfig
 	ProjectName               string
 	RegistryDomain            string
+	RegistryMirrors           []string
 
 	GuestSubnetMaskBits int
 
@@ -153,6 +154,7 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 						AzureClientCredentials: organizationAzureClientCredentialsConfig,
 						Ignition:               config.Ignition,
 						OIDC:                   config.OIDC,
+						RegistryMirrors:        config.RegistryMirrors,
 						SSOPublicKey:           config.SSOPublicKey,
 						SubscriptionID:         subscriptionID,
 					}

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/to"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v6/pkg/template"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v7/pkg/template"
 	"github.com/giantswarm/microerror"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"

--- a/service/controller/resource/blobobject/desired.go
+++ b/service/controller/resource/blobobject/desired.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v6/pkg/template"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v7/pkg/template"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/service/controller/resource/cloudconfig/desired.go
+++ b/service/controller/resource/cloudconfig/desired.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v6/pkg/template"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v7/pkg/template"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/service/service.go
+++ b/service/service.go
@@ -218,7 +218,7 @@ func New(config Config) (*Service, error) {
 			OIDC:             OIDC,
 			InstallationName: config.Viper.GetString(config.Flag.Service.Installation.Name),
 			ProjectName:      config.ProjectName,
-			RegistryDomain:   config.Viper.GetString(config.Flag.Service.RegistryDomain),
+			RegistryDomain:   config.Viper.GetString(config.Flag.Service.Registry.Domain),
 			SSOPublicKey:     config.Viper.GetString(config.Flag.Service.Tenant.SSH.SSOPublicKey),
 			VMSSCheckWorkers: config.Viper.GetInt(config.Flag.Service.Azure.VMSSCheckWorkers),
 
@@ -286,7 +286,8 @@ func New(config Config) (*Service, error) {
 			Logger:                    config.Logger,
 			OIDC:                      OIDC,
 			ProjectName:               config.ProjectName,
-			RegistryDomain:            config.Viper.GetString(config.Flag.Service.RegistryDomain),
+			RegistryDomain:            config.Viper.GetString(config.Flag.Service.Registry.Domain),
+			RegistryMirrors:           config.Viper.GetStringSlice(config.Flag.Service.Registry.Mirrors),
 			SentryDSN:                 sentryDSN,
 			SSOPublicKey:              config.Viper.GetString(config.Flag.Service.Tenant.SSH.SSOPublicKey),
 			VMSSCheckWorkers:          config.Viper.GetInt(config.Flag.Service.Azure.VMSSCheckWorkers),
@@ -309,7 +310,7 @@ func New(config Config) (*Service, error) {
 			K8sClient:                 k8sClient,
 			Locker:                    kubeLockLocker,
 			Logger:                    config.Logger,
-			RegistryDomain:            config.Viper.GetString(config.Flag.Service.RegistryDomain),
+			RegistryDomain:            config.Viper.GetString(config.Flag.Service.Registry.Domain),
 			SentryDSN:                 sentryDSN,
 		}
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/12126

This PR adds support for docker registry mirrors.
I tested it out and it seems to work just fine.