### PR TITLE
azure v5: use CAPI cluster name label instead of GS one

### DIFF
--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -9,7 +9,6 @@ const (
 	Organization  = "giantswarm.io/organization"
 	Provider      = "giantswarm.io/provider"
 	VersionBundle = "giantswarm.io/version-bundle"
-	XCluster      = "cluster.x-k8s.io/cluster-name"
 )
 
 const (

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -204,7 +204,7 @@ func ClusterIPRange(customObject providerv1alpha1.AzureConfig) string {
 }
 
 func ClusterName(getter LabelsGetter) string {
-	return getter.GetLabels()[label.XCluster]
+	return getter.GetLabels()[capiv1alpha3.ClusterLabelName]
 }
 
 // ClusterNamespace returns the cluster Namespace for this cluster.

--- a/service/controller/resource/azureconfig/create.go
+++ b/service/controller/resource/azureconfig/create.go
@@ -64,7 +64,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				ctx,
 				azureMachineList,
 				client.InNamespace(cluster.Namespace),
-				client.MatchingLabels{label.Cluster: key.ClusterID(&cluster)},
+				client.MatchingLabels{capiv1alpha3.ClusterLabelName: key.ClusterName(&cluster)},
 			)
 			if err != nil {
 				return microerror.Mask(err)
@@ -80,7 +80,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 
 		if len(masterMachines) < 1 {
-			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no control plane AzureMachines found for cluster %q", key.ClusterID(&cluster)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("no control plane AzureMachines found for cluster %q", key.ClusterName(&cluster)))
 			r.logger.LogCtx(ctx, "level", "debug", "message", "cancelling reconciliation")
 			reconciliationcanceledcontext.SetCanceled(ctx)
 			return nil
@@ -104,7 +104,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	var presentAzureConfig providerv1alpha1.AzureConfig
 	{
 		nsName := types.NamespacedName{
-			Name:      key.ClusterID(&cluster),
+			Name:      key.ClusterName(&cluster),
 			Namespace: azureCluster.Namespace,
 		}
 		err = r.ctrlClient.Get(ctx, nsName, &presentAzureConfig)
@@ -213,7 +213,7 @@ func (r *Resource) buildAzureConfig(ctx context.Context, cluster capiv1alpha3.Cl
 	azureConfig.Labels = make(map[string]string)
 
 	{
-		azureConfig.ObjectMeta.Name = key.ClusterID(&cluster)
+		azureConfig.ObjectMeta.Name = key.ClusterName(&cluster)
 		azureConfig.ObjectMeta.Namespace = cluster.Namespace
 	}
 
@@ -229,8 +229,8 @@ func (r *Resource) buildAzureConfig(ctx context.Context, cluster capiv1alpha3.Cl
 	}
 
 	{
-		azureConfig.Labels[label.Cluster] = key.ClusterID(&cluster)
-		azureConfig.Labels[label.XCluster] = key.ClusterID(&cluster)
+		azureConfig.Labels[label.Cluster] = key.ClusterName(&cluster)
+		azureConfig.Labels[capiv1alpha3.ClusterLabelName] = key.ClusterName(&cluster)
 		azureConfig.Labels[label.Organization] = key.OrganizationID(&cluster)
 		azureConfig.Labels[label.ReleaseVersion] = key.ReleaseVersion(&cluster)
 		azureConfig.Labels[label.OperatorVersion] = key.OperatorVersion(&azureCluster)
@@ -319,7 +319,7 @@ func (r *Resource) newCluster(cluster capiv1alpha3.Cluster, azureCluster capzv1a
 	}
 
 	{
-		commonCluster.ID = key.ClusterID(&cluster)
+		commonCluster.ID = key.ClusterName(&cluster)
 	}
 
 	{

--- a/service/controller/resource/clusterdependents/resource.go
+++ b/service/controller/resource/clusterdependents/resource.go
@@ -113,7 +113,7 @@ func (r *Resource) ensureInfrastructureCRDeleted(ctx context.Context, cr capiv1a
 
 func (r *Resource) ensureMachinePoolCRsDeleted(ctx context.Context, cr capiv1alpha3.Cluster) (bool, error) {
 	o := client.MatchingLabels{
-		capiv1alpha3.ClusterLabelName: key.ClusterID(&cr),
+		capiv1alpha3.ClusterLabelName: key.ClusterName(&cr),
 	}
 	mpList := new(expcapiv1alpha3.MachinePoolList)
 	err := r.ctrlClient.List(ctx, mpList, o)

--- a/service/controller/resource/clusterownerreference/resource.go
+++ b/service/controller/resource/clusterownerreference/resource.go
@@ -119,7 +119,7 @@ func (r *Resource) ensureMachinePools(ctx context.Context, cluster capiv1alpha3.
 	var err error
 
 	o := client.MatchingLabels{
-		capiv1alpha3.ClusterLabelName: key.ClusterID(&cluster),
+		capiv1alpha3.ClusterLabelName: key.ClusterName(&cluster),
 	}
 	mpList := new(expcapiv1alpha3.MachinePoolList)
 	err = r.ctrlClient.List(ctx, mpList, o)

--- a/service/controller/resource/clusterownerreference/resource_test.go
+++ b/service/controller/resource/clusterownerreference/resource_test.go
@@ -40,7 +40,8 @@ func TestThatAzureClusterIsLabeledWithClusterId(t *testing.T) {
 			Namespace: clusterNamespace,
 			Name:      clusterName,
 			Labels: map[string]string{
-				label.Cluster: clusterName,
+				label.Cluster:                 clusterName,
+				capiv1alpha3.ClusterLabelName: clusterName,
 			},
 		},
 		Spec: capiv1alpha3.ClusterSpec{
@@ -104,7 +105,8 @@ func TestThatAzureClusterIsOwnedByCluster(t *testing.T) {
 			Namespace: clusterNamespace,
 			Name:      clusterName,
 			Labels: map[string]string{
-				label.Cluster: clusterName,
+				label.Cluster:                 clusterName,
+				capiv1alpha3.ClusterLabelName: clusterName,
 			},
 		},
 		Spec: capiv1alpha3.ClusterSpec{
@@ -140,7 +142,8 @@ func TestThatMachinePoolIsOwnedByCluster(t *testing.T) {
 			Namespace: clusterNamespace,
 			Name:      clusterName,
 			Labels: map[string]string{
-				label.Cluster: clusterName,
+				label.Cluster:                 clusterName,
+				capiv1alpha3.ClusterLabelName: clusterName,
 			},
 		},
 		Spec: capiv1alpha3.ClusterSpec{

--- a/service/controller/resource/spark/create.go
+++ b/service/controller/resource/spark/create.go
@@ -218,7 +218,7 @@ func (r *Resource) createIgnitionBlob(ctx context.Context, azureMachinePool *exp
 		m := sync.Mutex{}
 
 		g.Go(func() error {
-			tls, err := r.certsSearcher.SearchTLS(key.ClusterID(cluster), certs.APICert)
+			tls, err := r.certsSearcher.SearchTLS(key.ClusterName(cluster), certs.APICert)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -230,7 +230,7 @@ func (r *Resource) createIgnitionBlob(ctx context.Context, azureMachinePool *exp
 		})
 
 		g.Go(func() error {
-			tls, err := r.certsSearcher.SearchTLS(key.ClusterID(cluster), certs.CalicoEtcdClientCert)
+			tls, err := r.certsSearcher.SearchTLS(key.ClusterName(cluster), certs.CalicoEtcdClientCert)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -243,7 +243,7 @@ func (r *Resource) createIgnitionBlob(ctx context.Context, azureMachinePool *exp
 		})
 
 		g.Go(func() error {
-			tls, err := r.certsSearcher.SearchTLS(key.ClusterID(cluster), certs.EtcdCert)
+			tls, err := r.certsSearcher.SearchTLS(key.ClusterName(cluster), certs.EtcdCert)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -255,7 +255,7 @@ func (r *Resource) createIgnitionBlob(ctx context.Context, azureMachinePool *exp
 		})
 
 		g.Go(func() error {
-			tls, err := r.certsSearcher.SearchTLS(key.ClusterID(cluster), certs.ServiceAccountCert)
+			tls, err := r.certsSearcher.SearchTLS(key.ClusterName(cluster), certs.ServiceAccountCert)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -267,7 +267,7 @@ func (r *Resource) createIgnitionBlob(ctx context.Context, azureMachinePool *exp
 		})
 
 		g.Go(func() error {
-			tls, err := r.certsSearcher.SearchTLS(key.ClusterID(cluster), certs.WorkerCert)
+			tls, err := r.certsSearcher.SearchTLS(key.ClusterName(cluster), certs.WorkerCert)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -442,7 +442,7 @@ func (r *Resource) buildAzureConfig(cluster *capiv1alpha3.Cluster, azureCluster 
 	azureConfig.Labels = make(map[string]string)
 
 	{
-		azureConfig.ObjectMeta.Name = key.ClusterID(cluster)
+		azureConfig.ObjectMeta.Name = key.ClusterName(cluster)
 		azureConfig.ObjectMeta.Namespace = cluster.Namespace
 	}
 
@@ -458,8 +458,8 @@ func (r *Resource) buildAzureConfig(cluster *capiv1alpha3.Cluster, azureCluster 
 	}
 
 	{
-		azureConfig.Labels[label.Cluster] = key.ClusterID(cluster)
-		azureConfig.Labels[label.XCluster] = key.ClusterID(cluster)
+		azureConfig.Labels[label.Cluster] = key.ClusterName(cluster)
+		azureConfig.Labels[capiv1alpha3.ClusterLabelName] = key.ClusterName(cluster)
 		azureConfig.Labels[label.Organization] = key.OrganizationID(cluster)
 		azureConfig.Labels[label.ReleaseVersion] = key.ReleaseVersion(cluster)
 		azureConfig.Labels[label.OperatorVersion] = key.OperatorVersion(azureCluster)
@@ -539,7 +539,7 @@ func (r *Resource) newCluster(cluster *capiv1alpha3.Cluster, azureCluster *capzv
 	}
 
 	{
-		commonCluster.ID = key.ClusterID(cluster)
+		commonCluster.ID = key.ClusterName(cluster)
 	}
 
 	{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12772