### PR TITLE
Extract OwnerReference handlers to own packages

### DIFF
--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
@@ -13,14 +12,11 @@ import (
 	"github.com/giantswarm/operatorkit/resource/wrapper/retryresource"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/giantswarm/azure-operator/v4/pkg/label"
 	"github.com/giantswarm/azure-operator/v4/pkg/project"
-	"github.com/giantswarm/azure-operator/v4/service/controller/key"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/clusterownerreference"
 	"github.com/giantswarm/azure-operator/v4/service/controller/setting"
 )
 
@@ -90,13 +86,13 @@ func NewClusterResourceSet(config ClusterConfig) ([]resource.Interface, error) {
 
 	var ownerReferencesResource resource.Interface
 	{
-		c := ClusterOwnerReferencesConfig{
+		c := clusterownerreference.Config{
 			CtrlClient: config.K8sClient.CtrlClient(),
 			Logger:     config.Logger,
 			Scheme:     config.K8sClient.Scheme(),
 		}
 
-		ownerReferencesResource, err = NewClusterOwnerReferences(c)
+		ownerReferencesResource, err = clusterownerreference.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -126,82 +122,4 @@ func NewClusterResourceSet(config ClusterConfig) ([]resource.Interface, error) {
 	}
 
 	return resources, nil
-}
-
-type ClusterOwnerReferencesConfig struct {
-	CtrlClient client.Client
-	Logger     micrologger.Logger
-	Scheme     *runtime.Scheme
-}
-
-type ClusterOwnerReferencesResource struct {
-	ctrlClient client.Client
-	logger     micrologger.Logger
-	scheme     *runtime.Scheme
-}
-
-func NewClusterOwnerReferences(config ClusterOwnerReferencesConfig) (*ClusterOwnerReferencesResource, error) {
-	if config.CtrlClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-	if config.Scheme == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Scheme must not be empty", config)
-	}
-
-	r := &ClusterOwnerReferencesResource{
-		ctrlClient: config.CtrlClient,
-		logger:     config.Logger,
-		scheme:     config.Scheme,
-	}
-
-	return r, nil
-}
-
-// EnsureCreated ensures the AzureCluster is owned by the Cluster it belongs to.
-func (r *ClusterOwnerReferencesResource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	cluster, err := key.ToCluster(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensuring %s label and 'ownerReference' fields on AzureCluster '%s/%s'", capiv1alpha3.ClusterLabelName, cluster.Namespace, cluster.Spec.InfrastructureRef.Name))
-
-	azureCluster := v1alpha3.AzureCluster{}
-	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Spec.InfrastructureRef.Name}, &azureCluster)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	if azureCluster.Labels == nil {
-		azureCluster.Labels = make(map[string]string)
-	}
-	azureCluster.Labels[capiv1alpha3.ClusterLabelName] = cluster.Name
-
-	// Set Cluster as owner of AzureCluster
-	err = controllerutil.SetControllerReference(&cluster, &azureCluster, r.scheme)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	err = r.ctrlClient.Update(ctx, &azureCluster)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensured %s label and 'ownerReference' fields on AzureCluster '%s/%s'", capiv1alpha3.ClusterLabelName, cluster.Namespace, cluster.Spec.InfrastructureRef.Name))
-
-	return nil
-}
-
-// EnsureDeleted is a noop.
-func (r *ClusterOwnerReferencesResource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	return nil
-}
-
-// Name returns the resource name.
-func (r *ClusterOwnerReferencesResource) Name() string {
-	return "ClusterOwnerReferences"
 }

--- a/service/controller/machine_pool.go
+++ b/service/controller/machine_pool.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
@@ -11,19 +10,13 @@ import (
 	"github.com/giantswarm/operatorkit/resource"
 	"github.com/giantswarm/operatorkit/resource/wrapper/metricsresource"
 	"github.com/giantswarm/operatorkit/resource/wrapper/retryresource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
-	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
-	capiutil "sigs.k8s.io/cluster-api/util"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/giantswarm/azure-operator/v4/pkg/label"
 	"github.com/giantswarm/azure-operator/v4/pkg/project"
-	"github.com/giantswarm/azure-operator/v4/service/controller/key"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/machinepoolownerreference"
 )
 
 type MachinePoolConfig struct {
@@ -92,13 +85,13 @@ func NewMachinePoolResourceSet(config MachinePoolConfig) ([]resource.Interface, 
 
 	var ownerReferencesResource resource.Interface
 	{
-		c := MachinePoolOwnerReferencesConfig{
+		c := machinepoolownerreference.Config{
 			CtrlClient: config.K8sClient.CtrlClient(),
 			Logger:     config.Logger,
 			Scheme:     config.K8sClient.Scheme(),
 		}
 
-		ownerReferencesResource, err = NewMachinePoolOwnerReferences(c)
+		ownerReferencesResource, err = machinepoolownerreference.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -128,108 +121,4 @@ func NewMachinePoolResourceSet(config MachinePoolConfig) ([]resource.Interface, 
 	}
 
 	return resources, nil
-}
-
-type MachinePoolOwnerReferencesConfig struct {
-	CtrlClient client.Client
-	Logger     micrologger.Logger
-	Scheme     *runtime.Scheme
-}
-
-type MachinePoolOwnerReferencesResource struct {
-	ctrlClient client.Client
-	logger     micrologger.Logger
-	scheme     *runtime.Scheme
-}
-
-func NewMachinePoolOwnerReferences(config MachinePoolOwnerReferencesConfig) (*MachinePoolOwnerReferencesResource, error) {
-	if config.CtrlClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
-	}
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-	if config.Scheme == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Scheme must not be empty", config)
-	}
-
-	r := &MachinePoolOwnerReferencesResource{
-		ctrlClient: config.CtrlClient,
-		logger:     config.Logger,
-		scheme:     config.Scheme,
-	}
-
-	return r, nil
-}
-
-// EnsureCreated ensures the MachinePool is owned by the Cluster it belongs to, and the AzureMachinePool is owned by the MachinePool.
-func (r *MachinePoolOwnerReferencesResource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	machinePool, err := key.ToMachinePool(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensuring %s label and 'ownerReference' fields on MachinePool '%s/%s'", capiv1alpha3.ClusterLabelName, machinePool.Namespace, machinePool.Name))
-	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensuring %s label and 'ownerReference' fields on AzureMachinePool '%s/%s'", capiv1alpha3.ClusterLabelName, machinePool.Namespace, machinePool.Spec.Template.Spec.InfrastructureRef.Name))
-
-	azureMachinePool := expcapzv1alpha3.AzureMachinePool{}
-	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: machinePool.Namespace, Name: machinePool.Spec.Template.Spec.InfrastructureRef.Name}, &azureMachinePool)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	if machinePool.Labels == nil {
-		machinePool.Labels = make(map[string]string)
-	}
-	machinePool.Labels[capiv1alpha3.ClusterLabelName] = machinePool.Spec.ClusterName
-
-	if azureMachinePool.Labels == nil {
-		azureMachinePool.Labels = make(map[string]string)
-	}
-	azureMachinePool.Labels[capiv1alpha3.ClusterLabelName] = machinePool.Spec.ClusterName
-
-	cluster, err := capiutil.GetClusterByName(ctx, r.ctrlClient, machinePool.Namespace, machinePool.Spec.ClusterName)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	// Set Cluster as owner of MachinePool
-	machinePool.OwnerReferences = capiutil.EnsureOwnerRef(machinePool.OwnerReferences, metav1.OwnerReference{
-		APIVersion: capiv1alpha3.GroupVersion.String(),
-		Kind:       "Cluster",
-		Name:       cluster.Name,
-		UID:        cluster.UID,
-	})
-
-	err = r.ctrlClient.Update(ctx, &machinePool)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensured %s label and 'ownerReference' fields on MachinePool '%s/%s'", capiv1alpha3.ClusterLabelName, machinePool.Namespace, machinePool.Name))
-
-	// Set MachinePool as owner of AzureMachinePool
-	err = controllerutil.SetControllerReference(&machinePool, &azureMachinePool, r.scheme)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	err = r.ctrlClient.Update(ctx, &azureMachinePool)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensuring %s label and 'ownerReference' fields on AzureMachinePool '%s/%s'", capiv1alpha3.ClusterLabelName, machinePool.Namespace, machinePool.Spec.Template.Spec.InfrastructureRef.Name))
-
-	return nil
-}
-
-// EnsureDeleted is a noop.
-func (r *MachinePoolOwnerReferencesResource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	return nil
-}
-
-// Name returns the resource name.
-func (r *MachinePoolOwnerReferencesResource) Name() string {
-	return "MachinePoolOwnerReferences"
 }

--- a/service/controller/resource/clusterownerreference/error.go
+++ b/service/controller/resource/clusterownerreference/error.go
@@ -1,0 +1,14 @@
+package clusterownerreference
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/clusterownerreference/resource.go
+++ b/service/controller/resource/clusterownerreference/resource.go
@@ -53,7 +53,8 @@ func New(config Config) (*Resource, error) {
 	return r, nil
 }
 
-// EnsureCreated ensures that reconciled AzureConfig CR has cluster ID label.
+// EnsureCreated ensures that OwnerReference is correctly set for
+// infrastructure CR.
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	cluster, err := key.ToCluster(obj)
 	if err != nil {

--- a/service/controller/resource/clusterownerreference/resource.go
+++ b/service/controller/resource/clusterownerreference/resource.go
@@ -1,0 +1,100 @@
+package clusterownerreference
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/giantswarm/azure-operator/v4/service/controller/key"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "clusterownerreference"
+)
+
+type Config struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+	Scheme     *runtime.Scheme
+}
+
+// Resource manages Azure resource groups.
+type Resource struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+	scheme     *runtime.Scheme
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Scheme == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Scheme must not be empty", config)
+	}
+
+	r := &Resource{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+		scheme:     config.Scheme,
+	}
+
+	return r, nil
+}
+
+// EnsureCreated ensures that reconciled AzureConfig CR has cluster ID label.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cluster, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensuring %s label and 'ownerReference' fields on AzureCluster '%s/%s'", capiv1alpha3.ClusterLabelName, cluster.Namespace, cluster.Spec.InfrastructureRef.Name))
+
+	azureCluster := v1alpha3.AzureCluster{}
+	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Spec.InfrastructureRef.Name}, &azureCluster)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if azureCluster.Labels == nil {
+		azureCluster.Labels = make(map[string]string)
+	}
+	azureCluster.Labels[capiv1alpha3.ClusterLabelName] = cluster.Name
+
+	// Set Cluster as owner of AzureCluster
+	err = controllerutil.SetControllerReference(&cluster, &azureCluster, r.scheme)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.ctrlClient.Update(ctx, &azureCluster)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensured %s label and 'ownerReference' fields on AzureCluster '%s/%s'", capiv1alpha3.ClusterLabelName, cluster.Namespace, cluster.Spec.InfrastructureRef.Name))
+
+	return nil
+}
+
+// EnsureDeleted is no-op.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}
+
+// Name returns the resource name.
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/resource/clusterownerreference/resource_test.go
+++ b/service/controller/resource/clusterownerreference/resource_test.go
@@ -1,4 +1,4 @@
-package controller
+package clusterownerreference
 
 import (
 	"context"
@@ -19,7 +19,7 @@ func TestThatAzureClusterIsLabeledWithClusterId(t *testing.T) {
 	ctx := context.Background()
 	fakeK8sClient := unittest.FakeK8sClient()
 	ctrlClient := fakeK8sClient.CtrlClient()
-	controller, err := NewClusterOwnerReferences(ClusterOwnerReferencesConfig{
+	controller, err := New(Config{
 		CtrlClient: ctrlClient,
 		Logger:     microloggertest.New(),
 		Scheme:     fakeK8sClient.Scheme(),
@@ -130,7 +130,7 @@ func givenAzureCluster(ctx context.Context, ctrlClient client.Client, clusterNam
 }
 
 func whenReconcilingCluster(ctx context.Context, ctrlClient client.Client, scheme *runtime.Scheme, cluster *capiv1alpha3.Cluster) error {
-	controller, err := NewClusterOwnerReferences(ClusterOwnerReferencesConfig{
+	controller, err := New(Config{
 		CtrlClient: ctrlClient,
 		Logger:     microloggertest.New(),
 		Scheme:     scheme,

--- a/service/controller/resource/machinepoolownerreference/error.go
+++ b/service/controller/resource/machinepoolownerreference/error.go
@@ -1,0 +1,14 @@
+package machinepoolownerreference
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/machinepoolownerreference/resource.go
+++ b/service/controller/resource/machinepoolownerreference/resource.go
@@ -55,7 +55,8 @@ func New(config Config) (*Resource, error) {
 	return r, nil
 }
 
-// EnsureCreated ensures that reconciled AzureConfig CR has machinepool ID label.
+// EnsureCreated ensures that OwnerReference is correctly set for
+// infrastructure CR.
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	machinePool, err := key.ToMachinePool(obj)
 	if err != nil {

--- a/service/controller/resource/machinepoolownerreference/resource.go
+++ b/service/controller/resource/machinepoolownerreference/resource.go
@@ -1,0 +1,128 @@
+package machinepoolownerreference
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiutil "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/giantswarm/azure-operator/v4/service/controller/key"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "machinepoolownerreference"
+)
+
+type Config struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+	Scheme     *runtime.Scheme
+}
+
+// Resource manages Azure resource groups.
+type Resource struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+	scheme     *runtime.Scheme
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Scheme == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Scheme must not be empty", config)
+	}
+
+	r := &Resource{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+		scheme:     config.Scheme,
+	}
+
+	return r, nil
+}
+
+// EnsureCreated ensures that reconciled AzureConfig CR has machinepool ID label.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	machinePool, err := key.ToMachinePool(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensuring %s label and 'ownerReference' fields on MachinePool '%s/%s'", capiv1alpha3.ClusterLabelName, machinePool.Namespace, machinePool.Name))
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensuring %s label and 'ownerReference' fields on AzureMachinePool '%s/%s'", capiv1alpha3.ClusterLabelName, machinePool.Namespace, machinePool.Spec.Template.Spec.InfrastructureRef.Name))
+
+	azureMachinePool := expcapzv1alpha3.AzureMachinePool{}
+	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: machinePool.Namespace, Name: machinePool.Spec.Template.Spec.InfrastructureRef.Name}, &azureMachinePool)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if machinePool.Labels == nil {
+		machinePool.Labels = make(map[string]string)
+	}
+	machinePool.Labels[capiv1alpha3.ClusterLabelName] = machinePool.Spec.ClusterName
+
+	if azureMachinePool.Labels == nil {
+		azureMachinePool.Labels = make(map[string]string)
+	}
+	azureMachinePool.Labels[capiv1alpha3.ClusterLabelName] = machinePool.Spec.ClusterName
+
+	cluster, err := capiutil.GetClusterByName(ctx, r.ctrlClient, machinePool.Namespace, machinePool.Spec.ClusterName)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Set Cluster as owner of MachinePool
+	machinePool.OwnerReferences = capiutil.EnsureOwnerRef(machinePool.OwnerReferences, metav1.OwnerReference{
+		APIVersion: capiv1alpha3.GroupVersion.String(),
+		Kind:       "Cluster",
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+	})
+
+	err = r.ctrlClient.Update(ctx, &machinePool)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensured %s label and 'ownerReference' fields on MachinePool '%s/%s'", capiv1alpha3.ClusterLabelName, machinePool.Namespace, machinePool.Name))
+
+	// Set MachinePool as owner of AzureMachinePool
+	err = controllerutil.SetControllerReference(&machinePool, &azureMachinePool, r.scheme)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.ctrlClient.Update(ctx, &azureMachinePool)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensuring %s label and 'ownerReference' fields on AzureMachinePool '%s/%s'", capiv1alpha3.ClusterLabelName, machinePool.Namespace, machinePool.Spec.Template.Spec.InfrastructureRef.Name))
+
+	return nil
+}
+
+// EnsureDeleted is no-op.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}
+
+// Name returns the resource name.
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/resource/machinepoolownerreference/resource_test.go
+++ b/service/controller/resource/machinepoolownerreference/resource_test.go
@@ -1,4 +1,4 @@
-package controller
+package machinepoolownerreference
 
 import (
 	"context"
@@ -77,7 +77,7 @@ func TestThatMachinePoolIsOwnedByCluster(t *testing.T) {
 }
 
 func whenReconcilingMachinePool(ctx context.Context, ctrlClient client.Client, scheme *runtime.Scheme, machinePool *expcapiv1alpha3.MachinePool) error {
-	controller, err := NewMachinePoolOwnerReferences(MachinePoolOwnerReferencesConfig{
+	controller, err := New(Config{
 		CtrlClient: ctrlClient,
 		Logger:     microloggertest.New(),
 		Scheme:     scheme,


### PR DESCRIPTION
Cluster & MachinePool controllers need to be configured with more handlers so
it makes sense to extract embedded handlers to their own packages as others.

There are no logic changes, the implementation is just moved to separate packages.