### PR TITLE
Cancel nodepool handler if Subnet is not ready yet

### DIFF
--- a/service/controller/resource/nodepool/create_deployment_uninitialized.go
+++ b/service/controller/resource/nodepool/create_deployment_uninitialized.go
@@ -73,6 +73,10 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 	if IsNotFound(err) {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "Azure resource not found, canceling resource")
 		return currentState, nil
+	} else if IsSubnetNotReadyError(err) {
+		r.Logger.LogCtx(ctx, "level", "debug", "message", "subnet is not Ready, it's probably still being created")
+		r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+		return currentState, nil
 	} else if err != nil {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 		return currentState, microerror.Mask(err)

--- a/service/controller/resource/nodepool/deployment.go
+++ b/service/controller/resource/nodepool/deployment.go
@@ -104,6 +104,10 @@ func (r Resource) newDeployment(ctx context.Context, storageAccountsClient *stor
 func (r Resource) getSubnetName(azureMachinePool *capzexpv1alpha3.AzureMachinePool, azureCluster *capzv1alpha3.AzureCluster) (string, string, error) {
 	for _, subnet := range azureCluster.Spec.NetworkSpec.Subnets {
 		if azureMachinePool.Name == subnet.Name {
+			if subnet.ID == "" {
+				return azureCluster.Spec.NetworkSpec.Vnet.Name, subnet.Name, microerror.Maskf(subnetNotReadyError, fmt.Sprintf("Subnet %#q ID field is empty, which means the Subnet is not Ready", subnet.Name))
+			}
+
 			return azureCluster.Spec.NetworkSpec.Vnet.Name, subnet.Name, nil
 		}
 	}

--- a/service/controller/resource/nodepool/deployment.go
+++ b/service/controller/resource/nodepool/deployment.go
@@ -105,7 +105,7 @@ func (r Resource) getSubnetName(azureMachinePool *capzexpv1alpha3.AzureMachinePo
 	for _, subnet := range azureCluster.Spec.NetworkSpec.Subnets {
 		if azureMachinePool.Name == subnet.Name {
 			if subnet.ID == "" {
-				return azureCluster.Spec.NetworkSpec.Vnet.Name, subnet.Name, microerror.Maskf(subnetNotReadyError, fmt.Sprintf("Subnet %#q ID field is empty, which means the Subnet is not Ready", subnet.Name))
+				return "", "", microerror.Maskf(subnetNotReadyError, fmt.Sprintf("Subnet %#q ID field is empty, which means the Subnet is not Ready", subnet.Name))
 			}
 
 			return azureCluster.Spec.NetworkSpec.Vnet.Name, subnet.Name, nil

--- a/service/controller/resource/nodepool/error.go
+++ b/service/controller/resource/nodepool/error.go
@@ -144,3 +144,12 @@ var ownerReferenceNotSet = &microerror.Error{
 func IsOwnerReferenceNotSet(err error) bool {
 	return microerror.Cause(err) == ownerReferenceNotSet
 }
+
+var subnetNotReadyError = &microerror.Error{
+	Kind: "subnetNotReadyError",
+}
+
+// IsSubnetNotReadyError asserts subnetNotReadyError.
+func IsSubnetNotReadyError(err error) bool {
+	return microerror.Cause(err) == subnetNotReadyError
+}

--- a/service/controller/resource/subnet/resource.go
+++ b/service/controller/resource/subnet/resource.go
@@ -152,8 +152,8 @@ func (r *Resource) ensureSubnets(ctx context.Context, deploymentsClient *azurere
 		return microerror.Mask(natGatewayNotReadyError)
 	}
 
-	for _, allocatedSubnet := range azureCluster.Spec.NetworkSpec.Subnets {
-		deploymentName := getSubnetARMDeploymentName(allocatedSubnet.Name)
+	for i := 0; i < len(azureCluster.Spec.NetworkSpec.Subnets); i++ {
+		deploymentName := getSubnetARMDeploymentName(azureCluster.Spec.NetworkSpec.Subnets[i].Name)
 		currentDeployment, err := deploymentsClient.Get(ctx, key.ClusterID(&azureCluster), deploymentName)
 		if IsNotFound(err) {
 			// fallthrough
@@ -161,7 +161,7 @@ func (r *Resource) ensureSubnets(ctx context.Context, deploymentsClient *azurere
 			return microerror.Mask(err)
 		}
 
-		parameters, err := r.getDeploymentParameters(ctx, key.ClusterID(&azureCluster), strconv.FormatInt(azureCluster.ObjectMeta.Generation, 10), azureCluster.Spec.NetworkSpec.Vnet.Name, *natGw.ID, allocatedSubnet)
+		parameters, err := r.getDeploymentParameters(ctx, key.ClusterID(&azureCluster), strconv.FormatInt(azureCluster.ObjectMeta.Generation, 10), azureCluster.Spec.NetworkSpec.Vnet.Name, *natGw.ID, azureCluster.Spec.NetworkSpec.Subnets[i])
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -216,7 +216,7 @@ func (r *Resource) ensureSubnets(ctx context.Context, deploymentsClient *azurere
 				return microerror.Mask(err)
 			}
 
-			allocatedSubnet.ID = subnetID
+			azureCluster.Spec.NetworkSpec.Subnets[i].ID = subnetID
 
 			storageAccount, err := storageAccountsClient.GetProperties(ctx, key.ClusterID(&azureCluster), key.StorageAccountName(&azureCluster), "")
 			if err != nil {


### PR DESCRIPTION
We sometimes hit an error when creating the nodepool ARM deployment because the subnet chosen for the VMSS is still being created. It eventually succeeds but in order to avoid errors as much as possible, I'm canceling the nodepool handler if we don't have the `AzureCluster.Spec.NetworkSpec.subnet.ID` field set for the nodepool subnet. This `subnet.ID` field will be set by the subnet handler when it finds the subnet ARM deployment in a successful state.