### PR TITLE
Improve multi-az e2e test

### DIFF
--- a/e2e/env/azure.go
+++ b/e2e/env/azure.go
@@ -165,6 +165,21 @@ func AzureAvailabilityZonesAsStrings() []string {
 	return azs
 }
 
+// AzureAvailabilityZonesCount returns expected number of availability zones for the cluster.
+func AzureAvailabilityZonesCount() int {
+	specifiedZones := AzureAvailabilityZones()
+	specifiedCount := len(specifiedZones)
+
+	switch specifiedCount {
+	case 0:
+		return 1
+	case 1, 2, 3:
+		return specifiedCount
+	default:
+		panic("AvailabilityZones valid numbers are 1, 2, 3.")
+	}
+}
+
 func AzureCalicoSubnetCIDR() string {
 	return azureCalicoSubnetCIDR
 }

--- a/e2e/test/multiaz/multiaz_test.go
+++ b/e2e/test/multiaz/multiaz_test.go
@@ -4,10 +4,13 @@ package multiaz
 
 import (
 	"context"
+	"sort"
 	"testing"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/azure-operator/v4/e2e/env"
 )
 
 func Test_AZ(t *testing.T) {
@@ -51,12 +54,23 @@ func (s *MultiAZ) Test(ctx context.Context) error {
 		return microerror.Mask(err)
 	}
 	s.logger.LogCtx(ctx, "level", "debug", "message", "found availability zones", "azs", zones)
+	expectedZonesCount := env.AzureAvailabilityZonesCount()
 
-	if len(zones) != 2 {
+	if len(zones) != expectedZonesCount {
 		return microerror.Maskf(executionFailedError, "The amount of AZ's used is not correct. Expected %d zones, got %d zones", 2, len(zones))
 	}
-	if zones[0] != "1" {
-		return microerror.Maskf(executionFailedError, "The AZ used is not correct. Expected %s, got %s", "1", zones[0])
+
+	if expectedZonesCount > 1 {
+		expectedZones := env.AzureAvailabilityZonesAsStrings()
+
+		sort.Strings(zones)
+		sort.Strings(expectedZones)
+
+		for i := range zones {
+			if zones[i] != expectedZones[i] {
+				return microerror.Maskf(executionFailedError, "The AZ used is not correct. Expected %s, got %s", expectedZones[i], zones[i])
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When checking tenant cluster availability zones, the test will use input provided by `AZURE_AZS` environment variable to check the number of availability zones and exact availability zones, instead of comparing to values hard-coded in the test.

This way custom test runs can use different multi-az settings.