### PR TITLE
Use same namespace than watched CR

### DIFF
--- a/service/controller/resource/azureclusterconfig/create.go
+++ b/service/controller/resource/azureclusterconfig/create.go
@@ -96,7 +96,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	{
 		nsName := types.NamespacedName{
 			Name:      clusterConfigName(key.ClusterID(&cluster)),
-			Namespace: metav1.NamespaceDefault,
+			Namespace: azureCluster.Namespace,
 		}
 		err = r.ctrlClient.Get(ctx, nsName, &presentAzureClusterConfig)
 		if errors.IsNotFound(err) {
@@ -184,7 +184,7 @@ func (r *Resource) buildAzureClusterConfig(ctx context.Context, cluster capiv1al
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterConfigName(key.ClusterID(&cluster)),
-			Namespace: metav1.NamespaceDefault,
+			Namespace: azureCluster.Namespace,
 			Labels: map[string]string{
 				label.ClusterOperatorVersion: clusterOperatorVersion,
 			},

--- a/service/controller/resource/azureclusterconfig/delete.go
+++ b/service/controller/resource/azureclusterconfig/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/key"
@@ -25,7 +24,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	{
 		nsName := types.NamespacedName{
 			Name:      clusterConfigName(key.ClusterID(&azureCluster)),
-			Namespace: metav1.NamespaceDefault,
+			Namespace: azureCluster.Namespace,
 		}
 		err = r.ctrlClient.Get(ctx, nsName, &azureClusterConfig)
 		if errors.IsNotFound(err) {

--- a/service/controller/resource/azureconfig/create.go
+++ b/service/controller/resource/azureconfig/create.go
@@ -105,7 +105,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	{
 		nsName := types.NamespacedName{
 			Name:      key.ClusterID(&cluster),
-			Namespace: metav1.NamespaceDefault,
+			Namespace: azureCluster.Namespace,
 		}
 		err = r.ctrlClient.Get(ctx, nsName, &presentAzureConfig)
 		if errors.IsNotFound(err) {

--- a/service/controller/resource/azureconfig/delete.go
+++ b/service/controller/resource/azureconfig/delete.go
@@ -7,7 +7,6 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/key"
@@ -25,7 +24,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	{
 		nsName := types.NamespacedName{
 			Name:      key.ClusterID(&azureCluster),
-			Namespace: metav1.NamespaceDefault,
+			Namespace: azureCluster.Namespace,
 		}
 		err = r.ctrlClient.Get(ctx, nsName, &azureConfig)
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12171

The _legacy_ CR's created should be in the same namespace than the watched `AzureCluster`.