### PR TITLE
Use slice of controllers instead of booting one by one

### DIFF
--- a/service/controller/azure_cluster_controller.go
+++ b/service/controller/azure_cluster_controller.go
@@ -49,11 +49,7 @@ type AzureClusterConfig struct {
 	SentryDSN string
 }
 
-type AzureCluster struct {
-	*controller.Controller
-}
-
-func NewAzureCluster(config AzureClusterConfig) (*AzureCluster, error) {
+func NewAzureCluster(config AzureClusterConfig) (*controller.Controller, error) {
 	var err error
 
 	var certsSearcher *certs.Searcher
@@ -104,11 +100,7 @@ func NewAzureCluster(config AzureClusterConfig) (*AzureCluster, error) {
 		}
 	}
 
-	c := &AzureCluster{
-		Controller: operatorkitController,
-	}
-
-	return c, nil
+	return operatorkitController, nil
 }
 
 func newAzureClusterResources(config AzureClusterConfig, certsSearcher certs.Interface) ([]resource.Interface, error) {

--- a/service/controller/azure_config.go
+++ b/service/controller/azure_config.go
@@ -81,11 +81,7 @@ type AzureConfigConfig struct {
 	SentryDSN string
 }
 
-type AzureConfig struct {
-	*controller.Controller
-}
-
-func NewAzureConfig(config AzureConfigConfig) (*AzureConfig, error) {
+func NewAzureConfig(config AzureConfigConfig) (*controller.Controller, error) {
 	var err error
 
 	var certsSearcher *certs.Searcher
@@ -192,9 +188,7 @@ func NewAzureConfig(config AzureConfigConfig) (*AzureConfig, error) {
 		}
 	}
 
-	return &AzureConfig{
-		Controller: operatorkitController,
-	}, nil
+	return operatorkitController, nil
 }
 
 func newAzureConfigResources(config AzureConfigConfig, certsSearcher certs.Interface) ([]resource.Interface, error) {

--- a/service/controller/azure_machine_pool.go
+++ b/service/controller/azure_machine_pool.go
@@ -39,11 +39,7 @@ type AzureMachinePoolConfig struct {
 	SentryDSN                 string
 }
 
-type AzureMachinePool struct {
-	*controller.Controller
-}
-
-func NewAzureMachinePool(config AzureMachinePoolConfig) (*AzureMachinePool, error) {
+func NewAzureMachinePool(config AzureMachinePoolConfig) (*controller.Controller, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
@@ -89,7 +85,7 @@ func NewAzureMachinePool(config AzureMachinePoolConfig) (*AzureMachinePool, erro
 		}
 	}
 
-	return &AzureMachinePool{Controller: operatorkitController}, nil
+	return operatorkitController, nil
 }
 
 func NewAzureMachinePoolResourceSet(config AzureMachinePoolConfig) ([]resource.Interface, error) {

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -29,11 +29,7 @@ type ClusterConfig struct {
 	SentryDSN string
 }
 
-type Cluster struct {
-	*controller.Controller
-}
-
-func NewCluster(config ClusterConfig) (*Cluster, error) {
+func NewCluster(config ClusterConfig) (*controller.Controller, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
@@ -76,7 +72,7 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 		}
 	}
 
-	return &Cluster{Controller: operatorkitController}, nil
+	return operatorkitController, nil
 }
 
 func NewClusterResourceSet(config ClusterConfig) ([]resource.Interface, error) {

--- a/service/controller/machine_pool.go
+++ b/service/controller/machine_pool.go
@@ -32,11 +32,7 @@ type MachinePoolConfig struct {
 	SentryDSN string
 }
 
-type MachinePool struct {
-	*controller.Controller
-}
-
-func NewMachinePool(config MachinePoolConfig) (*MachinePool, error) {
+func NewMachinePool(config MachinePoolConfig) (*controller.Controller, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
@@ -81,7 +77,7 @@ func NewMachinePool(config MachinePoolConfig) (*MachinePool, error) {
 		}
 	}
 
-	return &MachinePool{Controller: operatorkitController}, nil
+	return operatorkitController, nil
 }
 
 func NewMachinePoolResourceSet(config MachinePoolConfig) ([]resource.Interface, error) {


### PR DESCRIPTION
Use an slice to hold all the controllers and just iterate through it when booting them. I believe it's simpler, and the `Service` is not coupled to the controllers.