### PR TITLE
Skip CR mapping while cluster is being deleted

### DIFF
--- a/service/controller/resource/capzcrs/create.go
+++ b/service/controller/resource/capzcrs/create.go
@@ -39,6 +39,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "level", "debug", "message", "mapping AzureConfig CR to CAPI & CAPZ CRs")
+
 	{
 		objKey := client.ObjectKey{
 			Namespace: cr.Namespace,
@@ -55,8 +57,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return nil
 		}
 	}
-
-	r.logger.LogCtx(ctx, "level", "debug", "message", "mapping AzureConfig CR to CAPI & CAPZ CRs")
 
 	var mappedCRs []crmapping
 	{

--- a/service/controller/resource/capzcrs/create.go
+++ b/service/controller/resource/capzcrs/create.go
@@ -52,7 +52,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			// all good
 		} else if err != nil {
 			return microerror.Mask(err)
-		} else if cluster.GetDeletionTimestamp() != nil {
+		} else if !cluster.GetDeletionTimestamp().IsZero() {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "Cluster is being deleted, skipping mapping AzureConfig CR to CAPI & CAPZ CRs")
 			return nil
 		}


### PR DESCRIPTION
Cluster deletion is slow, and we can have a race condition where CAPI CRs get recreated during cluster deletion.

We should skip the CR mapping during cluster creation.