### PR TITLE
Add CAPI handlers to wait for dependent CRs on deletion

### DIFF
--- a/service/controller/resource/clusterdependents/error.go
+++ b/service/controller/resource/clusterdependents/error.go
@@ -1,0 +1,14 @@
+package clusterdependents
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/clusterdependents/resource.go
+++ b/service/controller/resource/clusterdependents/resource.go
@@ -12,7 +12,6 @@ import (
 	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/azure-operator/v4/pkg/label"
 	"github.com/giantswarm/azure-operator/v4/service/controller/key"
 )
 
@@ -107,7 +106,7 @@ func (r *Resource) infrastructureCRExists(ctx context.Context, cr capiv1alpha3.C
 
 func (r *Resource) machinePoolCRsExist(ctx context.Context, cr capiv1alpha3.Cluster) (bool, error) {
 	o := client.MatchingLabels{
-		label.Cluster: key.ClusterID(&cr),
+		capiv1alpha3.ClusterLabelName: key.ClusterID(&cr),
 	}
 	mpList := new(expcapiv1alpha3.MachinePoolList)
 	err := r.ctrlClient.List(ctx, mpList, o)

--- a/service/controller/resource/clusterdependents/resource.go
+++ b/service/controller/resource/clusterdependents/resource.go
@@ -90,8 +90,12 @@ func (r *Resource) Name() string {
 }
 
 func (r *Resource) infrastructureCRExists(ctx context.Context, cr capiv1alpha3.Cluster) (bool, error) {
+	objKey := client.ObjectKey{
+		Namespace: cr.Namespace,
+		Name: cr.Spec.InfrastructureRef.Name,
+	}
 	azureCluster := new(v1alpha3.AzureCluster)
-	err := r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cr.Namespace, Name: cr.Spec.InfrastructureRef.Name}, azureCluster)
+	err := r.ctrlClient.Get(ctx, objKey, azureCluster)
 	if errors.IsNotFound(err) {
 		return false, nil
 	} else if err != nil {

--- a/service/controller/resource/clusterdependents/resource.go
+++ b/service/controller/resource/clusterdependents/resource.go
@@ -92,7 +92,7 @@ func (r *Resource) Name() string {
 func (r *Resource) infrastructureCRExists(ctx context.Context, cr capiv1alpha3.Cluster) (bool, error) {
 	objKey := client.ObjectKey{
 		Namespace: cr.Namespace,
-		Name: cr.Spec.InfrastructureRef.Name,
+		Name:      cr.Spec.InfrastructureRef.Name,
 	}
 	azureCluster := new(v1alpha3.AzureCluster)
 	err := r.ctrlClient.Get(ctx, objKey, azureCluster)

--- a/service/controller/resource/clusterdependents/resource.go
+++ b/service/controller/resource/clusterdependents/resource.go
@@ -1,0 +1,115 @@
+package clusterdependents
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-operator/v4/pkg/label"
+	"github.com/giantswarm/azure-operator/v4/service/controller/key"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "clusterdependents"
+)
+
+type Config struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+}
+
+// Resource ensures that there are no orphaned dependent AzureCluster or MachinePool CRs.
+type Resource struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return r, nil
+}
+
+// EnsureCreated is a no-op.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}
+
+// EnsureDeleted ensures that all dependent CRs are deleted before finalizer
+// from Cluster is removed.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	exists, err := r.infrastructureCRExists(ctx, cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if exists {
+		finalizerskeptcontext.SetKept(ctx)
+		return nil
+	}
+
+	exists, err = r.machinePoolCRsExist(ctx, cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if exists {
+		finalizerskeptcontext.SetKept(ctx)
+		return nil
+	}
+
+	return nil
+}
+
+// Name returns the resource name.
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) infrastructureCRExists(ctx context.Context, cr capiv1alpha3.Cluster) (bool, error) {
+	azureCluster := new(v1alpha3.AzureCluster)
+	err := r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cr.Namespace, Name: cr.Spec.InfrastructureRef.Name}, azureCluster)
+	if errors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return true, nil
+}
+
+func (r *Resource) machinePoolCRsExist(ctx context.Context, cr capiv1alpha3.Cluster) (bool, error) {
+	o := client.MatchingLabels{
+		label.Cluster: key.ClusterID(&cr),
+	}
+	mpList := new(expcapiv1alpha3.MachinePoolList)
+	err := r.ctrlClient.List(ctx, mpList, o)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return (len(mpList.Items) > 0), nil
+}

--- a/service/controller/resource/machinepooldependents/error.go
+++ b/service/controller/resource/machinepooldependents/error.go
@@ -1,0 +1,14 @@
+package machinepooldependents
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/machinepooldependents/resource.go
+++ b/service/controller/resource/machinepooldependents/resource.go
@@ -78,8 +78,12 @@ func (r *Resource) Name() string {
 }
 
 func (r *Resource) infrastructureCRExists(ctx context.Context, cr expcapiv1alpha3.MachinePool) (bool, error) {
+	objKey := client.ObjectKey{
+		Namespace: cr.Namespace,
+		Name:      cr.Spec.Template.Spec.InfrastructureRef.Name,
+	}
 	azureMachinePool := new(expcapzv1alpha3.AzureMachinePool)
-	err := r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cr.Namespace, Name: cr.Spec.Template.Spec.InfrastructureRef.Name}, azureMachinePool)
+	err := r.ctrlClient.Get(ctx, objKey, azureMachinePool)
 	if errors.IsNotFound(err) {
 		return false, nil
 	} else if err != nil {

--- a/service/controller/resource/machinepooldependents/resource.go
+++ b/service/controller/resource/machinepooldependents/resource.go
@@ -1,0 +1,90 @@
+package machinepooldependents
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
+	"k8s.io/apimachinery/pkg/api/errors"
+	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-operator/v4/service/controller/key"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "machinepooldependents"
+)
+
+type Config struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+}
+
+// Resource ensures that there are no orphaned dependent AzureMachinePool CRs.
+type Resource struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return r, nil
+}
+
+// EnsureCreated is a no-op.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}
+
+// EnsureDeleted ensures that all dependent CRs are deleted before finalizer
+// from MachinePool is removed.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToMachinePool(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	exists, err := r.infrastructureCRExists(ctx, cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if exists {
+		finalizerskeptcontext.SetKept(ctx)
+		return nil
+	}
+
+	return nil
+}
+
+// Name returns the resource name.
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) infrastructureCRExists(ctx context.Context, cr expcapiv1alpha3.MachinePool) (bool, error) {
+	azureMachinePool := new(expcapzv1alpha3.AzureMachinePool)
+	err := r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cr.Namespace, Name: cr.Spec.Template.Spec.InfrastructureRef.Name}, azureMachinePool)
+	if errors.IsNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return true, nil
+}


### PR DESCRIPTION
When deleting cluster, Cluster controller must wait for all cluster related
child CRs before the finalizer is removed. Similar to this, MachinePool
controller must wait for all node pool related CRs to be deleted before
allowing the finalizer to be removed.

This prevents orphaned dependents when CRs are deleted in unspecified order.