### PR TITLE
Don't use Infrastructure.Namespace since dependent objects will always be on parent's namespace

### DIFF
--- a/service/controller/resource/nodepool/deployment.go
+++ b/service/controller/resource/nodepool/deployment.go
@@ -214,7 +214,7 @@ func (r *Resource) getOwnerMachinePool(ctx context.Context, obj metav1.ObjectMet
 func (r *Resource) getAzureClusterFromCluster(ctx context.Context, cluster *capiv1alpha3.Cluster) (*capzv1alpha3.AzureCluster, error) {
 	azureCluster := &capzv1alpha3.AzureCluster{}
 	azureClusterName := ctrlclient.ObjectKey{
-		Namespace: cluster.Spec.InfrastructureRef.Namespace,
+		Namespace: cluster.Namespace,
 		Name:      cluster.Spec.InfrastructureRef.Name,
 	}
 	err := r.CtrlClient.Get(ctx, azureClusterName, azureCluster)

--- a/service/controller/resource/spark/create.go
+++ b/service/controller/resource/spark/create.go
@@ -373,7 +373,7 @@ func (r *Resource) getAzureCluster(ctx context.Context, cluster *capiv1alpha3.Cl
 	}
 
 	azureCluster := &capzv1alpha3.AzureCluster{}
-	objectKey := client.ObjectKey{Name: cluster.Spec.InfrastructureRef.Name, Namespace: cluster.Spec.InfrastructureRef.Namespace}
+	objectKey := client.ObjectKey{Name: cluster.Spec.InfrastructureRef.Name, Namespace: cluster.Namespace}
 	if err := r.ctrlClient.Get(ctx, objectKey, azureCluster); err != nil {
 		return nil, microerror.Mask(err)
 	}


### PR DESCRIPTION
I believe we shouldn't use the `namespace` field from `Spec.InfrastructureRef`. Kubernetes owner references are not able to cross namespace boundaries, so these objects will always be in the same namespace than the owner.

Also, the `namespace` field may actually go away. [There is this discussion about it](https://github.com/kubernetes-sigs/cluster-api/issues/2318) that proposes changing the type of `Spec.InfrastructureRef` to `corev1.LocalObjectReference` since `corev1.ObjectReference` contains too many fields for what's needed (i.e `namespace`).