### PR TITLE
Pass node pool ID to test so it can assert later

### DIFF
--- a/e2e/test/multiaz/main_test.go
+++ b/e2e/test/multiaz/main_test.go
@@ -32,6 +32,7 @@ func init() {
 			G8sClient:   config.Host.G8sClient(),
 			Logger:      config.Logger,
 			ClusterID:   env.ClusterID(),
+			NodePoolID:  env.NodePoolID(),
 		}
 
 		p, err = NewProvider(c)

--- a/e2e/test/multiaz/provider.go
+++ b/e2e/test/multiaz/provider.go
@@ -17,7 +17,8 @@ type ProviderConfig struct {
 	G8sClient   versioned.Interface
 	Logger      micrologger.Logger
 
-	ClusterID string
+	ClusterID  string
+	NodePoolID string
 }
 
 type Provider struct {
@@ -25,7 +26,8 @@ type Provider struct {
 	g8sClient   versioned.Interface
 	logger      micrologger.Logger
 
-	clusterID string
+	clusterID  string
+	nodePoolID string
 }
 
 func NewProvider(config ProviderConfig) (*Provider, error) {
@@ -43,19 +45,24 @@ func NewProvider(config ProviderConfig) (*Provider, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.ClusterID must not be empty", config)
 	}
 
+	if config.NodePoolID == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.NodePoolID must not be empty", config)
+	}
+
 	p := &Provider{
 		azureClient: config.AzureClient,
 		g8sClient:   config.G8sClient,
 		logger:      config.Logger,
 
-		clusterID: config.ClusterID,
+		clusterID:  config.ClusterID,
+		nodePoolID: config.NodePoolID,
 	}
 
 	return p, nil
 }
 
 func (p *Provider) GetClusterAZs(ctx context.Context) ([]string, error) {
-	vmss, err := p.azureClient.VirtualMachineScaleSetsClient.Get(ctx, p.clusterID, fmt.Sprintf("nodepool-%s", p.clusterID))
+	vmss, err := p.azureClient.VirtualMachineScaleSetsClient.Get(ctx, p.clusterID, fmt.Sprintf("nodepool-%s", p.nodePoolID))
 	if err != nil {
 		return []string{}, microerror.Mask(err)
 	}


### PR DESCRIPTION
`MultiAZ` test needs the node pool id, so that it can assert it has been deployed in the right AZs.