### PR TITLE
Fix multiaz e2e tests for nodepools

### DIFF
--- a/e2e/test/multiaz/provider.go
+++ b/e2e/test/multiaz/provider.go
@@ -55,7 +55,7 @@ func NewProvider(config ProviderConfig) (*Provider, error) {
 }
 
 func (p *Provider) GetClusterAZs(ctx context.Context) ([]string, error) {
-	vmss, err := p.azureClient.VirtualMachineScaleSetsClient.Get(ctx, p.clusterID, fmt.Sprintf("%s-worker-%s", p.clusterID, p.clusterID))
+	vmss, err := p.azureClient.VirtualMachineScaleSetsClient.Get(ctx, p.clusterID, fmt.Sprintf("nodepool-%s", p.clusterID))
 	if err != nil {
 		return []string{}, microerror.Mask(err)
 	}


### PR DESCRIPTION
```
=== RUN   Test_AZ
{"caller":"github.com/giantswarm/azure-operator/v4/e2e/test/multiaz/multiaz_test.go:48","level":"debug","message":"getting current availability zones","time":"2020-08-26T10:52:49.501237+00:00"}
    Test_AZ: multiaz_test.go:17: {"kind":"unknown","annotation":"compute.VirtualMachineScaleSetsClient#Get: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code=\"ResourceNotFound\" Message=\"The Resource 'Microsoft.Compute/virtualMachineScaleSets/ci-wip-aa48c-19066-worker-ci-wip-aa48c-19066' under resource group 'ci-wip-aa48c-19066' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix\"","stack":[{"file":"/home/circleci/.go_workspace/src/github.com/giantswarm/azure-operator/e2e/test/multiaz/provider.go","line":60},{"file":"/home/circleci/.go_workspace/src/github.com/giantswarm/azure-operator/e2e/test/multiaz/multiaz_test.go","line":51}]}
--- FAIL: Test_AZ (0.28s)
```