### PR TITLE
Use employees repository for ssh keys

### DIFF
--- a/e2e/env/azure.go
+++ b/e2e/env/azure.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/giantswarm/employees/pkg/employees"
+
 	"github.com/giantswarm/azure-operator/v4/e2e/network"
 )
 
@@ -94,7 +96,12 @@ func init() {
 	sshPublicKey, ok = os.LookupEnv(EnvVarBastionPublicSSHKey)
 	if !ok {
 		fmt.Printf("No value found in '%s': default public key will be placed on the bastion server\n", EnvVarBastionPublicSSHKey)
-		sshPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDBSSJCLkZWhOvs6blotU+fWbrTmC7fOwOm0+w01Ww/YN3j3j1vCrvji1A4Yonr89ePQEQKfZsYcYFodQI/D3Uzu9rOFy0dCMQfvL/J6N8LkNtmooh3J2p061829MurAdD+TVsNGrD2FZGm5Ab4NiyDXIGAYCaHL6BHP16ipBglYjLQt6jVyzdTbYspkRi1QrsNFN3gIv9V47qQSvoNEsC97gvumKzCSQ/EwJzFoIlqVkZZHZTXvGwnZrAVXB69t9Y8OJ5zA6cYFAKR0O7lEiMpebdLNGkZgMA6t2PADxfT78PHkYXLR/4tchVuOSopssJqgSs7JgIktEE14xKyNyoLKIyBBo3xwywnDySsL8R2zG4Ytw1luo79pnSpIzTvfwrNhd7Cg//OYzyDCty+XUEUQx2JfOBx5Qb1OFw71WA+zYqjbworOsy2ZZ9UAy8ryjiaeT8L2ZRGuhdicD6kkL3Lxg5UeNIxS2FLNwgepZ4D8Vo6Yxe+VOZl524ffoOJSHQ0Gz8uE76hXMNEcn4t8HVkbR4sCMgLn2YbwJ2dJcROj4w80O4qgtN1vsL16r4gt9o6euml8LbmnJz6MtGdMczSO7kHRxirtEHMTtYbT1wNgUAzimbScRggBpUz5gbz+NRE1Xgnf4A5yNMRy+JOWtLVUozJlcGSiQkVcexzdb27yQ=="
+		employeesSet, err := employees.NewEmployeesSet()
+		if err != nil {
+			panic("Error trying to read employees SSH keys")
+		}
+
+		sshPublicKey = strings.Join(employeesSet.GetAllKeys(), "\n")
 	}
 
 	// azureCDIR must be provided along with other CIDRs,

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/giantswarm/e2esetup v0.1.0
 	github.com/giantswarm/e2etemplates v0.2.0
 	github.com/giantswarm/e2etests v0.1.0
+	github.com/giantswarm/employees v0.0.0-20200824092013-3689f672d235 // indirect
 	github.com/giantswarm/errors v0.2.3
 	github.com/giantswarm/helmclient v1.0.4
 	github.com/giantswarm/ipam v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,8 @@ github.com/giantswarm/e2etemplates v0.2.0 h1:xwsa8hSirDF8nFdRJZJROPwjiL1vsuhWltz
 github.com/giantswarm/e2etemplates v0.2.0/go.mod h1:q7aE42HUEdxm6NtLJ/csoMBWoRoIfhdy0WC85aRjLi8=
 github.com/giantswarm/e2etests v0.1.0 h1:VgD3rCoMUytET96eDiySYeVYCVtBQUtP7bO+y/ORxfg=
 github.com/giantswarm/e2etests v0.1.0/go.mod h1:jfE2zMqSmGC5Infyh/DufFRDriS+CwVAVV+lFb/SLWg=
+github.com/giantswarm/employees v0.0.0-20200824092013-3689f672d235 h1:BXShKR9Vr+/sT2gbftbUA81xmSfhvNENcsR4F8GKqTY=
+github.com/giantswarm/employees v0.0.0-20200824092013-3689f672d235/go.mod h1:2lTF/1nJTf76u62ZdmPO+qUUJDg8gphtAAcbNWptXAM=
 github.com/giantswarm/errors v0.2.3 h1:gE1dDSD0RNwYUah5hG6oUQh0unPyZ74tVwR1/PW3ZQ0=
 github.com/giantswarm/errors v0.2.3/go.mod h1:Oj1LIWs9Uoj6JGtK5HxTb50iZuqe9f60LDI0nLXA5vU=
 github.com/giantswarm/exporterkit v0.2.0 h1:+HTGl4fmT/1OkTox8HbV3JXeavmsZv94+2CDW8cSrq0=


### PR DESCRIPTION
Instead of having to pass an env var through CircleCI to get our public SSH key in the VMs to debug, we could use the new `employees` repository to dynamically fetch the public SSH keys of the employees. I have left the mechanism to overwrite the public SSH key to use, just in case we need it for something, but I'm thinking if it would be better to remove it. WDYT?