### PR TITLE
Added provider agnostic controllers to manager ownerReferences and labels

### DIFF
--- a/helm/azure-operator/templates/rbac.yaml
+++ b/helm/azure-operator/templates/rbac.yaml
@@ -70,14 +70,13 @@ rules:
       - create
       - delete
       - update
-  # The operator needs read and write access to the provider agnostic CAPI CRDs.
+  # The operator needs access to the provider agnostic CAPI CRDs.
   - apiGroups:
       - exp.cluster.x-k8s.io
     resources:
       - machinepools
     verbs:
-      - get
-      - list
+      - "*"
   # The operator needs read and write access to all provider specific
   # infrastructure CRs we manage for Tenant Clusters.
   - apiGroups:

--- a/service/controller/azure_config.go
+++ b/service/controller/azure_config.go
@@ -1,0 +1,656 @@
+package controller
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs"
+	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/resource"
+	"github.com/giantswarm/operatorkit/resource/crud"
+	"github.com/giantswarm/operatorkit/resource/wrapper/metricsresource"
+	"github.com/giantswarm/operatorkit/resource/wrapper/retryresource"
+	"github.com/giantswarm/randomkeys"
+	"github.com/giantswarm/statusresource"
+	"github.com/giantswarm/tenantcluster"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/giantswarm/azure-operator/v4/client"
+	"github.com/giantswarm/azure-operator/v4/pkg/credential"
+	"github.com/giantswarm/azure-operator/v4/pkg/label"
+	"github.com/giantswarm/azure-operator/v4/pkg/locker"
+	"github.com/giantswarm/azure-operator/v4/pkg/project"
+	"github.com/giantswarm/azure-operator/v4/service/controller/cloudconfig"
+	"github.com/giantswarm/azure-operator/v4/service/controller/controllercontext"
+	"github.com/giantswarm/azure-operator/v4/service/controller/debugger"
+	"github.com/giantswarm/azure-operator/v4/service/controller/internal/vmsscheck"
+	"github.com/giantswarm/azure-operator/v4/service/controller/key"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/blobobject"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/clusterid"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/containerurl"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/deployment"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/dnsrecord"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/encryptionkey"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/endpoints"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/instance"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/ipam"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/masters"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/namespace"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/nodes"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/release"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/resourcegroup"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/service"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/tenantclients"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/vpn"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/vpnconnection"
+	"github.com/giantswarm/azure-operator/v4/service/controller/setting"
+)
+
+type AzureConfigConfig struct {
+	CredentialProvider credential.Provider
+	InstallationName   string
+	K8sClient          k8sclient.Interface
+	Locker             locker.Interface
+	Logger             micrologger.Logger
+
+	Azure setting.Azure
+	// Azure client set used when managing control plane resources
+	CPAzureClientSet *client.AzureClientSet
+	// Azure credentials used to create Azure client set for tenant clusters
+	GSClientCredentialsConfig auth.ClientCredentialsConfig
+	ProjectName               string
+	RegistryDomain            string
+	RegistryMirrors           []string
+
+	GuestSubnetMaskBits int
+
+	Ignition         setting.Ignition
+	IPAMNetworkRange net.IPNet
+	OIDC             setting.OIDC
+	SSOPublicKey     string
+	TemplateVersion  string
+	VMSSCheckWorkers int
+
+	SentryDSN string
+}
+
+type AzureConfig struct {
+	*controller.Controller
+}
+
+func NewAzureConfig(config AzureConfigConfig) (*AzureConfig, error) {
+	var err error
+
+	var certsSearcher *certs.Searcher
+	{
+		c := certs.Config{
+			K8sClient: config.K8sClient.K8sClient(),
+			Logger:    config.Logger,
+
+			WatchTimeout: 5 * time.Second,
+		}
+
+		certsSearcher, err = certs.NewSearcher(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var randomkeysSearcher *randomkeys.Searcher
+	{
+		c := randomkeys.Config{
+			K8sClient: config.K8sClient.K8sClient(),
+			Logger:    config.Logger,
+		}
+
+		randomkeysSearcher, err = randomkeys.NewSearcher(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var resources []resource.Interface
+	{
+		resources, err = newAzureConfigResources(config, certsSearcher)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var operatorkitController *controller.Controller
+	{
+		c := controller.Config{
+			InitCtx: func(ctx context.Context, obj interface{}) (context.Context, error) {
+				cr, err := key.ToCustomResource(obj)
+				if err != nil {
+					return nil, microerror.Mask(err)
+				}
+
+				organizationAzureClientCredentialsConfig, subscriptionID, partnerID, err := config.CredentialProvider.GetOrganizationAzureCredentials(ctx, key.CredentialNamespace(cr), key.CredentialName(cr))
+				if err != nil {
+					return nil, microerror.Mask(err)
+				}
+
+				tenantClusterAzureClientSet, err := client.NewAzureClientSet(organizationAzureClientCredentialsConfig, subscriptionID, partnerID)
+				if err != nil {
+					return nil, microerror.Mask(err)
+				}
+
+				var cloudConfig *cloudconfig.CloudConfig
+				{
+					c := cloudconfig.Config{
+						CertsSearcher:      certsSearcher,
+						Logger:             config.Logger,
+						RandomkeysSearcher: randomkeysSearcher,
+
+						Azure:                  config.Azure,
+						AzureClientCredentials: organizationAzureClientCredentialsConfig,
+						Ignition:               config.Ignition,
+						OIDC:                   config.OIDC,
+						RegistryMirrors:        config.RegistryMirrors,
+						SSOPublicKey:           config.SSOPublicKey,
+						SubscriptionID:         subscriptionID,
+					}
+
+					cloudConfig, err = cloudconfig.New(c)
+					if err != nil {
+						return nil, microerror.Mask(err)
+					}
+				}
+
+				c := controllercontext.Context{
+					AzureClientSet: tenantClusterAzureClientSet,
+					CloudConfig:    cloudConfig,
+				}
+				ctx = controllercontext.NewContext(ctx, c)
+
+				return ctx, nil
+			},
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+			Name:      project.Name() + "-azureconfig-controller",
+			NewRuntimeObjectFunc: func() runtime.Object {
+				return new(v1alpha1.AzureConfig)
+			},
+			Resources: resources,
+			Selector: labels.SelectorFromSet(map[string]string{
+				label.OperatorVersion: project.Version(),
+			}),
+			SentryDSN: config.SentryDSN,
+		}
+
+		operatorkitController, err = controller.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return &AzureConfig{
+		Controller: operatorkitController,
+	}, nil
+}
+
+func newAzureConfigResources(config AzureConfigConfig, certsSearcher certs.Interface) ([]resource.Interface, error) {
+	var err error
+
+	var clientFactory *client.Factory
+	{
+		c := client.FactoryConfig{
+			CacheDuration:      30 * time.Minute,
+			CredentialProvider: config.CredentialProvider,
+			Logger:             config.Logger,
+		}
+
+		clientFactory, err = client.NewFactory(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var newDebugger *debugger.Debugger
+	{
+		c := debugger.Config{
+			Logger: config.Logger,
+		}
+
+		newDebugger, err = debugger.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var tenantCluster tenantcluster.Interface
+	{
+		c := tenantcluster.Config{
+			CertsSearcher: certsSearcher,
+			Logger:        config.Logger,
+
+			CertID: certs.APICert,
+		}
+
+		tenantCluster, err = tenantcluster.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var clusteridResource resource.Interface
+	{
+		c := clusterid.Config{
+			CtrlClient: config.K8sClient.CtrlClient(),
+			Logger:     config.Logger,
+		}
+
+		clusteridResource, err = clusterid.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var statusResource resource.Interface
+	{
+		c := statusresource.ResourceConfig{
+			ClusterEndpointFunc:      key.ToClusterEndpoint,
+			ClusterIDFunc:            key.ToClusterID,
+			ClusterStatusFunc:        key.ToClusterStatus,
+			NodeCountFunc:            key.ToNodeCount,
+			Logger:                   config.Logger,
+			RESTClient:               config.K8sClient.G8sClient().ProviderV1alpha1().RESTClient(),
+			TenantCluster:            tenantCluster,
+			VersionBundleVersionFunc: key.ToOperatorVersion,
+		}
+
+		statusResource, err = statusresource.NewResource(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var tenantClientsResource resource.Interface
+	{
+		c := tenantclients.Config{
+			Logger: config.Logger,
+			Tenant: tenantCluster,
+		}
+
+		tenantClientsResource, err = tenantclients.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var releaseResource resource.Interface
+	{
+		c := release.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		releaseResource, err = release.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var resourceGroupResource resource.Interface
+	{
+		c := resourcegroup.Config{
+			Logger: config.Logger,
+
+			Azure:            config.Azure,
+			InstallationName: config.InstallationName,
+		}
+
+		resourceGroupResource, err = resourcegroup.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var containerURLResource resource.Interface
+	{
+		c := containerurl.Config{
+			Logger: config.Logger,
+		}
+
+		containerURLResource, err = containerurl.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var encryptionkeyResource resource.Interface
+	{
+		c := encryptionkey.Config{
+			K8sClient:   config.K8sClient.K8sClient(),
+			Logger:      config.Logger,
+			ProjectName: config.ProjectName,
+		}
+
+		encryptionkeyResource, err = encryptionkey.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var blobObjectResource resource.Interface
+	{
+		c := blobobject.Config{
+			CertsSearcher:  certsSearcher,
+			G8sClient:      config.K8sClient.G8sClient(),
+			K8sClient:      config.K8sClient.K8sClient(),
+			Logger:         config.Logger,
+			RegistryDomain: config.RegistryDomain,
+		}
+
+		blobObject, err := blobobject.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		blobObjectResource, err = toCRUDResource(config.Logger, blobObject)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var deploymentResource resource.Interface
+	{
+		c := deployment.Config{
+			Debugger:         newDebugger,
+			G8sClient:        config.K8sClient.G8sClient(),
+			InstallationName: config.InstallationName,
+			Logger:           config.Logger,
+
+			Azure:                      config.Azure,
+			ClientFactory:              clientFactory,
+			ControlPlaneSubscriptionID: config.CPAzureClientSet.SubscriptionID,
+		}
+
+		deploymentResource, err = deployment.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var dnsrecordResource resource.Interface
+	{
+		c := dnsrecord.Config{
+			CPRecordSetsClient: *config.CPAzureClientSet.DNSRecordSetsClient,
+			Logger:             config.Logger,
+		}
+
+		ops, err := dnsrecord.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		dnsrecordResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var endpointsResource resource.Interface
+	{
+		c := endpoints.Config{
+			K8sClient: config.K8sClient.K8sClient(),
+			Logger:    config.Logger,
+		}
+
+		ops, err := endpoints.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		endpointsResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var iwd vmsscheck.InstanceWatchdog
+	{
+		c := vmsscheck.Config{
+			Logger:     config.Logger,
+			NumWorkers: config.VMSSCheckWorkers,
+		}
+
+		var err error
+		iwd, err = vmsscheck.NewInstanceWatchdog(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	nodesConfig := nodes.Config{
+		Debugger:  newDebugger,
+		G8sClient: config.K8sClient.G8sClient(),
+		K8sClient: config.K8sClient.K8sClient(),
+		Logger:    config.Logger,
+
+		Azure:            config.Azure,
+		ClientFactory:    clientFactory,
+		InstanceWatchdog: iwd,
+	}
+
+	var mastersResource resource.Interface
+	{
+		c := masters.Config{
+			Config: nodesConfig,
+		}
+
+		mastersResource, err = masters.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var instanceResource resource.Interface
+	{
+		c := instance.Config{
+			Config: nodesConfig,
+		}
+
+		instanceResource, err = instance.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var clusterChecker *ipam.ClusterChecker
+	{
+		c := ipam.ClusterCheckerConfig{
+			G8sClient: config.K8sClient.G8sClient(),
+			Logger:    config.Logger,
+		}
+
+		clusterChecker, err = ipam.NewClusterChecker(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var azureConfigPersister *ipam.AzureConfigPersister
+	{
+		c := ipam.AzureConfigPersisterConfig{
+			G8sClient: config.K8sClient.G8sClient(),
+			Logger:    config.Logger,
+		}
+
+		azureConfigPersister, err = ipam.NewAzureConfigPersister(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var subnetCollector *ipam.SubnetCollector
+	{
+		c := ipam.SubnetCollectorConfig{
+			CredentialProvider: config.CredentialProvider,
+			K8sClient:          config.K8sClient,
+			InstallationName:   config.InstallationName,
+			Logger:             config.Logger,
+
+			NetworkRange: config.IPAMNetworkRange,
+		}
+
+		subnetCollector, err = ipam.NewSubnetCollector(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var ipamResource resource.Interface
+	{
+		c := ipam.Config{
+			Checker:   clusterChecker,
+			Collector: subnetCollector,
+			Locker:    config.Locker,
+			Logger:    config.Logger,
+			Persister: azureConfigPersister,
+
+			AllocatedSubnetMaskBits: config.GuestSubnetMaskBits,
+			NetworkRange:            config.IPAMNetworkRange,
+		}
+
+		ipamResource, err = ipam.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var namespaceResource resource.Interface
+	{
+		c := namespace.Config{
+			K8sClient: config.K8sClient.K8sClient(),
+			Logger:    config.Logger,
+		}
+
+		ops, err := namespace.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		namespaceResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var serviceResource resource.Interface
+	{
+		c := service.Config{
+			K8sClient: config.K8sClient.K8sClient(),
+			Logger:    config.Logger,
+		}
+
+		ops, err := service.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		serviceResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var vpnResource resource.Interface
+	{
+		c := vpn.Config{
+			Debugger: newDebugger,
+			Logger:   config.Logger,
+
+			Azure: config.Azure,
+		}
+
+		vpnResource, err = vpn.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var vpnconnectionResource resource.Interface
+	{
+		c := vpnconnection.Config{
+			Azure:                                    config.Azure,
+			Logger:                                   config.Logger,
+			CPVirtualNetworkGatewaysClient:           *config.CPAzureClientSet.VirtualNetworkGatewaysClient,
+			CPVirtualNetworkGatewayConnectionsClient: *config.CPAzureClientSet.VirtualNetworkGatewayConnectionsClient,
+		}
+
+		ops, err := vpnconnection.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		vpnconnectionResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []resource.Interface{
+		clusteridResource,
+		namespaceResource,
+		ipamResource,
+		statusResource,
+		releaseResource,
+		tenantClientsResource,
+		serviceResource,
+		resourceGroupResource,
+		encryptionkeyResource,
+		deploymentResource,
+		containerURLResource,
+		blobObjectResource,
+		dnsrecordResource,
+		mastersResource,
+		instanceResource,
+		endpointsResource,
+		vpnResource,
+		vpnconnectionResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			Logger: config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{}
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resources, nil
+}
+
+func toCRUDResource(logger micrologger.Logger, v crud.Interface) (*crud.Resource, error) {
+	c := crud.ResourceConfig{
+		CRUD:   v,
+		Logger: logger,
+	}
+
+	r, err := crud.NewResource(c)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return r, nil
+}

--- a/service/controller/azure_machine_pool.go
+++ b/service/controller/azure_machine_pool.go
@@ -1,0 +1,181 @@
+package controller
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/giantswarm/certs"
+	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/resource"
+	"github.com/giantswarm/operatorkit/resource/wrapper/metricsresource"
+	"github.com/giantswarm/operatorkit/resource/wrapper/retryresource"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+
+	"github.com/giantswarm/azure-operator/v4/client"
+	"github.com/giantswarm/azure-operator/v4/pkg/credential"
+	"github.com/giantswarm/azure-operator/v4/pkg/label"
+	"github.com/giantswarm/azure-operator/v4/pkg/locker"
+	"github.com/giantswarm/azure-operator/v4/pkg/project"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/cloudconfig"
+)
+
+type AzureMachinePoolConfig struct {
+	CredentialProvider        credential.Provider
+	GSClientCredentialsConfig auth.ClientCredentialsConfig
+	GuestSubnetMaskBits       int
+	InstallationName          string
+	IPAMNetworkRange          net.IPNet
+	K8sClient                 k8sclient.Interface
+	Locker                    locker.Interface
+	Logger                    micrologger.Logger
+	RegistryDomain            string
+	SentryDSN                 string
+}
+
+type AzureMachinePool struct {
+	*controller.Controller
+}
+
+func NewAzureMachinePool(config AzureMachinePoolConfig) (*AzureMachinePool, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+
+	var err error
+
+	var resources []resource.Interface
+	{
+		resources, err = NewAzureMachinePoolResourceSet(config)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var operatorkitController *controller.Controller
+	{
+		c := controller.Config{
+			InitCtx: func(ctx context.Context, obj interface{}) (context.Context, error) {
+				return ctx, nil
+			},
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+			// Name is used to compute finalizer names. This results in something
+			// like operatorkit.giantswarm.io/azure-operator-machine-pool-controller.
+			Name: project.Name() + "-azure-machine-pool-controller",
+			NewRuntimeObjectFunc: func() runtime.Object {
+				return new(v1alpha3.AzureMachinePool)
+			},
+			Resources: resources,
+			Selector: labels.SelectorFromSet(map[string]string{
+				label.OperatorVersion: project.Version(),
+			}),
+			SentryDSN: config.SentryDSN,
+		}
+
+		operatorkitController, err = controller.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return &AzureMachinePool{Controller: operatorkitController}, nil
+}
+
+func NewAzureMachinePoolResourceSet(config AzureMachinePoolConfig) ([]resource.Interface, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	var err error
+
+	var clientFactory *client.Factory
+	{
+		c := client.FactoryConfig{
+			CacheDuration:      30 * time.Minute,
+			CredentialProvider: config.CredentialProvider,
+			Logger:             config.Logger,
+		}
+
+		clientFactory, err = client.NewFactory(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var certsSearcher *certs.Searcher
+	{
+		c := certs.Config{
+			K8sClient: config.K8sClient.K8sClient(),
+			Logger:    config.Logger,
+
+			WatchTimeout: 5 * time.Second,
+		}
+
+		certsSearcher, err = certs.NewSearcher(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var cloudConfigResource resource.Interface
+	{
+		c := cloudconfig.Config{
+			AzureClientsFactory: clientFactory,
+			CertsSearcher:       certsSearcher,
+			CtrlClient:          config.K8sClient.CtrlClient(),
+			G8sClient:           config.K8sClient.G8sClient(),
+			K8sClient:           config.K8sClient.K8sClient(),
+			Logger:              config.Logger,
+			RegistryDomain:      config.RegistryDomain,
+		}
+
+		cloudconfigObject, err := cloudconfig.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		cloudConfigResource, err = toCRUDResource(config.Logger, cloudconfigObject)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []resource.Interface{
+		cloudConfigResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			Logger: config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{}
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resources, nil
+}

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -168,7 +168,7 @@ func (r *ClusterOwnerReferencesResource) EnsureCreated(ctx context.Context, obj 
 	}
 
 	azureCluster := v1alpha3.AzureCluster{}
-	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cluster.Spec.InfrastructureRef.Namespace, Name: cluster.Spec.InfrastructureRef.Name}, &azureCluster)
+	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Spec.InfrastructureRef.Name}, &azureCluster)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -2,82 +2,29 @@ package controller
 
 import (
 	"context"
-	"net"
-	"time"
 
-	"github.com/Azure/go-autorest/autorest/azure/auth"
-	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
-	"github.com/giantswarm/certs"
 	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/controller"
 	"github.com/giantswarm/operatorkit/resource"
-	"github.com/giantswarm/operatorkit/resource/crud"
 	"github.com/giantswarm/operatorkit/resource/wrapper/metricsresource"
 	"github.com/giantswarm/operatorkit/resource/wrapper/retryresource"
-	"github.com/giantswarm/randomkeys"
-	"github.com/giantswarm/statusresource"
-	"github.com/giantswarm/tenantcluster"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/giantswarm/azure-operator/v4/client"
-	"github.com/giantswarm/azure-operator/v4/pkg/credential"
 	"github.com/giantswarm/azure-operator/v4/pkg/label"
-	"github.com/giantswarm/azure-operator/v4/pkg/locker"
 	"github.com/giantswarm/azure-operator/v4/pkg/project"
-	"github.com/giantswarm/azure-operator/v4/service/controller/cloudconfig"
-	"github.com/giantswarm/azure-operator/v4/service/controller/controllercontext"
-	"github.com/giantswarm/azure-operator/v4/service/controller/debugger"
-	"github.com/giantswarm/azure-operator/v4/service/controller/internal/vmsscheck"
 	"github.com/giantswarm/azure-operator/v4/service/controller/key"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/blobobject"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/clusterid"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/containerurl"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/deployment"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/dnsrecord"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/encryptionkey"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/endpoints"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/instance"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/ipam"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/masters"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/namespace"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/nodes"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/release"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/resourcegroup"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/service"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/tenantclients"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/vpn"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/vpnconnection"
-	"github.com/giantswarm/azure-operator/v4/service/controller/setting"
 )
 
 type ClusterConfig struct {
-	CredentialProvider credential.Provider
-	InstallationName   string
-	K8sClient          k8sclient.Interface
-	Locker             locker.Interface
-	Logger             micrologger.Logger
-
-	Azure setting.Azure
-	// Azure client set used when managing control plane resources
-	CPAzureClientSet *client.AzureClientSet
-	// Azure credentials used to create Azure client set for tenant clusters
-	GSClientCredentialsConfig auth.ClientCredentialsConfig
-	ProjectName               string
-	RegistryDomain            string
-	RegistryMirrors           []string
-
-	GuestSubnetMaskBits int
-
-	Ignition         setting.Ignition
-	IPAMNetworkRange net.IPNet
-	OIDC             setting.OIDC
-	SSOPublicKey     string
-	TemplateVersion  string
-	VMSSCheckWorkers int
-
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
 	SentryDSN string
 }
 
@@ -86,39 +33,18 @@ type Cluster struct {
 }
 
 func NewCluster(config ClusterConfig) (*Cluster, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+
 	var err error
-
-	var certsSearcher *certs.Searcher
-	{
-		c := certs.Config{
-			K8sClient: config.K8sClient.K8sClient(),
-			Logger:    config.Logger,
-
-			WatchTimeout: 5 * time.Second,
-		}
-
-		certsSearcher, err = certs.NewSearcher(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var randomkeysSearcher *randomkeys.Searcher
-	{
-		c := randomkeys.Config{
-			K8sClient: config.K8sClient.K8sClient(),
-			Logger:    config.Logger,
-		}
-
-		randomkeysSearcher, err = randomkeys.NewSearcher(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
 
 	var resources []resource.Interface
 	{
-		resources, err = newClusterResources(config, certsSearcher)
+		resources, err = NewClusterResourceSet(config)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -128,56 +54,13 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 	{
 		c := controller.Config{
 			InitCtx: func(ctx context.Context, obj interface{}) (context.Context, error) {
-				cr, err := key.ToCustomResource(obj)
-				if err != nil {
-					return nil, microerror.Mask(err)
-				}
-
-				organizationAzureClientCredentialsConfig, subscriptionID, partnerID, err := config.CredentialProvider.GetOrganizationAzureCredentials(ctx, key.CredentialNamespace(cr), key.CredentialName(cr))
-				if err != nil {
-					return nil, microerror.Mask(err)
-				}
-
-				tenantClusterAzureClientSet, err := client.NewAzureClientSet(organizationAzureClientCredentialsConfig, subscriptionID, partnerID)
-				if err != nil {
-					return nil, microerror.Mask(err)
-				}
-
-				var cloudConfig *cloudconfig.CloudConfig
-				{
-					c := cloudconfig.Config{
-						CertsSearcher:      certsSearcher,
-						Logger:             config.Logger,
-						RandomkeysSearcher: randomkeysSearcher,
-
-						Azure:                  config.Azure,
-						AzureClientCredentials: organizationAzureClientCredentialsConfig,
-						Ignition:               config.Ignition,
-						OIDC:                   config.OIDC,
-						RegistryMirrors:        config.RegistryMirrors,
-						SSOPublicKey:           config.SSOPublicKey,
-						SubscriptionID:         subscriptionID,
-					}
-
-					cloudConfig, err = cloudconfig.New(c)
-					if err != nil {
-						return nil, microerror.Mask(err)
-					}
-				}
-
-				c := controllercontext.Context{
-					AzureClientSet: tenantClusterAzureClientSet,
-					CloudConfig:    cloudConfig,
-				}
-				ctx = controllercontext.NewContext(ctx, c)
-
 				return ctx, nil
 			},
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
-			Name:      project.Name(),
+			Name:      project.Name() + "-cluster-controller",
 			NewRuntimeObjectFunc: func() runtime.Object {
-				return new(v1alpha1.AzureConfig)
+				return new(capiv1alpha3.Cluster)
 			},
 			Resources: resources,
 			Selector: labels.SelectorFromSet(map[string]string{
@@ -192,431 +75,35 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 		}
 	}
 
-	return &Cluster{
-		Controller: operatorkitController,
-	}, nil
+	return &Cluster{Controller: operatorkitController}, nil
 }
 
-func newClusterResources(config ClusterConfig, certsSearcher certs.Interface) ([]resource.Interface, error) {
+func NewClusterResourceSet(config ClusterConfig) ([]resource.Interface, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
 	var err error
 
-	var clientFactory *client.Factory
+	var ownerReferencesResource resource.Interface
 	{
-		c := client.FactoryConfig{
-			CacheDuration:      30 * time.Minute,
-			CredentialProvider: config.CredentialProvider,
-			Logger:             config.Logger,
-		}
-
-		clientFactory, err = client.NewFactory(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var newDebugger *debugger.Debugger
-	{
-		c := debugger.Config{
-			Logger: config.Logger,
-		}
-
-		newDebugger, err = debugger.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var tenantCluster tenantcluster.Interface
-	{
-		c := tenantcluster.Config{
-			CertsSearcher: certsSearcher,
-			Logger:        config.Logger,
-
-			CertID: certs.APICert,
-		}
-
-		tenantCluster, err = tenantcluster.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var clusteridResource resource.Interface
-	{
-		c := clusterid.Config{
+		c := ClusterOwnerReferencesConfig{
 			CtrlClient: config.K8sClient.CtrlClient(),
 			Logger:     config.Logger,
+			Scheme:     config.K8sClient.Scheme(),
 		}
 
-		clusteridResource, err = clusterid.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var statusResource resource.Interface
-	{
-		c := statusresource.ResourceConfig{
-			ClusterEndpointFunc:      key.ToClusterEndpoint,
-			ClusterIDFunc:            key.ToClusterID,
-			ClusterStatusFunc:        key.ToClusterStatus,
-			NodeCountFunc:            key.ToNodeCount,
-			Logger:                   config.Logger,
-			RESTClient:               config.K8sClient.G8sClient().ProviderV1alpha1().RESTClient(),
-			TenantCluster:            tenantCluster,
-			VersionBundleVersionFunc: key.ToOperatorVersion,
-		}
-
-		statusResource, err = statusresource.NewResource(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var tenantClientsResource resource.Interface
-	{
-		c := tenantclients.Config{
-			Logger: config.Logger,
-			Tenant: tenantCluster,
-		}
-
-		tenantClientsResource, err = tenantclients.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var releaseResource resource.Interface
-	{
-		c := release.Config{
-			K8sClient: config.K8sClient,
-			Logger:    config.Logger,
-		}
-
-		releaseResource, err = release.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var resourceGroupResource resource.Interface
-	{
-		c := resourcegroup.Config{
-			Logger: config.Logger,
-
-			Azure:            config.Azure,
-			InstallationName: config.InstallationName,
-		}
-
-		resourceGroupResource, err = resourcegroup.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var containerURLResource resource.Interface
-	{
-		c := containerurl.Config{
-			Logger: config.Logger,
-		}
-
-		containerURLResource, err = containerurl.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var encryptionkeyResource resource.Interface
-	{
-		c := encryptionkey.Config{
-			K8sClient:   config.K8sClient.K8sClient(),
-			Logger:      config.Logger,
-			ProjectName: config.ProjectName,
-		}
-
-		encryptionkeyResource, err = encryptionkey.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var blobObjectResource resource.Interface
-	{
-		c := blobobject.Config{
-			CertsSearcher:  certsSearcher,
-			G8sClient:      config.K8sClient.G8sClient(),
-			K8sClient:      config.K8sClient.K8sClient(),
-			Logger:         config.Logger,
-			RegistryDomain: config.RegistryDomain,
-		}
-
-		blobObject, err := blobobject.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		blobObjectResource, err = toCRUDResource(config.Logger, blobObject)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var deploymentResource resource.Interface
-	{
-		c := deployment.Config{
-			Debugger:         newDebugger,
-			G8sClient:        config.K8sClient.G8sClient(),
-			InstallationName: config.InstallationName,
-			Logger:           config.Logger,
-
-			Azure:                      config.Azure,
-			ClientFactory:              clientFactory,
-			ControlPlaneSubscriptionID: config.CPAzureClientSet.SubscriptionID,
-		}
-
-		deploymentResource, err = deployment.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var dnsrecordResource resource.Interface
-	{
-		c := dnsrecord.Config{
-			CPRecordSetsClient: *config.CPAzureClientSet.DNSRecordSetsClient,
-			Logger:             config.Logger,
-		}
-
-		ops, err := dnsrecord.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		dnsrecordResource, err = toCRUDResource(config.Logger, ops)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var endpointsResource resource.Interface
-	{
-		c := endpoints.Config{
-			K8sClient: config.K8sClient.K8sClient(),
-			Logger:    config.Logger,
-		}
-
-		ops, err := endpoints.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		endpointsResource, err = toCRUDResource(config.Logger, ops)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var iwd vmsscheck.InstanceWatchdog
-	{
-		c := vmsscheck.Config{
-			Logger:     config.Logger,
-			NumWorkers: config.VMSSCheckWorkers,
-		}
-
-		var err error
-		iwd, err = vmsscheck.NewInstanceWatchdog(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	nodesConfig := nodes.Config{
-		Debugger:  newDebugger,
-		G8sClient: config.K8sClient.G8sClient(),
-		K8sClient: config.K8sClient.K8sClient(),
-		Logger:    config.Logger,
-
-		Azure:            config.Azure,
-		ClientFactory:    clientFactory,
-		InstanceWatchdog: iwd,
-	}
-
-	var mastersResource resource.Interface
-	{
-		c := masters.Config{
-			Config: nodesConfig,
-		}
-
-		mastersResource, err = masters.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var instanceResource resource.Interface
-	{
-		c := instance.Config{
-			Config: nodesConfig,
-		}
-
-		instanceResource, err = instance.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var clusterChecker *ipam.ClusterChecker
-	{
-		c := ipam.ClusterCheckerConfig{
-			G8sClient: config.K8sClient.G8sClient(),
-			Logger:    config.Logger,
-		}
-
-		clusterChecker, err = ipam.NewClusterChecker(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var azureConfigPersister *ipam.AzureConfigPersister
-	{
-		c := ipam.AzureConfigPersisterConfig{
-			G8sClient: config.K8sClient.G8sClient(),
-			Logger:    config.Logger,
-		}
-
-		azureConfigPersister, err = ipam.NewAzureConfigPersister(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var subnetCollector *ipam.SubnetCollector
-	{
-		c := ipam.SubnetCollectorConfig{
-			CredentialProvider: config.CredentialProvider,
-			K8sClient:          config.K8sClient,
-			InstallationName:   config.InstallationName,
-			Logger:             config.Logger,
-
-			NetworkRange: config.IPAMNetworkRange,
-		}
-
-		subnetCollector, err = ipam.NewSubnetCollector(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var ipamResource resource.Interface
-	{
-		c := ipam.Config{
-			Checker:   clusterChecker,
-			Collector: subnetCollector,
-			Locker:    config.Locker,
-			Logger:    config.Logger,
-			Persister: azureConfigPersister,
-
-			AllocatedSubnetMaskBits: config.GuestSubnetMaskBits,
-			NetworkRange:            config.IPAMNetworkRange,
-		}
-
-		ipamResource, err = ipam.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var namespaceResource resource.Interface
-	{
-		c := namespace.Config{
-			K8sClient: config.K8sClient.K8sClient(),
-			Logger:    config.Logger,
-		}
-
-		ops, err := namespace.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		namespaceResource, err = toCRUDResource(config.Logger, ops)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var serviceResource resource.Interface
-	{
-		c := service.Config{
-			K8sClient: config.K8sClient.K8sClient(),
-			Logger:    config.Logger,
-		}
-
-		ops, err := service.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		serviceResource, err = toCRUDResource(config.Logger, ops)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var vpnResource resource.Interface
-	{
-		c := vpn.Config{
-			Debugger: newDebugger,
-			Logger:   config.Logger,
-
-			Azure: config.Azure,
-		}
-
-		vpnResource, err = vpn.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var vpnconnectionResource resource.Interface
-	{
-		c := vpnconnection.Config{
-			Azure:                                    config.Azure,
-			Logger:                                   config.Logger,
-			CPVirtualNetworkGatewaysClient:           *config.CPAzureClientSet.VirtualNetworkGatewaysClient,
-			CPVirtualNetworkGatewayConnectionsClient: *config.CPAzureClientSet.VirtualNetworkGatewayConnectionsClient,
-		}
-
-		ops, err := vpnconnection.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		vpnconnectionResource, err = toCRUDResource(config.Logger, ops)
+		ownerReferencesResource, err = NewClusterOwnerReferences(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
 	resources := []resource.Interface{
-		clusteridResource,
-		namespaceResource,
-		ipamResource,
-		statusResource,
-		releaseResource,
-		tenantClientsResource,
-		serviceResource,
-		resourceGroupResource,
-		encryptionkeyResource,
-		deploymentResource,
-		containerURLResource,
-		blobObjectResource,
-		dnsrecordResource,
-		mastersResource,
-		instanceResource,
-		endpointsResource,
-		vpnResource,
-		vpnconnectionResource,
+		ownerReferencesResource,
 	}
 
 	{
@@ -641,16 +128,76 @@ func newClusterResources(config ClusterConfig, certsSearcher certs.Interface) ([
 	return resources, nil
 }
 
-func toCRUDResource(logger micrologger.Logger, v crud.Interface) (*crud.Resource, error) {
-	c := crud.ResourceConfig{
-		CRUD:   v,
-		Logger: logger,
+type ClusterOwnerReferencesConfig struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+	Scheme     *runtime.Scheme
+}
+
+type ClusterOwnerReferencesResource struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+	scheme     *runtime.Scheme
+}
+
+func NewClusterOwnerReferences(config ClusterOwnerReferencesConfig) (*ClusterOwnerReferencesResource, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Scheme == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Scheme must not be empty", config)
 	}
 
-	r, err := crud.NewResource(c)
-	if err != nil {
-		return nil, microerror.Mask(err)
+	r := &ClusterOwnerReferencesResource{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+		scheme:     config.Scheme,
 	}
 
 	return r, nil
+}
+
+// EnsureCreated ensures the AzureCluster is owned by the Cluster it belongs to.
+func (r *ClusterOwnerReferencesResource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cluster, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	azureCluster := v1alpha3.AzureCluster{}
+	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cluster.Spec.InfrastructureRef.Namespace, Name: cluster.Spec.InfrastructureRef.Name}, &azureCluster)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if azureCluster.Labels == nil {
+		azureCluster.Labels = make(map[string]string)
+	}
+	azureCluster.Labels[capiv1alpha3.ClusterLabelName] = cluster.Name
+
+	// Set Cluster as owner of AzureCluster
+	err = controllerutil.SetControllerReference(&cluster, &azureCluster, r.scheme)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.ctrlClient.Update(ctx, &azureCluster)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+// EnsureDeleted is a noop.
+func (r *ClusterOwnerReferencesResource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}
+
+// Name returns the resource name.
+func (r *ClusterOwnerReferencesResource) Name() string {
+	return "ClusterOwnerReferences"
 }

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
@@ -167,6 +168,8 @@ func (r *ClusterOwnerReferencesResource) EnsureCreated(ctx context.Context, obj 
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensuring %s label and 'ownerReference' fields on AzureCluster '%s/%s'", capiv1alpha3.ClusterLabelName, cluster.Namespace, cluster.Spec.InfrastructureRef.Name))
+
 	azureCluster := v1alpha3.AzureCluster{}
 	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Spec.InfrastructureRef.Name}, &azureCluster)
 	if err != nil {
@@ -188,6 +191,8 @@ func (r *ClusterOwnerReferencesResource) EnsureCreated(ctx context.Context, obj 
 	if err != nil {
 		return microerror.Mask(err)
 	}
+
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensured %s label and 'ownerReference' fields on AzureCluster '%s/%s'", capiv1alpha3.ClusterLabelName, cluster.Namespace, cluster.Spec.InfrastructureRef.Name))
 
 	return nil
 }

--- a/service/controller/cluster_test.go
+++ b/service/controller/cluster_test.go
@@ -1,0 +1,162 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/micrologger/microloggertest"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-operator/v4/service/unittest"
+)
+
+func TestThatAzureClusterIsLabeledWithClusterId(t *testing.T) {
+	ctx := context.Background()
+	fakeK8sClient := unittest.FakeK8sClient()
+	ctrlClient := fakeK8sClient.CtrlClient()
+	controller, err := NewClusterOwnerReferences(ClusterOwnerReferencesConfig{
+		CtrlClient: ctrlClient,
+		Logger:     microloggertest.New(),
+		Scheme:     fakeK8sClient.Scheme(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clusterNamespace := "default"
+	clusterName := "my-cluster"
+	cluster := &capiv1alpha3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: clusterNamespace,
+			Name:      clusterName,
+		},
+		Spec: capiv1alpha3.ClusterSpec{
+			InfrastructureRef: &v1.ObjectReference{
+				Kind:      "AzureCluster",
+				Namespace: clusterNamespace,
+				Name:      clusterName,
+			},
+		},
+	}
+	err = ctrlClient.Create(ctx, cluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	azureCluster := &v1alpha3.AzureCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: clusterNamespace,
+			Name:      clusterName,
+		},
+		Spec: v1alpha3.AzureClusterSpec{},
+	}
+	err = ctrlClient.Create(ctx, azureCluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = controller.EnsureCreated(ctx, cluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ctrlClient.Get(ctx, client.ObjectKey{Namespace: clusterNamespace, Name: clusterName}, azureCluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	labelClusterName, exists := azureCluster.Labels[capiv1alpha3.ClusterLabelName]
+	if !exists {
+		t.Fatalf("Azure cluster should be labeled with Cluster name")
+	}
+
+	if labelClusterName != clusterName {
+		t.Fatalf("Azure cluster is labeled but label contains wrong name")
+	}
+}
+
+func TestThatAzureClusterIsOwnedByCluster(t *testing.T) {
+	ctx := context.Background()
+	fakeK8sClient := unittest.FakeK8sClient()
+	ctrlClient := fakeK8sClient.CtrlClient()
+	scheme := fakeK8sClient.Scheme()
+
+	azureCluster, err := givenAzureCluster(ctx, ctrlClient, "default", "my-cluster")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cluster := &capiv1alpha3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "my-cluster",
+		},
+		Spec: capiv1alpha3.ClusterSpec{
+			InfrastructureRef: &v1.ObjectReference{
+				Kind:      "AzureCluster",
+				Namespace: azureCluster.Namespace,
+				Name:      azureCluster.Name,
+			},
+		},
+	}
+	err = ctrlClient.Create(ctx, cluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = whenReconcilingCluster(ctx, ctrlClient, scheme, cluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	thenAzureClusterShouldBeOwnedByCluster(ctx, t, ctrlClient, azureCluster.Namespace, azureCluster.Name)
+}
+
+func givenAzureCluster(ctx context.Context, ctrlClient client.Client, clusterNamespace, clusterName string) (*v1alpha3.AzureCluster, error) {
+	azureCluster := &v1alpha3.AzureCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: clusterNamespace,
+			Name:      clusterName,
+		},
+		Spec: v1alpha3.AzureClusterSpec{},
+	}
+	err := ctrlClient.Create(ctx, azureCluster)
+	return azureCluster, err
+}
+
+func whenReconcilingCluster(ctx context.Context, ctrlClient client.Client, scheme *runtime.Scheme, cluster *capiv1alpha3.Cluster) error {
+	controller, err := NewClusterOwnerReferences(ClusterOwnerReferencesConfig{
+		CtrlClient: ctrlClient,
+		Logger:     microloggertest.New(),
+		Scheme:     scheme,
+	})
+	if err != nil {
+		return err
+	}
+
+	return controller.EnsureCreated(ctx, cluster)
+}
+
+func thenAzureClusterShouldBeOwnedByCluster(ctx context.Context, t *testing.T, ctrlClient client.Client, azureClusterNamespace, azureClusterName string) {
+	azureCluster := &v1alpha3.AzureCluster{}
+	err := ctrlClient.Get(ctx, client.ObjectKey{Namespace: azureClusterNamespace, Name: azureClusterName}, azureCluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, ref := range azureCluster.OwnerReferences {
+		if ref.Kind == "Cluster" && ref.APIVersion == capiv1alpha3.GroupVersion.String() {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatalf("Azure cluster should be owned by Cluster in OwnerReferences")
+	}
+}

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -11,6 +11,8 @@ import (
 	"github.com/giantswarm/microerror"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 
 	"github.com/giantswarm/azure-operator/v4/pkg/label"
 	"github.com/giantswarm/azure-operator/v4/service/controller/templates/ignition"
@@ -100,6 +102,20 @@ func AzureConfigNetworkCIDR(customObject providerv1alpha1.AzureConfig) string {
 	return customObject.Spec.Azure.VirtualNetwork.CIDR
 }
 
+func ToCluster(v interface{}) (capiv1alpha3.Cluster, error) {
+	if v == nil {
+		return capiv1alpha3.Cluster{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &capiv1alpha3.Cluster{}, v)
+	}
+
+	customObjectPointer, ok := v.(*capiv1alpha3.Cluster)
+	if !ok {
+		return capiv1alpha3.Cluster{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &capiv1alpha3.Cluster{}, v)
+	}
+	customObject := *customObjectPointer
+
+	return customObject, nil
+}
+
 func ToAzureMachinePool(v interface{}) (expcapzv1alpha3.AzureMachinePool, error) {
 	if v == nil {
 		return expcapzv1alpha3.AzureMachinePool{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &providerv1alpha1.AzureConfig{}, v)
@@ -108,6 +124,20 @@ func ToAzureMachinePool(v interface{}) (expcapzv1alpha3.AzureMachinePool, error)
 	customObjectPointer, ok := v.(*expcapzv1alpha3.AzureMachinePool)
 	if !ok {
 		return expcapzv1alpha3.AzureMachinePool{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &providerv1alpha1.AzureConfig{}, v)
+	}
+	customObject := *customObjectPointer
+
+	return customObject, nil
+}
+
+func ToMachinePool(v interface{}) (expcapiv1alpha3.MachinePool, error) {
+	if v == nil {
+		return expcapiv1alpha3.MachinePool{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &expcapiv1alpha3.MachinePool{}, v)
+	}
+
+	customObjectPointer, ok := v.(*expcapiv1alpha3.MachinePool)
+	if !ok {
+		return expcapiv1alpha3.MachinePool{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &expcapiv1alpha3.MachinePool{}, v)
 	}
 	customObject := *customObjectPointer
 

--- a/service/controller/machine_pool.go
+++ b/service/controller/machine_pool.go
@@ -173,7 +173,7 @@ func (r *MachinePoolOwnerReferencesResource) EnsureCreated(ctx context.Context, 
 	}
 
 	azureMachinePool := expcapzv1alpha3.AzureMachinePool{}
-	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: machinePool.Spec.Template.Spec.InfrastructureRef.Namespace, Name: machinePool.Spec.Template.Spec.InfrastructureRef.Name}, &azureMachinePool)
+	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: machinePool.Namespace, Name: machinePool.Spec.Template.Spec.InfrastructureRef.Name}, &azureMachinePool)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/machine_pool.go
+++ b/service/controller/machine_pool.go
@@ -195,8 +195,8 @@ func (r *MachinePoolOwnerReferencesResource) EnsureCreated(ctx context.Context, 
 
 	// Set Cluster as owner of MachinePool
 	machinePool.OwnerReferences = capiutil.EnsureOwnerRef(machinePool.OwnerReferences, metav1.OwnerReference{
-		APIVersion: cluster.APIVersion,
-		Kind:       cluster.Kind,
+		APIVersion: capiv1alpha3.GroupVersion.String(),
+		Kind:       "Cluster",
 		Name:       cluster.Name,
 		UID:        cluster.UID,
 	})

--- a/service/controller/machine_pool.go
+++ b/service/controller/machine_pool.go
@@ -2,11 +2,7 @@ package controller
 
 import (
 	"context"
-	"net"
-	"time"
 
-	"github.com/Azure/go-autorest/autorest/azure/auth"
-	"github.com/giantswarm/certs"
 	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -14,29 +10,25 @@ import (
 	"github.com/giantswarm/operatorkit/resource"
 	"github.com/giantswarm/operatorkit/resource/wrapper/metricsresource"
 	"github.com/giantswarm/operatorkit/resource/wrapper/retryresource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	v1alpha33 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	v1alpha32 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/giantswarm/azure-operator/v4/client"
-	"github.com/giantswarm/azure-operator/v4/pkg/credential"
 	"github.com/giantswarm/azure-operator/v4/pkg/label"
-	"github.com/giantswarm/azure-operator/v4/pkg/locker"
 	"github.com/giantswarm/azure-operator/v4/pkg/project"
-	"github.com/giantswarm/azure-operator/v4/service/controller/resource/cloudconfig"
+	"github.com/giantswarm/azure-operator/v4/service/controller/key"
 )
 
 type MachinePoolConfig struct {
-	CredentialProvider        credential.Provider
-	GSClientCredentialsConfig auth.ClientCredentialsConfig
-	GuestSubnetMaskBits       int
-	InstallationName          string
-	IPAMNetworkRange          net.IPNet
-	K8sClient                 k8sclient.Interface
-	Locker                    locker.Interface
-	Logger                    micrologger.Logger
-	RegistryDomain            string
-	SentryDSN                 string
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+	SentryDSN string
 }
 
 type MachinePool struct {
@@ -47,7 +39,6 @@ func NewMachinePool(config MachinePoolConfig) (*MachinePool, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
-
 	if config.K8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
 	}
@@ -74,7 +65,7 @@ func NewMachinePool(config MachinePoolConfig) (*MachinePool, error) {
 			// like operatorkit.giantswarm.io/azure-operator-machine-pool-controller.
 			Name: project.Name() + "-machine-pool-controller",
 			NewRuntimeObjectFunc: func() runtime.Object {
-				return new(v1alpha3.AzureMachinePool)
+				return new(v1alpha32.MachinePool)
 			},
 			Resources: resources,
 			Selector: labels.SelectorFromSet(map[string]string{
@@ -102,60 +93,22 @@ func NewMachinePoolResourceSet(config MachinePoolConfig) ([]resource.Interface, 
 
 	var err error
 
-	var clientFactory *client.Factory
+	var ownerReferencesResource resource.Interface
 	{
-		c := client.FactoryConfig{
-			CacheDuration:      30 * time.Minute,
-			CredentialProvider: config.CredentialProvider,
-			Logger:             config.Logger,
+		c := MachinePoolOwnerReferencesConfig{
+			CtrlClient: config.K8sClient.CtrlClient(),
+			Logger:     config.Logger,
+			Scheme:     config.K8sClient.Scheme(),
 		}
 
-		clientFactory, err = client.NewFactory(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var certsSearcher *certs.Searcher
-	{
-		c := certs.Config{
-			K8sClient: config.K8sClient.K8sClient(),
-			Logger:    config.Logger,
-
-			WatchTimeout: 5 * time.Second,
-		}
-
-		certsSearcher, err = certs.NewSearcher(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var cloudConfigResource resource.Interface
-	{
-		c := cloudconfig.Config{
-			AzureClientsFactory: clientFactory,
-			CertsSearcher:       certsSearcher,
-			CtrlClient:          config.K8sClient.CtrlClient(),
-			G8sClient:           config.K8sClient.G8sClient(),
-			K8sClient:           config.K8sClient.K8sClient(),
-			Logger:              config.Logger,
-			RegistryDomain:      config.RegistryDomain,
-		}
-
-		cloudconfigObject, err := cloudconfig.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		cloudConfigResource, err = toCRUDResource(config.Logger, cloudconfigObject)
+		ownerReferencesResource, err = NewMachinePoolOwnerReferences(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
 	resources := []resource.Interface{
-		cloudConfigResource,
+		ownerReferencesResource,
 	}
 
 	{
@@ -178,4 +131,96 @@ func NewMachinePoolResourceSet(config MachinePoolConfig) ([]resource.Interface, 
 	}
 
 	return resources, nil
+}
+
+type MachinePoolOwnerReferencesConfig struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+	Scheme     *runtime.Scheme
+}
+
+type MachinePoolOwnerReferencesResource struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+	scheme     *runtime.Scheme
+}
+
+func NewMachinePoolOwnerReferences(config MachinePoolOwnerReferencesConfig) (*MachinePoolOwnerReferencesResource, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Scheme == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Scheme must not be empty", config)
+	}
+
+	r := &MachinePoolOwnerReferencesResource{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+		scheme:     config.Scheme,
+	}
+
+	return r, nil
+}
+
+// EnsureCreated ensures the MachinePool is owned by the Cluster it belongs to, and the AzureMachinePool is owned by the MachinePool.
+func (r *MachinePoolOwnerReferencesResource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	machinePool, err := key.ToMachinePool(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if machinePool.Labels == nil {
+		machinePool.Labels = make(map[string]string)
+	}
+	machinePool.Labels[capiv1alpha3.ClusterLabelName] = machinePool.Spec.ClusterName
+
+	cluster, err := util.GetClusterByName(ctx, r.ctrlClient, machinePool.ObjectMeta.Namespace, machinePool.Spec.ClusterName)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Set Cluster as owner of MachinePool
+	machinePool.OwnerReferences = util.EnsureOwnerRef(machinePool.OwnerReferences, metav1.OwnerReference{
+		APIVersion: cluster.APIVersion,
+		Kind:       cluster.Kind,
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+	})
+
+	err = r.ctrlClient.Update(ctx, &machinePool)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Set MachinePool as owner of AzureMachinePool
+	azureMachinePool := v1alpha33.AzureMachinePool{}
+	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: machinePool.Spec.Template.Spec.InfrastructureRef.Namespace, Name: machinePool.Spec.Template.Spec.InfrastructureRef.Name}, &azureMachinePool)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = controllerutil.SetControllerReference(&machinePool, &azureMachinePool, r.scheme)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.ctrlClient.Update(ctx, &azureMachinePool)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+// EnsureDeleted is a noop.
+func (r *MachinePoolOwnerReferencesResource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}
+
+// Name returns the resource name.
+func (r *MachinePoolOwnerReferencesResource) Name() string {
+	return "MachinePoolOwnerReferences"
 }

--- a/service/controller/machine_pool.go
+++ b/service/controller/machine_pool.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
@@ -172,6 +173,9 @@ func (r *MachinePoolOwnerReferencesResource) EnsureCreated(ctx context.Context, 
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensuring %s label and 'ownerReference' fields on MachinePool '%s/%s'", capiv1alpha3.ClusterLabelName, machinePool.Namespace, machinePool.Name))
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensuring %s label and 'ownerReference' fields on AzureMachinePool '%s/%s'", capiv1alpha3.ClusterLabelName, machinePool.Namespace, machinePool.Spec.Template.Spec.InfrastructureRef.Name))
+
 	azureMachinePool := expcapzv1alpha3.AzureMachinePool{}
 	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: machinePool.Namespace, Name: machinePool.Spec.Template.Spec.InfrastructureRef.Name}, &azureMachinePool)
 	if err != nil {
@@ -188,7 +192,7 @@ func (r *MachinePoolOwnerReferencesResource) EnsureCreated(ctx context.Context, 
 	}
 	azureMachinePool.Labels[capiv1alpha3.ClusterLabelName] = machinePool.Spec.ClusterName
 
-	cluster, err := capiutil.GetClusterByName(ctx, r.ctrlClient, machinePool.ObjectMeta.Namespace, machinePool.Spec.ClusterName)
+	cluster, err := capiutil.GetClusterByName(ctx, r.ctrlClient, machinePool.Namespace, machinePool.Spec.ClusterName)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -206,6 +210,8 @@ func (r *MachinePoolOwnerReferencesResource) EnsureCreated(ctx context.Context, 
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensured %s label and 'ownerReference' fields on MachinePool '%s/%s'", capiv1alpha3.ClusterLabelName, machinePool.Namespace, machinePool.Name))
+
 	// Set MachinePool as owner of AzureMachinePool
 	err = controllerutil.SetControllerReference(&machinePool, &azureMachinePool, r.scheme)
 	if err != nil {
@@ -216,6 +222,8 @@ func (r *MachinePoolOwnerReferencesResource) EnsureCreated(ctx context.Context, 
 	if err != nil {
 		return microerror.Mask(err)
 	}
+
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensuring %s label and 'ownerReference' fields on AzureMachinePool '%s/%s'", capiv1alpha3.ClusterLabelName, machinePool.Namespace, machinePool.Spec.Template.Spec.InfrastructureRef.Name))
 
 	return nil
 }

--- a/service/controller/machine_pool_test.go
+++ b/service/controller/machine_pool_test.go
@@ -1,0 +1,192 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/micrologger/microloggertest"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	v1alpha32 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-operator/v4/service/unittest"
+)
+
+func TestThatMachinePoolIsLabeledWithClusterId(t *testing.T) {
+	ctx := context.Background()
+	fakeK8sClient := unittest.FakeK8sClient()
+	ctrlClient := fakeK8sClient.CtrlClient()
+	scheme := fakeK8sClient.Scheme()
+
+	cluster, err := givenCluster(ctx, ctrlClient, "default", "my-cluster")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	azureMachinePool, err := givenAzureMachinePool(ctx, ctrlClient, cluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machinePool, err := givenMachinePool(ctx, ctrlClient, cluster, azureMachinePool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = whenReconcilingMachinePool(ctx, ctrlClient, scheme, machinePool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	thenMachinePoolShouldLabeledWithClusterName(ctx, t, ctrlClient, cluster.Namespace, cluster.Name, machinePool.Name)
+}
+
+func TestThatMachinePoolIsOwnedByCluster(t *testing.T) {
+	ctx := context.Background()
+	fakeK8sClient := unittest.FakeK8sClient()
+	ctrlClient := fakeK8sClient.CtrlClient()
+	scheme := fakeK8sClient.Scheme()
+
+	cluster, err := givenCluster(ctx, ctrlClient, "default", "my-cluster")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	azureMachinePool, err := givenAzureMachinePool(ctx, ctrlClient, cluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machinePool, err := givenMachinePool(ctx, ctrlClient, cluster, azureMachinePool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = whenReconcilingMachinePool(ctx, ctrlClient, scheme, machinePool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	thenMachinePoolShouldBeOwnedByCluster(ctx, t, ctrlClient, cluster.Namespace, machinePool.Name)
+	thenAzureMachinePoolShouldBeOwnedByMachinePool(ctx, t, ctrlClient, cluster.Namespace, azureMachinePool.Name)
+}
+
+func whenReconcilingMachinePool(ctx context.Context, ctrlClient client.Client, scheme *runtime.Scheme, machinePool *v1alpha32.MachinePool) error {
+	controller, err := NewMachinePoolOwnerReferences(MachinePoolOwnerReferencesConfig{
+		CtrlClient: ctrlClient,
+		Logger:     microloggertest.New(),
+		Scheme:     scheme,
+	})
+	if err != nil {
+		return err
+	}
+
+	return controller.EnsureCreated(ctx, machinePool)
+}
+
+func givenCluster(ctx context.Context, ctrlClient client.Client, clusterNamespace, clusterName string) (*capiv1alpha3.Cluster, error) {
+	cluster := &capiv1alpha3.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: clusterNamespace,
+			Name:      clusterName,
+		},
+		Spec: capiv1alpha3.ClusterSpec{},
+	}
+	err := ctrlClient.Create(ctx, cluster)
+	return cluster, err
+}
+
+func givenAzureMachinePool(ctx context.Context, ctrlClient client.Client, cluster *capiv1alpha3.Cluster) (*expcapzv1alpha3.AzureMachinePool, error) {
+	azureMachinePool := &expcapzv1alpha3.AzureMachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cluster.Namespace,
+			Name:      cluster.Name,
+		},
+		Spec: expcapzv1alpha3.AzureMachinePoolSpec{},
+	}
+	err := ctrlClient.Create(ctx, azureMachinePool)
+	return azureMachinePool, err
+}
+
+func givenMachinePool(ctx context.Context, ctrlClient client.Client, cluster *capiv1alpha3.Cluster, azureMachinePool *expcapzv1alpha3.AzureMachinePool) (*v1alpha32.MachinePool, error) {
+	machinePool := &v1alpha32.MachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: cluster.Namespace,
+			Name:      cluster.Name,
+		},
+		Spec: v1alpha32.MachinePoolSpec{
+			ClusterName: cluster.Name,
+			Template: capiv1alpha3.MachineTemplateSpec{
+				Spec: capiv1alpha3.MachineSpec{
+					InfrastructureRef: v1.ObjectReference{
+						Kind:      "AzureMachinePool",
+						Namespace: azureMachinePool.Namespace,
+						Name:      azureMachinePool.Name,
+					},
+				},
+			},
+		},
+	}
+	err := ctrlClient.Create(ctx, machinePool)
+	return machinePool, err
+}
+
+func thenMachinePoolShouldLabeledWithClusterName(ctx context.Context, t *testing.T, ctrlClient client.Client, clusterNamespace, clusterName, machinePoolName string) {
+	machinePool := &v1alpha32.MachinePool{}
+	err := ctrlClient.Get(ctx, client.ObjectKey{Namespace: clusterNamespace, Name: machinePoolName}, machinePool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	labelClusterName, exists := machinePool.Labels[capiv1alpha3.ClusterLabelName]
+	if !exists {
+		t.Fatalf("MachinePool should be labeled with Cluster name")
+	}
+
+	if labelClusterName != clusterName {
+		t.Fatalf("MachinePool is labeled but label contains wrong name")
+	}
+}
+
+func thenMachinePoolShouldBeOwnedByCluster(ctx context.Context, t *testing.T, ctrlClient client.Client, machinePoolNamespace, machinePoolName string) {
+	machinePool := &v1alpha32.MachinePool{}
+	err := ctrlClient.Get(ctx, client.ObjectKey{Namespace: machinePoolNamespace, Name: machinePoolName}, machinePool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, ref := range machinePool.OwnerReferences {
+		if ref.Kind == "Cluster" && ref.APIVersion == capiv1alpha3.GroupVersion.String() {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatalf("MachinePool should be owned by Cluster in OwnerReferences")
+	}
+}
+
+func thenAzureMachinePoolShouldBeOwnedByMachinePool(ctx context.Context, t *testing.T, ctrlClient client.Client, azureMachinePoolNamespace, azureMachinePoolName string) {
+	azureMachinePool := &expcapzv1alpha3.AzureMachinePool{}
+	err := ctrlClient.Get(ctx, client.ObjectKey{Namespace: azureMachinePoolNamespace, Name: azureMachinePoolName}, azureMachinePool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, ref := range azureMachinePool.OwnerReferences {
+		if ref.Kind == "MachinePool" && ref.APIVersion == expcapiv1alpha3.GroupVersion.String() && *ref.Controller {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatalf("AzureMachinePool should be owned by MachinePool in OwnerReferences")
+	}
+}

--- a/service/controller/machine_pool_test.go
+++ b/service/controller/machine_pool_test.go
@@ -11,13 +11,12 @@ import (
 	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
-	v1alpha32 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-operator/v4/service/unittest"
 )
 
-func TestThatMachinePoolIsLabeledWithClusterId(t *testing.T) {
+func TestThatMachinePoolAndAzureMachinePoolAreLabeledWithClusterId(t *testing.T) {
 	ctx := context.Background()
 	fakeK8sClient := unittest.FakeK8sClient()
 	ctrlClient := fakeK8sClient.CtrlClient()
@@ -44,6 +43,7 @@ func TestThatMachinePoolIsLabeledWithClusterId(t *testing.T) {
 	}
 
 	thenMachinePoolShouldLabeledWithClusterName(ctx, t, ctrlClient, cluster.Namespace, cluster.Name, machinePool.Name)
+	thenAzureMachinePoolShouldLabeledWithClusterName(ctx, t, ctrlClient, cluster.Namespace, cluster.Name, azureMachinePool.Name)
 }
 
 func TestThatMachinePoolIsOwnedByCluster(t *testing.T) {
@@ -76,7 +76,7 @@ func TestThatMachinePoolIsOwnedByCluster(t *testing.T) {
 	thenAzureMachinePoolShouldBeOwnedByMachinePool(ctx, t, ctrlClient, cluster.Namespace, azureMachinePool.Name)
 }
 
-func whenReconcilingMachinePool(ctx context.Context, ctrlClient client.Client, scheme *runtime.Scheme, machinePool *v1alpha32.MachinePool) error {
+func whenReconcilingMachinePool(ctx context.Context, ctrlClient client.Client, scheme *runtime.Scheme, machinePool *expcapiv1alpha3.MachinePool) error {
 	controller, err := NewMachinePoolOwnerReferences(MachinePoolOwnerReferencesConfig{
 		CtrlClient: ctrlClient,
 		Logger:     microloggertest.New(),
@@ -113,13 +113,13 @@ func givenAzureMachinePool(ctx context.Context, ctrlClient client.Client, cluste
 	return azureMachinePool, err
 }
 
-func givenMachinePool(ctx context.Context, ctrlClient client.Client, cluster *capiv1alpha3.Cluster, azureMachinePool *expcapzv1alpha3.AzureMachinePool) (*v1alpha32.MachinePool, error) {
-	machinePool := &v1alpha32.MachinePool{
+func givenMachinePool(ctx context.Context, ctrlClient client.Client, cluster *capiv1alpha3.Cluster, azureMachinePool *expcapzv1alpha3.AzureMachinePool) (*expcapiv1alpha3.MachinePool, error) {
+	machinePool := &expcapiv1alpha3.MachinePool{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cluster.Namespace,
 			Name:      cluster.Name,
 		},
-		Spec: v1alpha32.MachinePoolSpec{
+		Spec: expcapiv1alpha3.MachinePoolSpec{
 			ClusterName: cluster.Name,
 			Template: capiv1alpha3.MachineTemplateSpec{
 				Spec: capiv1alpha3.MachineSpec{
@@ -137,7 +137,7 @@ func givenMachinePool(ctx context.Context, ctrlClient client.Client, cluster *ca
 }
 
 func thenMachinePoolShouldLabeledWithClusterName(ctx context.Context, t *testing.T, ctrlClient client.Client, clusterNamespace, clusterName, machinePoolName string) {
-	machinePool := &v1alpha32.MachinePool{}
+	machinePool := &expcapiv1alpha3.MachinePool{}
 	err := ctrlClient.Get(ctx, client.ObjectKey{Namespace: clusterNamespace, Name: machinePoolName}, machinePool)
 	if err != nil {
 		t.Fatal(err)
@@ -153,8 +153,25 @@ func thenMachinePoolShouldLabeledWithClusterName(ctx context.Context, t *testing
 	}
 }
 
+func thenAzureMachinePoolShouldLabeledWithClusterName(ctx context.Context, t *testing.T, ctrlClient client.Client, clusterNamespace, clusterName, azureMachinePoolName string) {
+	azureMachinePool := &expcapzv1alpha3.AzureMachinePool{}
+	err := ctrlClient.Get(ctx, client.ObjectKey{Namespace: clusterNamespace, Name: azureMachinePoolName}, azureMachinePool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	labelClusterName, exists := azureMachinePool.Labels[capiv1alpha3.ClusterLabelName]
+	if !exists {
+		t.Fatalf("AzureMachinePool should be labeled with Cluster name")
+	}
+
+	if labelClusterName != clusterName {
+		t.Fatalf("AzureMachinePool is labeled but label contains wrong name")
+	}
+}
+
 func thenMachinePoolShouldBeOwnedByCluster(ctx context.Context, t *testing.T, ctrlClient client.Client, machinePoolNamespace, machinePoolName string) {
-	machinePool := &v1alpha32.MachinePool{}
+	machinePool := &expcapiv1alpha3.MachinePool{}
 	err := ctrlClient.Get(ctx, client.ObjectKey{Namespace: machinePoolNamespace, Name: machinePoolName}, machinePool)
 	if err != nil {
 		t.Fatal(err)

--- a/service/unittest/default_k8sclient.go
+++ b/service/unittest/default_k8sclient.go
@@ -12,12 +12,17 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 type fakeK8sClient struct {
 	ctrlClient client.Client
+	scheme     *runtime.Scheme
 }
 
 func FakeK8sClient() k8sclient.Interface {
@@ -27,6 +32,22 @@ func FakeK8sClient() k8sclient.Interface {
 	{
 		scheme := runtime.NewScheme()
 		err = v1.AddToScheme(scheme)
+		if err != nil {
+			panic(err)
+		}
+		err = expcapiv1alpha3.AddToScheme(scheme)
+		if err != nil {
+			panic(err)
+		}
+		err = expcapzv1alpha3.AddToScheme(scheme)
+		if err != nil {
+			panic(err)
+		}
+		err = capiv1alpha3.AddToScheme(scheme)
+		if err != nil {
+			panic(err)
+		}
+		err = capzv1alpha3.AddToScheme(scheme)
 		if err != nil {
 			panic(err)
 		}
@@ -41,6 +62,7 @@ func FakeK8sClient() k8sclient.Interface {
 
 		k8sClient = &fakeK8sClient{
 			ctrlClient: fake.NewFakeClientWithScheme(scheme),
+			scheme:     scheme,
 		}
 	}
 
@@ -80,5 +102,5 @@ func (f *fakeK8sClient) RESTConfig() *rest.Config {
 }
 
 func (f *fakeK8sClient) Scheme() *runtime.Scheme {
-	return nil
+	return f.scheme
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12428

This PR adds two provider agnostic controllers: machine pool controller and cluster controller. These controllers try to mimic the upstream CAPI provider agnostic controllers.

By setting the `ownerReferences` in our CR's we can leverage Kubernetes garbage collection. This means that if a `Cluster` is deleted, owned resources like `AzureCluster` and `MachinePool` will be deleted (and also `AzureMachinePool` because it's owned by `MachinePool`).

At the moment these controllers only do this small task, so I _inlined_ the handlers inside the controllers. Not sure about this approach though. We could create two new handlers "the normal way" and just reference them from the controllers.

## machine pool controller

The machine pool controller makes sure that:
- `MachinePool` is owned by `Cluster`.
- `MachinePool` is labeled with `Cluster` id.
- `AzureMachinePool` is owned by `MachinePool`.


## cluster controller

The cluster controller makes sure that:
- `AzureCluster` is owned by `Cluster`.
- `AzureCluster` is labeled with `Cluster` id.