### PR TITLE
Delete AzureMachine CRs when deleting master instances

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.0-handle"
+	version            = "5.0.0-delete"
 )
 
 func Description() string {

--- a/service/controller/azure_config.go
+++ b/service/controller/azure_config.go
@@ -467,7 +467,8 @@ func newAzureConfigResources(config AzureConfigConfig, certsSearcher certs.Inter
 	var mastersResource resource.Interface
 	{
 		c := masters.Config{
-			Config: nodesConfig,
+			Config:     nodesConfig,
+			CtrlClient: config.K8sClient.CtrlClient(),
 		}
 
 		mastersResource, err = masters.New(c)

--- a/service/controller/resource/capzcrs/create.go
+++ b/service/controller/resource/capzcrs/create.go
@@ -101,7 +101,7 @@ func (r *Resource) mapAzureConfigToCluster(ctx context.Context, cr providerv1alp
 				label.AzureOperatorVersion:    key.OperatorVersion(&cr),
 				label.ClusterOperatorVersion:  cr.Labels[label.ClusterOperatorVersion],
 				label.Cluster:                 key.ClusterID(&cr),
-				capiv1alpha3.ClusterLabelName: key.ClusterID(&cr),
+				capiv1alpha3.ClusterLabelName: key.ClusterName(&cr),
 				label.Organization:            key.OrganizationID(&cr),
 				label.ReleaseVersion:          key.ReleaseVersion(&cr),
 			},
@@ -138,7 +138,7 @@ func (r *Resource) mapAzureConfigToAzureCluster(ctx context.Context, cr provider
 			Labels: map[string]string{
 				label.AzureOperatorVersion:    key.OperatorVersion(&cr),
 				label.Cluster:                 key.ClusterID(&cr),
-				capiv1alpha3.ClusterLabelName: key.ClusterID(&cr),
+				capiv1alpha3.ClusterLabelName: key.ClusterName(&cr),
 				label.Organization:            key.OrganizationID(&cr),
 				label.ReleaseVersion:          key.ReleaseVersion(&cr),
 			},
@@ -181,7 +181,7 @@ func (r *Resource) mapAzureConfigToAzureMachine(ctx context.Context, cr provider
 			Labels: map[string]string{
 				label.AzureOperatorVersion:                key.OperatorVersion(&cr),
 				label.Cluster:                             key.ClusterID(&cr),
-				capiv1alpha3.ClusterLabelName:             key.ClusterID(&cr),
+				capiv1alpha3.ClusterLabelName:             key.ClusterName(&cr),
 				capiv1alpha3.MachineControlPlaneLabelName: "true",
 				label.Organization:                        key.OrganizationID(&cr),
 				label.ReleaseVersion:                      key.ReleaseVersion(&cr),

--- a/service/controller/resource/masters/delete.go
+++ b/service/controller/resource/masters/delete.go
@@ -2,8 +2,43 @@ package masters
 
 import (
 	"context"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-operator/v4/service/controller/key"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	m, err := meta.Accessor(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Ensure that AzureMachines for the cluster are deleted.
+	{
+		o := client.MatchingLabels{
+			capiv1alpha3.ClusterLabelName: key.ClusterID(m),
+		}
+		mList := new(capzv1alpha3.AzureMachineList)
+		err = r.ctrlClient.List(ctx, mList, o)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, m := range mList.Items {
+			err = r.ctrlClient.Delete(ctx, &m)
+			if errors.IsNotFound(err) {
+				continue
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+	}
+
 	return nil
 }

--- a/service/controller/resource/masters/error.go
+++ b/service/controller/resource/masters/error.go
@@ -54,6 +54,15 @@ func IsDeploymentNotFound(err error) bool {
 	return false
 }
 
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
 func IsNotFound(err error) bool {
 	if err == nil {
 		return false


### PR DESCRIPTION
For now, when master instances are managed with AzureConfig reconciliation,
deletion of AzureMachines is most natural when deleting the instances as well.

This will change once the tenant cluster control plane is also reconciled by
CAPI&CAPZ types.