### PR TITLE
change jobs dependencies to make circle graph better

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,8 @@ workflows:
       # manual approval to run e2e tests.
       - hold:
           type: approval
+          requires:
+            - push-azure-operator-to-control-plane-app-catalog
 
 #      - architect/integration-test:
 #          name: cluster-state-test
@@ -80,7 +82,6 @@ workflows:
           test-timeout: "90m"
           requires:
           - hold
-          - push-azure-operator-to-control-plane-app-catalog
 
       - architect/integration-test:
           name: multiaz-test
@@ -91,7 +92,6 @@ workflows:
           test-timeout: "70m"
           requires:
           - hold
-          - push-azure-operator-to-control-plane-app-catalog
 
       - architect/integration-test:
           name: cluster-deletion-test
@@ -102,7 +102,6 @@ workflows:
           test-timeout: "70m"
           requires:
           - hold
-          - push-azure-operator-to-control-plane-app-catalog
 
       - architect/integration-test:
           name: update-test
@@ -113,7 +112,6 @@ workflows:
           test-timeout: "180m"
           requires:
           - hold
-          - push-azure-operator-to-control-plane-app-catalog
 
       - architect/integration-test:
           name: cp-tc-connectivity-test
@@ -124,4 +122,3 @@ workflows:
           test-timeout: "70m"
           requires:
           - hold
-          - push-azure-operator-to-control-plane-app-catalog


### PR DESCRIPTION
The goal of this PR is to make circle job dependency a little more elegant.

Before:
![bedore](https://user-images.githubusercontent.com/868430/88778645-1027f400-d189-11ea-8918-7f9ed080638e.png)

After:
![after](https://user-images.githubusercontent.com/868430/88778673-17e79880-d189-11ea-9a7a-4ea4f6b0b555.png)

From a functional point of view nothing changes
