### PR TITLE
Handle missing storage account & blob gracefully on create & delete

### DIFF
--- a/service/controller/resource/cloudconfigblob/delete.go
+++ b/service/controller/resource/cloudconfigblob/delete.go
@@ -41,7 +41,10 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	var containerURL azblob.ContainerURL
 	{
 		containerURL, err = r.getContainerURL(ctx, credentialSecret, key.ClusterID(&azureMachinePool), key.StorageAccountName(&azureMachinePool))
-		if err != nil {
+		if IsStorageAccountNotFound(err) {
+			// Most probably resource group is already deleted. All good for cloudconfig.
+			return nil
+		} else if err != nil {
 			return microerror.Mask(err)
 		}
 	}

--- a/service/controller/resource/cloudconfigblob/delete.go
+++ b/service/controller/resource/cloudconfigblob/delete.go
@@ -51,7 +51,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 
 	blob := containerURL.NewBlockBlobURL(blobName)
 	_, err = blob.Delete(ctx, azblob.DeleteSnapshotsOptionInclude, azblob.BlobAccessConditions{})
-	if blobclient.IsNotFound(err) {
+	if blobclient.IsNotFound(err) || blobclient.IsBlobNotFound(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "Bootstrap blob not found when trying to delete it")
 		return nil
 	} else if err != nil {


### PR DESCRIPTION
When cluster gets deleted, the top level cluster reconciliation deletes whole
resource group. If machinepool cleanup is still in progress, it might happen
that storage account gets deleted before the machine pool is fully gone so
handle the not found error gracefully.

Equally when it's created, the storage account might not be there yet so
cancel resource while waiting for it.