### PR TITLE
Pass missing ClusterAPIRange in e2e

### DIFF
--- a/e2e/setup/bastion.go
+++ b/e2e/setup/bastion.go
@@ -97,6 +97,7 @@ func CreatePublicIP(ctx context.Context, location, groupName string, ipClient ne
 		network.PublicIPAddress{
 			Name:     to.StringPtr(bastionE2EPublicIpName),
 			Location: to.StringPtr(location),
+			Sku:      &network.PublicIPAddressSku{Name: network.PublicIPAddressSkuNameStandard},
 			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
 				PublicIPAddressVersion:   network.IPv4,
 				PublicIPAllocationMethod: network.Static,

--- a/e2e/setup/provider.go
+++ b/e2e/setup/provider.go
@@ -57,7 +57,7 @@ Installation:
           BaseDomain: ""
       SSH:
         SSOPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDPr6Mxx3cdPNm3v4Ufvo5sRfT7jCgDi7z3wwaCufVrw8am+PBW7toRWBQtGddtp7zsdicHy1+FeWHw09txsbzjupO0yynVAtXSxS8HjsWZOcn0ZRQXMtbbikSxWRs9C255yBswPlD7y9OOiUr8OidIHRYq/vMKIPE+066PqVBYIgO4wR9BRhWPz385+Ob+36K+jkSbniiQr4c8Q545Fm+ilCccLCN1KVVj2pYkCyLHSaEJEp57eyU2ZiBqN0ntgqCVo3xery3HQQalin6Uhqaecwla9bpj48Oo22PLYN2yNhxFU66sSN9TkBquP2VGWlHmWRRg3RPnTY1IPBBC4ea3JOurYOEHydHtoMOGQ6irnd8avqFonXKT2cc/UWUsktv5RwI7S+hUbBdy0o/uX6SbecLIyL+iIIcWL5A0loWyjMEPdDdLjdz72EdnuLVeQohFuSeTpVqpiHugzCCZYwItT7N8QRSgx6wF7j8XkTDZYhWTv9nxtjsRwSDfZJbhsPsgjeQh0z1YJEKZ6RMyrHAzsui/6seFzlgvogRH2iJBzzrKui0uNyE7lQVAeRGHfqUN9YX0DgQ/AvT0BBnCyhMQCD7cJsFJ7A4nRTNsvpPR2uJ2n8fSf2kxXCHH2Tz+CbobVLeZqslKSiz5aO5iKCrHPK7fGnDCKKW8CyYG6V974Q=="
-        UserList: ""
+        UserList: "e2e:%s"
     Name: godsmack
     Provider:
       Azure:
@@ -89,7 +89,7 @@ Installation:
 
 // provider installs the operator and tenant cluster CR.
 func provider(ctx context.Context, config Config, giantSwarmRelease releasev1alpha1.Release) error {
-	renderedAzureOperatorChartValues := fmt.Sprintf(azureOperatorChartValues, env.AzureClientID(), env.AzureTenantID(), env.AzureLocation(), env.AzureClientID(), env.AzureClientSecret(), env.AzureSubscriptionID(), env.AzureTenantID(), env.CircleSHA())
+	renderedAzureOperatorChartValues := fmt.Sprintf(azureOperatorChartValues, env.AzureClientID(), env.AzureTenantID(), env.SSHPublicKey(), env.AzureLocation(), env.AzureClientID(), env.AzureClientSecret(), env.AzureSubscriptionID(), env.AzureTenantID(), env.CircleSHA())
 	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensuring AzureConfig CRD exists")
 

--- a/e2e/setup/provider.go
+++ b/e2e/setup/provider.go
@@ -113,6 +113,17 @@ func provider(ctx context.Context, config Config, giantSwarmRelease releasev1alp
 	}
 
 	{
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensuring AzureMachine CRD exists")
+
+		err := config.K8sClients.CRDClient().EnsureCreated(ctx, crd.LoadV1("infrastructure.cluster.x-k8s.io", "AzureMachine"), backoff.NewMaxRetries(7, 1*time.Second))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensured AzureMachine CRD exists")
+	}
+
+	{
 		config.Logger.LogCtx(ctx, "level", "debug", "message", "ensuring AzureMachinePool CRD exists")
 
 		err := config.K8sClients.CRDClient().EnsureCreated(ctx, crd.LoadV1("exp.infrastructure.cluster.x-k8s.io", "AzureMachinePool"), backoff.NewMaxRetries(7, 1*time.Second))

--- a/e2e/setup/provider.go
+++ b/e2e/setup/provider.go
@@ -50,7 +50,7 @@ Installation:
                 IssuerURL: "https://login.microsoftonline.com/%s/v2.0"
                 UsernameClaim: "email"
                 GroupsClaim: "groups"
-          ClusterIPRange: ""
+          ClusterIPRange: "172.31.0.0/16"
           Domain: ""
         ClusterDomain: ""
         IngressController:


### PR DESCRIPTION
```
panic: {"kind":"invalidConfigError","annotation":"spark.Config.ClusterIPRange must not be empty","stack":[{"file":"/root/project/service/controller/resource/spark/resource.go","line":86},{"file":"/root/project/service/controller/azure_machine_pool.go","line":169},{"file":"/root/project/service/controller/azure_machine_pool.go","line":70},{"file":"/root/project/service/service.go","line":347},{"file":"/root/project/main.go","line":66}]}```