### PR TITLE
Delete Spark CR when deleting a node pool

### DIFF
--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -102,12 +102,12 @@ func AzureConfigNetworkCIDR(customObject providerv1alpha1.AzureConfig) string {
 
 func ToAzureMachinePool(v interface{}) (expcapzv1alpha3.AzureMachinePool, error) {
 	if v == nil {
-		return expcapzv1alpha3.AzureMachinePool{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &providerv1alpha1.AzureConfig{}, v)
+		return expcapzv1alpha3.AzureMachinePool{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &expcapzv1alpha3.AzureMachinePool{}, v)
 	}
 
 	customObjectPointer, ok := v.(*expcapzv1alpha3.AzureMachinePool)
 	if !ok {
-		return expcapzv1alpha3.AzureMachinePool{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &providerv1alpha1.AzureConfig{}, v)
+		return expcapzv1alpha3.AzureMachinePool{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &expcapzv1alpha3.AzureMachinePool{}, v)
 	}
 	customObject := *customObjectPointer
 

--- a/service/controller/resource/spark/create.go
+++ b/service/controller/resource/spark/create.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/Azure/go-autorest/autorest/to"
 	corev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	releasev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
@@ -102,10 +103,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 					Namespace: azureMachinePool.Namespace,
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							APIVersion: sparkCR.APIVersion,
-							Kind:       sparkCR.Kind,
-							Name:       sparkCR.Name,
-							UID:        sparkCR.UID,
+							APIVersion:         sparkCR.APIVersion,
+							BlockOwnerDeletion: to.BoolPtr(true),
+							Kind:               sparkCR.Kind,
+							Name:               sparkCR.Name,
+							UID:                sparkCR.UID,
 						},
 					},
 				},

--- a/service/controller/resource/spark/create.go
+++ b/service/controller/resource/spark/create.go
@@ -100,6 +100,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      secretName(sparkCR.Name),
 					Namespace: azureMachinePool.Namespace,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: sparkCR.APIVersion,
+							Kind:       sparkCR.Kind,
+							Name:       sparkCR.Name,
+							UID:        sparkCR.UID,
+						},
+					},
 				},
 				Data: map[string][]byte{
 					ignitionBlobKey: ignitionBlob,

--- a/service/controller/resource/spark/delete.go
+++ b/service/controller/resource/spark/delete.go
@@ -2,9 +2,44 @@ package spark
 
 import (
 	"context"
+
+	corev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-operator/v4/service/controller/key"
 )
 
 // EnsureDeleted will delete the `Spark` CR that was created for this specific node pool, and the `Secret` referenced by it.
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	azureMachinePool, err := key.ToAzureMachinePool(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var sparkCR *corev1alpha1.Spark
+	{
+		err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: azureMachinePool.Namespace, Name: azureMachinePool.Name}, sparkCR)
+		if errors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "bootstrap CR not found when trying to delete it")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "cancelling resource")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	{
+		err = r.ctrlClient.Delete(ctx, sparkCR)
+		if errors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "bootstrap CR not found when trying to delete it")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "cancelling resource")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	return nil
 }

--- a/service/controller/resource/spark/delete.go
+++ b/service/controller/resource/spark/delete.go
@@ -18,9 +18,9 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	var sparkCR *corev1alpha1.Spark
+	var sparkCR corev1alpha1.Spark
 	{
-		err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: azureMachinePool.Namespace, Name: azureMachinePool.Name}, sparkCR)
+		err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: azureMachinePool.Namespace, Name: azureMachinePool.Name}, &sparkCR)
 		if errors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "bootstrap CR not found when trying to delete it")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "cancelling resource")
@@ -31,7 +31,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	}
 
 	{
-		err = r.ctrlClient.Delete(ctx, sparkCR)
+		err = r.ctrlClient.Delete(ctx, &sparkCR)
 		if errors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "bootstrap CR not found when trying to delete it")
 			r.logger.LogCtx(ctx, "level", "debug", "message", "cancelling resource")

--- a/service/controller/resource/spark/delete_test.go
+++ b/service/controller/resource/spark/delete_test.go
@@ -1,0 +1,87 @@
+package spark
+
+import (
+	"context"
+	"testing"
+
+	corev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-operator/v4/service/unittest"
+)
+
+func TestSparkCRIsDeletedWhenDeletingNodePool(t *testing.T) {
+	ctrlClient := unittest.FakeK8sClient().CtrlClient()
+	ctx := context.Background()
+	logger := microloggertest.New()
+	azureMachinePoolNamespace := "default"
+	azureMachinePoolName := "my-azure-machine-pool"
+
+	handler := Resource{
+		ctrlClient: ctrlClient,
+		logger:     logger,
+	}
+
+	givenSparkCRInK8sAPI(ctx, t, ctrlClient, azureMachinePoolNamespace, azureMachinePoolName)
+
+	whenNodePoolIsDeleted(ctx, t, handler, azureMachinePoolNamespace, azureMachinePoolName)
+
+	sparkCRShouldNotExistAnymore(ctx, t, ctrlClient)
+}
+
+func TestNoErrorsIfSparkCRDidntExistAlready(t *testing.T) {
+	fakeK8sClient := unittest.FakeK8sClient()
+	ctx := context.Background()
+	logger := microloggertest.New()
+	azureMachinePoolNamespace := "default"
+	azureMachinePoolName := "my-azure-machine-pool"
+
+	handler := Resource{
+		ctrlClient: fakeK8sClient.CtrlClient(),
+		logger:     logger,
+	}
+
+	whenNodePoolIsDeleted(ctx, t, handler, azureMachinePoolNamespace, azureMachinePoolName)
+}
+
+func givenSparkCRInK8sAPI(ctx context.Context, t *testing.T, ctrlClient client.Client, azureMachinePoolNamespace, azureMachinePoolName string) {
+	sparkCR := corev1alpha1.Spark{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: azureMachinePoolNamespace,
+			Name:      azureMachinePoolName,
+		},
+		Spec: corev1alpha1.SparkSpec{},
+	}
+	err := ctrlClient.Create(ctx, &sparkCR)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func whenNodePoolIsDeleted(ctx context.Context, t *testing.T, handler Resource, azureMachinePoolNamespace, azureMachinePoolName string) {
+	azureMachinePool := &v1alpha3.AzureMachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: azureMachinePoolNamespace,
+			Name:      azureMachinePoolName,
+		},
+		Spec: v1alpha3.AzureMachinePoolSpec{},
+	}
+
+	err := handler.EnsureDeleted(ctx, azureMachinePool)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sparkCRShouldNotExistAnymore(ctx context.Context, t *testing.T, ctrlClient client.Client) {
+	var sparkCR corev1alpha1.Spark
+
+	err := ctrlClient.Get(ctx, client.ObjectKey{Namespace: sparkCR.Namespace, Name: sparkCR.Name}, &sparkCR)
+	if !errors.IsNotFound(err) {
+		t.Fatal("the Spark CR should have been deleted but it's still there")
+	}
+}

--- a/service/unittest/default_k8sclient.go
+++ b/service/unittest/default_k8sclient.go
@@ -1,6 +1,7 @@
 package unittest
 
 import (
+	corev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	releasev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
@@ -27,6 +28,10 @@ func FakeK8sClient() k8sclient.Interface {
 	{
 		scheme := runtime.NewScheme()
 		err = v1.AddToScheme(scheme)
+		if err != nil {
+			panic(err)
+		}
+		err = corev1alpha1.AddToScheme(scheme)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12271

When we use the real Ignition Operator, we wouldn't have to worry about the `Secret` deletion from here. 

But should we care about the `Spark` CR deletion? or should the piece that created it in the first place take care of deleting it @giantswarm/team-ludacris? I mean in the future when we have the Ignition operator in place. 
