### PR TITLE
Improve capzcrs CR merging

### DIFF
--- a/integration/test/crmapping/testdata/case-0-create-AzureConfig_AzureConfig.golden
+++ b/integration/test/crmapping/testdata/case-0-create-AzureConfig_AzureConfig.golden
@@ -73,7 +73,7 @@ spec:
       kubelet:
         altNames: ""
         domain: worker.c6fme.k8s.ghost.westeurope.azure.gigantic.io
-        labels: azure-operator.giantswarm.io/version=4.2.0,giantswarm.io/provider=azure
+        labels: giantswarm.io/provider=azure,azure-operator.giantswarm.io/version=4.2.0
         port: 0
       networkSetup:
         docker:
@@ -106,7 +106,7 @@ status:
       desiredCapacity: 0
     versions:
     - date: null
-      lastTransitionTime: "2020-08-13T04:41:17Z"
+      lastTransitionTime: "2020-08-25T12:25:51Z"
       semver: 4.2.0
   provider:
     ingress:

--- a/integration/test/crmapping/testdata/case-0-migrate-AzureConfig_AzureConfig.golden
+++ b/integration/test/crmapping/testdata/case-0-migrate-AzureConfig_AzureConfig.golden
@@ -79,7 +79,7 @@ spec:
       kubelet:
         altNames: ""
         domain: worker.c6fme.k8s.ghost.westeurope.azure.gigantic.io
-        labels: azure-operator.giantswarm.io/version=4.2.0,giantswarm.io/provider=azure
+        labels: giantswarm.io/provider=azure,azure-operator.giantswarm.io/version=4.2.0
         port: 0
       networkSetup:
         docker:

--- a/service/controller/resource/capzcrs/create.go
+++ b/service/controller/resource/capzcrs/create.go
@@ -24,6 +24,13 @@ import (
 	"github.com/giantswarm/azure-operator/v4/service/controller/key"
 )
 
+type crmapping struct {
+	obj runtime.Object
+
+	needUpdateFunc func(orig, desired runtime.Object) (bool, error)
+	mergeFunc      func(orig, desired runtime.Object) (runtime.Object, error)
+}
+
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	cr, err := key.ToCustomResource(obj)
 	if err != nil {
@@ -32,13 +39,17 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "mapping AzureConfig CR to CAPI & CAPZ CRs")
 
-	var mappedCRs []runtime.Object
+	var mappedCRs []crmapping
 	{
 		o, err := r.mapAzureConfigToAzureCluster(ctx, cr)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		mappedCRs = append(mappedCRs, o)
+		mappedCRs = append(mappedCRs, crmapping{
+			obj:            o,
+			needUpdateFunc: detectAzureClusterUpdate,
+			mergeFunc:      mergeAzureCluster,
+		})
 
 		infraRef := &corev1.ObjectReference{
 			Kind:      "AzureCluster",
@@ -49,13 +60,21 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		mappedCRs = append(mappedCRs, o)
+		mappedCRs = append(mappedCRs, crmapping{
+			obj:            o,
+			needUpdateFunc: genericUpdateDetection,
+			mergeFunc:      genericObjectMerge,
+		})
 
 		o, err = r.mapAzureConfigToAzureMachine(ctx, cr)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		mappedCRs = append(mappedCRs, o)
+		mappedCRs = append(mappedCRs, crmapping{
+			obj:            o,
+			needUpdateFunc: genericUpdateDetection,
+			mergeFunc:      genericObjectMerge,
+		})
 	}
 
 	err = r.updateCRs(ctx, mappedCRs)
@@ -197,17 +216,17 @@ func (r *Resource) mapAzureConfigToAzureMachine(ctx context.Context, cr provider
 	return azureMachine, nil
 }
 
-func (r *Resource) updateCRs(ctx context.Context, desiredCRs []runtime.Object) error {
-	for _, desired := range desiredCRs {
+func (r *Resource) updateCRs(ctx context.Context, crmappings []crmapping) error {
+	for _, m := range crmappings {
 		// Construct new instance by creating deep copy of desired object.
-		readCR := desired.DeepCopyObject()
+		readCR := m.obj.DeepCopyObject()
 
 		// Acquire accessors for ObjectMeta and TypeMeta fields of CR.
-		desiredMeta, err := meta.Accessor(desired)
+		desiredMeta, err := meta.Accessor(m.obj)
 		if err != nil {
 			return microerror.Mask(err)
 		}
-		desiredType, err := meta.TypeAccessor(desired)
+		desiredType, err := meta.TypeAccessor(m.obj)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -224,7 +243,7 @@ func (r *Resource) updateCRs(ctx context.Context, desiredCRs []runtime.Object) e
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%s %s did not exist. creating", desiredType.GetKind(), nsName.String()))
 
 			// It's ok. Let's create it.
-			err = r.ctrlClient.Create(ctx, desired)
+			err = r.ctrlClient.Create(ctx, m.obj)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -235,48 +254,33 @@ func (r *Resource) updateCRs(ctx context.Context, desiredCRs []runtime.Object) e
 			return microerror.Mask(err)
 		}
 
-		readMeta, err := meta.Accessor(readCR)
+		updateNeeded, err := m.needUpdateFunc(readCR, m.obj)
 		if err != nil {
 			return microerror.Mask(err)
-		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("finding if %s %s needs updating", desiredType.GetKind(), nsName.String()))
-
-		var updateNeeded bool
-		if !cmp.Equal(desiredMeta.GetLabels(), readMeta.GetLabels()) {
-			labels := readMeta.GetLabels()
-			for k, v := range desiredMeta.GetLabels() {
-				labels[k] = v
-			}
-			// Set merged labels on desired object as that's the one we write
-			// in update.
-			desiredMeta.SetLabels(labels)
-			updateNeeded = true
-		}
-
-		if !cmp.Equal(desiredMeta.GetAnnotations(), readMeta.GetAnnotations()) {
-			annotations := readMeta.GetAnnotations()
-			for k, v := range desiredMeta.GetAnnotations() {
-				annotations[k] = v
-			}
-			// Set merged labels on desired object as that's the one we write
-			// in update.
-			desiredMeta.SetAnnotations(annotations)
-			updateNeeded = true
-		}
-
-		if !cmp.Equal(desired, readCR, cmpopts.IgnoreTypes(&metav1.ObjectMeta{}), cmpopts.IgnoreTypes(&metav1.TypeMeta{})) {
-			updateNeeded = true
 		}
 
 		if updateNeeded {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found that %s %s needs updating", desiredType.GetKind(), nsName.String()))
 
+			merged, err := m.mergeFunc(readCR, m.obj)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			readMeta, err := meta.Accessor(readCR)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			mergedMeta, err := meta.Accessor(merged)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
 			// Copy read CR's resource version to update object for optimistic
 			// locking.
-			desiredMeta.SetResourceVersion(readMeta.GetResourceVersion())
+			mergedMeta.SetResourceVersion(readMeta.GetResourceVersion())
 
-			err = r.ctrlClient.Update(ctx, desired)
+			err = r.ctrlClient.Update(ctx, merged)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -288,6 +292,109 @@ func (r *Resource) updateCRs(ctx context.Context, desiredCRs []runtime.Object) e
 	}
 
 	return nil
+}
+
+func detectAzureClusterUpdate(orig, desired runtime.Object) (bool, error) {
+	o := orig.(*capzv1alpha3.AzureCluster)
+	d := desired.(*capzv1alpha3.AzureCluster)
+
+	if !cmp.Equal(d.GetLabels(), o.GetLabels()) {
+		return true, nil
+	}
+
+	if !cmp.Equal(d.GetAnnotations(), o.GetAnnotations()) {
+		return true, nil
+	}
+
+	if !cmp.Equal(d, o, cmpopts.IgnoreTypes(&metav1.ObjectMeta{}), cmpopts.IgnoreTypes(&metav1.TypeMeta{}, cmpopts.IgnoreTypes(&capzv1alpha3.Subnets{}))) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func mergeAzureCluster(orig, desired runtime.Object) (runtime.Object, error) {
+	o := orig.(*capzv1alpha3.AzureCluster)
+	d := desired.(*capzv1alpha3.AzureCluster)
+
+	labels := o.GetLabels()
+	for k, v := range d.GetLabels() {
+		labels[k] = v
+	}
+	// Set merged labels on desired object as that's the one we write
+	// in update.
+	d.SetLabels(labels)
+
+	annotations := o.GetAnnotations()
+	for k, v := range d.GetAnnotations() {
+		annotations[k] = v
+	}
+	// Set merged labels on desired object as that's the one we write
+	// in update.
+	d.SetAnnotations(annotations)
+
+	// Maintain existing subnets.
+	d.Spec.NetworkSpec.Subnets = o.Spec.NetworkSpec.Subnets
+
+	return d, nil
+}
+
+func genericUpdateDetection(orig, desired runtime.Object) (bool, error) {
+	// Acquire accessors for ObjectMeta fields of CR.
+	desiredMeta, err := meta.Accessor(desired)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	readMeta, err := meta.Accessor(orig)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	if !cmp.Equal(desiredMeta.GetLabels(), readMeta.GetLabels()) {
+		return true, nil
+	}
+
+	if !cmp.Equal(desiredMeta.GetAnnotations(), readMeta.GetAnnotations()) {
+		return true, nil
+	}
+
+	if !cmp.Equal(desired, orig, cmpopts.IgnoreTypes(&metav1.ObjectMeta{}), cmpopts.IgnoreTypes(&metav1.TypeMeta{})) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func genericObjectMerge(orig, desired runtime.Object) (runtime.Object, error) {
+	// Acquire accessors for ObjectMeta fields of CR.
+	desiredMeta, err := meta.Accessor(desired)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	readMeta, err := meta.Accessor(orig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	labels := readMeta.GetLabels()
+	for k, v := range desiredMeta.GetLabels() {
+		labels[k] = v
+	}
+	// Set merged labels on desired object as that's the one we write
+	// in update.
+	desiredMeta.SetLabels(labels)
+
+	annotations := readMeta.GetAnnotations()
+	for k, v := range desiredMeta.GetAnnotations() {
+		annotations[k] = v
+	}
+	// Set merged labels on desired object as that's the one we write
+	// in update.
+	desiredMeta.SetAnnotations(annotations)
+
+	return desired, nil
 }
 
 func toInt32P(v int32) *int32 {

--- a/service/controller/resource/capzcrs/testdata/azurecluster_with_subnets.yaml
+++ b/service/controller/resource/capzcrs/testdata/azurecluster_with_subnets.yaml
@@ -1,0 +1,54 @@
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
+kind: AzureCluster
+metadata:
+  annotations:
+    cluster.giantswarm.io/description: ""
+  creationTimestamp: null
+  labels:
+    azure-operator.giantswarm.io/version: 4.2.0
+    cluster.x-k8s.io/cluster-name: c6fme
+    giantswarm.io/cluster: c6fme
+    giantswarm.io/organization: ""
+    release.giantswarm.io/version: 12.0.0
+  name: c6fme
+  namespace: default
+  resourceVersion: "1"
+spec:
+  controlPlaneEndpoint:
+    host: api.c6fme.k8s.ghost.westeurope.azure.gigantic.io
+    port: 443
+  location: westeurope
+  networkSpec:
+    subnets:
+    - role: node
+      id: nodepool-np201
+      name: nodepool-np201
+      cidrblock: 10.100.2.0/24
+      internallbipaddress: ""
+      securitygroup:
+        id: ""
+        name: ""
+        ingressrules: []
+        tags: {}
+        routetable:
+          id: ""
+          name: ""
+    vnet:
+      cidrBlock: 10.10.0.0/16
+      name: c6fme-VirtualNetwork
+      resourceGroup: c6fme
+  resourceGroup: ""
+status:
+  bastion:
+    image: {}
+    osDisk:
+      diskSizeGB: 0
+      managedDisk:
+        storageAccountType: ""
+      osType: ""
+  network:
+    apiServerIp: {}
+    apiServerLb:
+      backendPool: {}
+      frontendIpConfig: {}
+  ready: false

--- a/service/controller/resource/capzcrs/testdata/case-3-Ensure-that-AzureCluster-Subnets-are-not-wiped_AzureCluster.golden
+++ b/service/controller/resource/capzcrs/testdata/case-3-Ensure-that-AzureCluster-Subnets-are-not-wiped_AzureCluster.golden
@@ -1,0 +1,80 @@
+typemeta:
+  kind: AzureCluster
+  apiversion: infrastructure.cluster.x-k8s.io/v1alpha3
+objectmeta:
+  name: ""
+  generatename: ""
+  namespace: ""
+  selflink: ""
+  uid: ""
+  resourceversion: "2"
+  generation: 0
+  creationtimestamp: "0001-01-01T00:00:00Z"
+  deletiontimestamp: null
+  deletiongraceperiodseconds: null
+  labels:
+    azure-operator.giantswarm.io/version: ""
+    cluster.x-k8s.io/cluster-name: ""
+    giantswarm.io/cluster: ""
+    giantswarm.io/organization: ""
+    release.giantswarm.io/version: ""
+  annotations:
+    cluster.giantswarm.io/description: ""
+  ownerreferences: []
+  finalizers: []
+  clustername: ""
+  managedfields: []
+spec:
+  networkspec:
+    vnet:
+      resourcegroup: ""
+      id: ""
+      name: -VirtualNetwork
+      cidrblock: ""
+      tags: {}
+    subnets: []
+  resourcegroup: ""
+  subscriptionid: ""
+  location: westeurope
+  controlplaneendpoint:
+    host: api.c6fme.k8s.ghost.westeurope.azure.gigantic.io
+    port: 443
+  additionaltags: {}
+status:
+  network:
+    securitygroups: {}
+    apiserverlb:
+      id: ""
+      name: ""
+      sku: ""
+      frontendipconfig: {}
+      backendpool:
+        name: ""
+        id: ""
+      tags: {}
+    apiserverip:
+      id: ""
+      name: ""
+      ipaddress: ""
+      dnsname: ""
+  failuredomains: {}
+  bastion:
+    id: ""
+    name: ""
+    availabilityzone: ""
+    vmsize: ""
+    image:
+      id: null
+      sharedgallery: null
+      marketplace: null
+    osdisk:
+      ostype: ""
+      disksizegb: 0
+      manageddisk:
+        storageaccounttype: ""
+    startupscript: ""
+    state: ""
+    identity: ""
+    tags: {}
+    addresses: []
+  ready: false

--- a/service/controller/resource/capzcrs/testdata/case-3-Ensure-that-AzureCluster-Subnets-are-not-wiped_AzureMachine.golden
+++ b/service/controller/resource/capzcrs/testdata/case-3-Ensure-that-AzureCluster-Subnets-are-not-wiped_AzureMachine.golden
@@ -1,0 +1,59 @@
+typemeta:
+  kind: AzureMachine
+  apiversion: infrastructure.cluster.x-k8s.io/v1alpha3
+objectmeta:
+  name: -master-0
+  generatename: ""
+  namespace: ""
+  selflink: ""
+  uid: ""
+  resourceversion: "1"
+  generation: 0
+  creationtimestamp: "0001-01-01T00:00:00Z"
+  deletiontimestamp: null
+  deletiongraceperiodseconds: null
+  labels:
+    azure-operator.giantswarm.io/version: ""
+    cluster.x-k8s.io/cluster-name: ""
+    cluster.x-k8s.io/control-plane: "true"
+    giantswarm.io/cluster: ""
+    giantswarm.io/organization: ""
+    release.giantswarm.io/version: ""
+  annotations: {}
+  ownerreferences: []
+  finalizers: []
+  clustername: ""
+  managedfields: []
+spec:
+  providerid: null
+  vmsize: ""
+  failuredomain: null
+  availabilityzone:
+    id: null
+    enabled: null
+  image:
+    id: null
+    sharedgallery: null
+    marketplace:
+      publisher: kinvolk
+      offer: flatcar-container-linux-free
+      sku: stable
+      version: 2345.3.1
+  identity: ""
+  userassignedidentities: []
+  osdisk:
+    ostype: Linux
+    disksizegb: 50
+    manageddisk:
+      storageaccounttype: Premium_LRS
+  location: westeurope
+  sshpublickey: ""
+  additionaltags: {}
+  allocatepublicip: false
+  acceleratednetworking: null
+status:
+  ready: false
+  addresses: []
+  vmstate: null
+  failurereason: null
+  failuremessage: null

--- a/service/controller/resource/capzcrs/testdata/case-3-Ensure-that-AzureCluster-Subnets-are-not-wiped_Cluster.golden
+++ b/service/controller/resource/capzcrs/testdata/case-3-Ensure-that-AzureCluster-Subnets-are-not-wiped_Cluster.golden
@@ -1,0 +1,57 @@
+typemeta:
+  kind: Cluster
+  apiversion: cluster.x-k8s.io/v1alpha3
+objectmeta:
+  name: ""
+  generatename: ""
+  namespace: ""
+  selflink: ""
+  uid: ""
+  resourceversion: "2"
+  generation: 0
+  creationtimestamp: "0001-01-01T00:00:00Z"
+  deletiontimestamp: null
+  deletiongraceperiodseconds: null
+  labels:
+    azure-operator.giantswarm.io/version: ""
+    cluster-operator.giantswarm.io/version: ""
+    cluster.x-k8s.io/cluster-name: ""
+    giantswarm.io/cluster: ""
+    giantswarm.io/organization: ""
+    release.giantswarm.io/version: ""
+  annotations: {}
+  ownerreferences: []
+  finalizers: []
+  clustername: ""
+  managedfields: []
+spec:
+  paused: false
+  clusternetwork:
+    apiserverport: 0
+    services:
+      cidrblocks:
+      - ""
+    pods: null
+    servicedomain: c6fme.k8s.ghost.westeurope.azure.gigantic.io
+  controlplaneendpoint:
+    host: api.c6fme.k8s.ghost.westeurope.azure.gigantic.io
+    port: 443
+  controlplaneref: null
+  infrastructureref:
+    kind: AzureCluster
+    namespace: ""
+    name: ""
+    uid: ""
+    apiversion: ""
+    resourceversion: ""
+    fieldpath: ""
+status:
+  failuredomains: {}
+  failurereason: null
+  failuremessage: null
+  phase: ""
+  infrastructureready: false
+  controlplaneinitialized: false
+  controlplaneready: false
+  conditions: []
+  observedgeneration: 0


### PR DESCRIPTION
Generic implementation doesn't preserve original CR spec fields. This is needed
to maintain dynamically managed subnets in AzureCluster.