### PR TITLE
Wire CAPI dependents deletion handlers

### DIFF
--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/giantswarm/azure-operator/v4/pkg/label"
 	"github.com/giantswarm/azure-operator/v4/pkg/project"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/clusterdependents"
 	"github.com/giantswarm/azure-operator/v4/service/controller/resource/clusterownerreference"
 	"github.com/giantswarm/azure-operator/v4/service/controller/setting"
 )
@@ -84,6 +85,19 @@ func NewClusterResourceSet(config ClusterConfig) ([]resource.Interface, error) {
 
 	var err error
 
+	var clusterDependentsResource resource.Interface
+	{
+		c := clusterdependents.Config{
+			CtrlClient: config.K8sClient.CtrlClient(),
+			Logger:     config.Logger,
+		}
+
+		clusterDependentsResource, err = clusterdependents.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var ownerReferencesResource resource.Interface
 	{
 		c := clusterownerreference.Config{
@@ -99,6 +113,7 @@ func NewClusterResourceSet(config ClusterConfig) ([]resource.Interface, error) {
 	}
 
 	resources := []resource.Interface{
+		clusterDependentsResource,
 		ownerReferencesResource,
 	}
 

--- a/service/controller/machine_pool.go
+++ b/service/controller/machine_pool.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/giantswarm/azure-operator/v4/pkg/label"
 	"github.com/giantswarm/azure-operator/v4/pkg/project"
+	"github.com/giantswarm/azure-operator/v4/service/controller/resource/machinepooldependents"
 	"github.com/giantswarm/azure-operator/v4/service/controller/resource/machinepoolownerreference"
 )
 
@@ -83,6 +84,19 @@ func NewMachinePoolResourceSet(config MachinePoolConfig) ([]resource.Interface, 
 
 	var err error
 
+	var machinepoolDependentsResource resource.Interface
+	{
+		c := machinepooldependents.Config{
+			CtrlClient: config.K8sClient.CtrlClient(),
+			Logger:     config.Logger,
+		}
+
+		machinepoolDependentsResource, err = machinepooldependents.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var ownerReferencesResource resource.Interface
 	{
 		c := machinepoolownerreference.Config{
@@ -98,6 +112,7 @@ func NewMachinePoolResourceSet(config MachinePoolConfig) ([]resource.Interface, 
 	}
 
 	resources := []resource.Interface{
+		machinepoolDependentsResource,
 		ownerReferencesResource,
 	}
 


### PR DESCRIPTION
CAPI dependents deletion handlers wait until all dependent CRs are gone before
removing finalizer from Cluster and MachinePool.