### PR TITLE
Customize e2e test cluster ID

### DIFF
--- a/e2e/entityid/generator.go
+++ b/e2e/entityid/generator.go
@@ -1,0 +1,48 @@
+package entityid
+
+import (
+	"math/rand"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+const (
+	// idChars represents the character set used to generate cluster IDs.
+	// (does not contain 1 and l, to avoid confusion)
+	idChars = "023456789abcdefghijkmnopqrstuvwxyz"
+
+	// idLength represents the number of characters used to create a cluster ID.
+	idLength = 5
+)
+
+var (
+	// Use local instance of RNG. Can be overwritten with fixed seed in tests
+	// if needed.
+	localRng = rand.New(rand.NewSource(time.Now().UnixNano()))
+)
+
+func New() string {
+	pattern := regexp.MustCompile("^[a-z]+$")
+	for {
+		letterRunes := []rune(idChars)
+		b := make([]rune, idLength)
+		for i := range b {
+			b[i] = letterRunes[localRng.Intn(len(letterRunes))]
+		}
+
+		id := string(b)
+
+		if _, err := strconv.Atoi(id); err == nil {
+			// string is numbers only, which we want to avoid
+			continue
+		}
+
+		if pattern.MatchString(id) {
+			// strings is letters only, which we also avoid
+			continue
+		}
+
+		return id
+	}
+}

--- a/e2e/entityid/generator.go
+++ b/e2e/entityid/generator.go
@@ -22,7 +22,7 @@ var (
 	localRng = rand.New(rand.NewSource(time.Now().UnixNano()))
 )
 
-func New() string {
+func Generate() string {
 	pattern := regexp.MustCompile("^[a-z]+$")
 	for {
 		letterRunes := []rune(idChars)

--- a/e2e/env/common.go
+++ b/e2e/env/common.go
@@ -91,7 +91,10 @@ func init() {
 	}
 
 	if randomizeClusterID && (len(clusterIDPrefix)+len(testedVersion) > MaxClusterIDPrefixAndTestedVersionLength) {
-		panic(fmt.Sprintf("Max length for cluster ID prefix (%s) + tested version (%s) version, when combined, is %d due to Azure resource name limitations (e.g. storage account name)", clusterIDPrefix, testedVersion, MaxClusterIDPrefixAndTestedVersionLength))
+		panic(fmt.Sprintf(
+			"Max length for cluster ID prefix (%s) + tested version (%s) version, when combined, "+
+				"is %d due to Azure resource name limitations (e.g. storage account name). Try passing a shorter prefix in '%s'.",
+			clusterIDPrefix, testedVersion, MaxClusterIDPrefixAndTestedVersionLength, EnvVarClusterIDPrefix))
 	}
 
 	testDir = os.Getenv(EnvVarTestDir)

--- a/e2e/env/common.go
+++ b/e2e/env/common.go
@@ -64,11 +64,6 @@ func init() {
 		randomizeClusterID = randomizeClusterIDEnvVar
 	}
 
-	if randomizeClusterID {
-		randomPrefixPart := entityid.Generate()
-		clusterIDPrefix = fmt.Sprintf("%s-%s", clusterIDPrefix, randomPrefixPart)
-	}
-
 	circleSHA = os.Getenv(EnvVarCircleSHA)
 	if circleSHA == "" {
 		panic(fmt.Sprintf("env var '%s' must not be empty", EnvVarCircleSHA))
@@ -88,6 +83,11 @@ func init() {
 		// Default cluster ID prefix is always the same for CI
 		clusterIDPrefix = DefaultClusterIDPrefix
 		fmt.Printf("No value found in '%s': using default value %s\n", EnvVarClusterIDPrefix, DefaultClusterIDPrefix)
+	}
+
+	if randomizeClusterID {
+		randomPrefixPart := entityid.New()
+		clusterIDPrefix = fmt.Sprintf("%s-%s", clusterIDPrefix, randomPrefixPart)
 	}
 
 	if randomizeClusterID && (len(clusterIDPrefix)+len(testedVersion) > MaxClusterIDPrefixAndTestedVersionLength) {

--- a/e2e/env/common.go
+++ b/e2e/env/common.go
@@ -104,7 +104,7 @@ func init() {
 		panic(err)
 	}
 
-	clusterID := os.Getenv("CLUSTER_NAME")
+	clusterID = os.Getenv("CLUSTER_NAME")
 	if clusterID == "" {
 		var parts []string
 
@@ -136,7 +136,7 @@ func init() {
 		}
 
 		clusterID = strings.Join(parts, "-")
-		os.Setenv("CLUSTER_NAME", clusterID)
+		err = os.Setenv("CLUSTER_NAME", clusterID)
 		if err != nil {
 			panic(err)
 		}

--- a/e2e/env/common.go
+++ b/e2e/env/common.go
@@ -18,6 +18,9 @@ const (
 	DefaultRandomizeClusterID = false
 	DefaultTestedVersion      = "wip"
 
+	// MaxClusterIDPrefixLength is set to 15 due to limitations for some Azure resource names (like storage account)
+	MaxClusterIDPrefixAndTestedVersionLength = 15
+
 	EnvVarCircleSHA               = "CIRCLE_SHA1" // #nosec
 	EnvVarClusterIDPrefix         = "CLUSTER_ID_PREFIX"
 	EnvVarKeepResources           = "KEEP_RESOURCES"
@@ -61,13 +64,6 @@ func init() {
 		randomizeClusterID = randomizeClusterIDEnvVar
 	}
 
-	clusterIDPrefix = os.Getenv(EnvVarClusterIDPrefix)
-	if clusterIDPrefix == "" {
-		// Default cluster ID prefix is always the same for CI
-		clusterIDPrefix = DefaultClusterIDPrefix
-		fmt.Printf("No value found in '%s': using default value %s\n", EnvVarClusterIDPrefix, DefaultClusterIDPrefix)
-	}
-
 	if randomizeClusterID {
 		randomPrefixPart := entityid.Generate()
 		clusterIDPrefix = fmt.Sprintf("%s-%s", clusterIDPrefix, randomPrefixPart)
@@ -85,6 +81,17 @@ func init() {
 	if testedVersion == "" {
 		testedVersion = DefaultTestedVersion
 		fmt.Printf("No value found in '%s': using default value %s\n", EnvVarTestedVersion, DefaultTestedVersion)
+	}
+
+	clusterIDPrefix = os.Getenv(EnvVarClusterIDPrefix)
+	if clusterIDPrefix == "" {
+		// Default cluster ID prefix is always the same for CI
+		clusterIDPrefix = DefaultClusterIDPrefix
+		fmt.Printf("No value found in '%s': using default value %s\n", EnvVarClusterIDPrefix, DefaultClusterIDPrefix)
+	}
+
+	if randomizeClusterID && (len(clusterIDPrefix)+len(testedVersion) > MaxClusterIDPrefixAndTestedVersionLength) {
+		panic(fmt.Sprintf("Max length for cluster ID prefix (%s) + tested version (%s) version, when combined, is %d due to Azure resource name limitations (e.g. storage account name)", clusterIDPrefix, testedVersion, MaxClusterIDPrefixAndTestedVersionLength))
 	}
 
 	testDir = os.Getenv(EnvVarTestDir)
@@ -134,9 +141,12 @@ func ClusterID() string {
 
 	parts = append(parts, clusterIDPrefix)
 	parts = append(parts, TestedVersion()[0:3])
-	parts = append(parts, CircleSHA()[0:5])
-	if TestHash() != "" {
-		parts = append(parts, TestHash())
+
+	if !RandomizeClusterID() {
+		parts = append(parts, CircleSHA()[0:5])
+		if TestHash() != "" {
+			parts = append(parts, TestHash())
+		}
 	}
 
 	return strings.Join(parts, "-")
@@ -160,6 +170,10 @@ func NodePoolID() string {
 	}
 
 	return nodepoolID
+}
+
+func RandomizeClusterID() bool {
+	return randomizeClusterID
 }
 
 func TestedVersion() string {


### PR DESCRIPTION
New env vars:

- `CLUSTER_ID_PREFIX`: by default it's `ci` (current naming scheme)
- `RANDOMIZE_CLUSTER_ID`: by default it's `false`
  - `false`: cluster ID = `cluster ID prefix` + `Tested version` (by default `wip`) + `commit SHA` + `Test name hash`
  - `true`: cluster ID = `cluster ID prefix` + `random 5 chars` + `Tested version` (by default `wip`)