### PR TITLE
Label different node pools differently

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,16 @@ workflows:
           - hold
 
       - architect/integration-test:
+          name: nodepool-test
+          resource_class: large
+          setup-script: "e2e/config/setup.sh"
+          env-file: "e2e/test/nodepool/.env"
+          test-dir: "e2e/test/nodepool"
+          test-timeout: "90m"
+          requires:
+          - hold
+
+      - architect/integration-test:
           name: cluster-deletion-test
           resource_class: large
           setup-script: "e2e/config/setup.sh"

--- a/e2e/env/azure.go
+++ b/e2e/env/azure.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/giantswarm/azure-operator/v4/e2e/network"
+	"github.com/giantswarm/azure-operator/v4/pkg/project"
 )
 
 const (
@@ -226,6 +227,22 @@ func CommonDomainResourceGroup() string {
 
 func GetLatestOperatorRelease() string {
 	return latestOperatorRelease
+}
+
+func GetOperatorVersion() string {
+	var operatorVersion string
+	{
+		// `operatorVersion` is the link between an operator and a `CustomResource`.
+		// azure-operator with version `operatorVersion` will only reconcile `AzureConfig` labeled with `operatorVersion`.
+		operatorVersion = project.Version()
+		if TestDir() == "e2e/test/update" {
+			// When testing the update process, we want the latest release of the operator to reconcile the `CustomResource` and create a cluster.
+			// We can then update the label in the `CustomResource`, making the operator under test to reconcile it and update the cluster.
+			operatorVersion = GetLatestOperatorRelease()
+		}
+	}
+
+	return operatorVersion
 }
 
 func SSHPublicKey() string {

--- a/e2e/setup/provider.go
+++ b/e2e/setup/provider.go
@@ -531,7 +531,7 @@ func createNodePool(ctx context.Context, logger micrologger.Logger, ctrlClient c
 		}
 	}
 
-	logger.LogCtx(ctx, "level", "debug", "message", "Created new nodepool")
+	logger.LogCtx(ctx, "level", "debug", "message", "created new nodepool")
 
 	return nil
 }

--- a/e2e/setup/provider.go
+++ b/e2e/setup/provider.go
@@ -407,6 +407,8 @@ func provider(ctx context.Context, config Config, giantSwarmRelease releasev1alp
 }
 
 func createNodePool(ctx context.Context, logger micrologger.Logger, ctrlClient client.Client, giantSwarmRelease releasev1alpha1.Release, nodepoolID string, replicas int32, vmSize string) error {
+	logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating new node pool %#q with vmsize %#q and %d replicas", nodepoolID, vmSize, replicas))
+
 	clusterOperatorVersion, err := key.ComponentVersion(giantSwarmRelease, "cluster-operator")
 	if err != nil {
 		return microerror.Mask(err)
@@ -528,6 +530,8 @@ func createNodePool(ctx context.Context, logger micrologger.Logger, ctrlClient c
 			return microerror.Mask(err)
 		}
 	}
+
+	logger.LogCtx(ctx, "level", "debug", "message", "Created new nodepool")
 
 	return nil
 }

--- a/e2e/test/nodepool/.env
+++ b/e2e/test/nodepool/.env
@@ -1,0 +1,3 @@
+TEST_DIR="e2e/test/nodepool"
+AZURE_AZS="1 3"
+LATEST_OPERATOR_RELEASE=$(architect project version)

--- a/e2e/test/nodepool/error.go
+++ b/e2e/test/nodepool/error.go
@@ -1,0 +1,65 @@
+// +build k8srequired
+
+package nodepool
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var unexpectedNumberOfNodesError = &microerror.Error{
+	Kind: "unexpectedNumberOfNodesError",
+}
+
+// IsUnexpectedNumberOfNodesError asserts unexpectedNumberOfNodesError.
+func IsUnexpectedNumberOfNodesError(err error) bool {
+	return microerror.Cause(err) == unexpectedNumberOfNodesError
+}
+
+var missingNodePoolLabelError = &microerror.Error{
+	Kind: "missingNodePoolLabelError",
+}
+
+// IsMissingNodePoolLabelError asserts missingNodePoolLabelError.
+func IsMissingNodePoolLabelError(err error) bool {
+	return microerror.Cause(err) == missingNodePoolLabelError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFoundError asserts notFoundError.
+func IsNotFoundError(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var sameVmSizeError = &microerror.Error{
+	Kind: "sameVmSizeError",
+}
+
+// IsSameVmSizeError asserts sameVmSizeError.
+func IsSameVmSizeError(err error) bool {
+	return microerror.Cause(err) == sameVmSizeError
+}
+
+var waitError = &microerror.Error{
+	Kind: "waitError",
+}
+
+// IsWait asserts waitError.
+func IsWait(err error) bool {
+	return microerror.Cause(err) == waitError
+}

--- a/e2e/test/nodepool/main_test.go
+++ b/e2e/test/nodepool/main_test.go
@@ -45,6 +45,7 @@ func init() {
 			Logger:     config.Logger,
 			NodePoolID: env.NodePoolID(),
 			Provider:   p,
+			Guest:      config.Guest,
 		}
 
 		nodepool, err = New(c)

--- a/e2e/test/nodepool/main_test.go
+++ b/e2e/test/nodepool/main_test.go
@@ -1,0 +1,61 @@
+// +build k8srequired
+
+package nodepool
+
+import (
+	"testing"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/azure-operator/v4/e2e/env"
+	"github.com/giantswarm/azure-operator/v4/e2e/setup"
+)
+
+var (
+	config   setup.Config
+	nodepool *Nodepool
+)
+
+func init() {
+	var err error
+	{
+		config, err = setup.NewConfig()
+		if err != nil {
+			panic(microerror.JSON(err))
+		}
+	}
+
+	var p *Provider
+	{
+		c := ProviderConfig{
+			CtrlClient: config.K8sClients.CtrlClient(),
+			Logger:     config.Logger,
+		}
+
+		p, err = NewProvider(c)
+		if err != nil {
+			panic(microerror.JSON(err))
+		}
+	}
+
+	{
+		c := Config{
+			ClusterID:  env.ClusterID(),
+			CtrlClient: config.K8sClients.CtrlClient(),
+			Logger:     config.Logger,
+			NodePoolID: env.NodePoolID(),
+			Provider:   p,
+		}
+
+		nodepool, err = New(c)
+		if err != nil {
+			panic(microerror.JSON(err))
+		}
+	}
+}
+
+// TestMain allows us to have common setup and teardown steps that are run
+// once for all the tests https://golang.org/pkg/testing/#hdr-Main.
+func TestMain(m *testing.M) {
+	setup.WrapTestMain(m, config)
+}

--- a/e2e/test/nodepool/nodepool_test.go
+++ b/e2e/test/nodepool/nodepool_test.go
@@ -89,7 +89,7 @@ func New(config Config) (*Nodepool, error) {
 	return s, nil
 }
 
-const LabelVmSize = "node.kubernetes.io/instance-type"
+const LabelVmSize = "beta.kubernetes.io/instance-type"
 
 func (s *Nodepool) Test(ctx context.Context) error {
 	clusterID := s.clusterID

--- a/e2e/test/nodepool/nodepool_test.go
+++ b/e2e/test/nodepool/nodepool_test.go
@@ -1,0 +1,384 @@
+// +build k8srequired
+
+package nodepool
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	releasev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/label"
+	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/reference"
+	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-operator/v4/e2e/env"
+	"github.com/giantswarm/azure-operator/v4/e2e/setup"
+	key2 "github.com/giantswarm/azure-operator/v4/service/controller/key"
+)
+
+func Test_Nodepool(t *testing.T) {
+	err := nodepool.Test(context.Background())
+	if err != nil {
+		t.Fatalf("%#v", err)
+	}
+}
+
+type Config struct {
+	ClusterID  string
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+	Provider   *Provider
+	NodePoolID string
+}
+
+type Nodepool struct {
+	clusterID  string
+	ctrlClient client.Client
+	logger     micrologger.Logger
+	provider   *Provider
+	nodePoolID string
+}
+
+func New(config Config) (*Nodepool, error) {
+	if config.ClusterID == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ClusterID must not be empty", config)
+	}
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.NodePoolID == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.NodePoolID must not be empty", config)
+	}
+	if config.Provider == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Provider must not be empty", config)
+	}
+
+	s := &Nodepool{
+		clusterID:  config.ClusterID,
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+		nodePoolID: config.NodePoolID,
+		provider:   config.Provider,
+	}
+
+	return s, nil
+}
+
+const LabelVmSize = "node.kubernetes.io/instance-type"
+
+func (s *Nodepool) Test(ctx context.Context) error {
+	clusterID := s.clusterID
+
+	setupNodePoolID := s.nodePoolID
+	setupNodePoolVmSize := env.AzureVMSize()
+	setupNodePoolReplicas := 2
+
+	newNodepoolID := "t3st"
+	newNodePoolVmSize := "Standard_D3_v2"
+	newNodePoolReplicas := 3
+
+	err := s.CreateNodePool(ctx, newNodepoolID, int32(newNodePoolReplicas), newNodePoolVmSize)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = s.WaitForNodesReady(ctx, newNodePoolReplicas+setupNodePoolReplicas)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = s.assertRightNumberOfNodes(ctx, setupNodePoolID, newNodepoolID, setupNodePoolReplicas, newNodePoolReplicas, setupNodePoolVmSize, newNodePoolVmSize)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = s.provider.AddWorker(ctx, clusterID, newNodepoolID)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = s.WaitForNodesReady(ctx, newNodePoolReplicas+setupNodePoolReplicas+1)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = s.assertRightNumberOfNodes(ctx, setupNodePoolID, newNodepoolID, setupNodePoolReplicas, newNodePoolReplicas+1, setupNodePoolVmSize, newNodePoolVmSize)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = s.provider.ChangeVmSize(ctx, clusterID, newNodepoolID, "Standard_D5_v2")
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = s.assertRightNumberOfNodes(ctx, setupNodePoolID, newNodepoolID, setupNodePoolReplicas, newNodePoolReplicas+1, setupNodePoolVmSize, "Standard_D5_v2")
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+// assertRightNumberOfNodes Asserts that two different node pools contain different number of nodes.
+// Since normally node pools will have different virtual machine sizes, I'm selecting nodes by nodepool label or by vm size label, and making sure there are the right number.
+func (s *Nodepool) assertRightNumberOfNodes(ctx context.Context, setupNodePoolID, newNodePoolID string, setupNodePoolReplicas, newNodePoolReplicas int, setupNodePoolVMSize, newNodePoolVMSize string) error {
+	o := func() error {
+		nodes, err := getWorkerNodes(ctx, s.ctrlClient)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		// Check node pool created during setup.
+		err = assertRightNumberOfNodesByNodePool(nodes, setupNodePoolID, setupNodePoolReplicas)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		err = assertRightNumberOfNodesByVmSize(nodes, setupNodePoolVMSize, setupNodePoolReplicas)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		// Check node pool created in test.
+		err = assertRightNumberOfNodesByNodePool(nodes, newNodePoolID, newNodePoolReplicas)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		err = assertRightNumberOfNodesByVmSize(nodes, newNodePoolVMSize, newNodePoolReplicas)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		return nil
+	}
+	b := backoff.NewConstant(backoff.ShortMaxWait, backoff.ShortMaxInterval)
+	err := backoff.Retry(o, b)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func assertRightNumberOfNodesByNodePool(nodes *v1.NodeList, nodepoolID string, expectedNumberOfNodes int) error {
+	existingNodesInNodePool, err := getNumberOfNodesByLabel(nodes, label.MachinePool, nodepoolID)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if existingNodesInNodePool != expectedNumberOfNodes {
+		return microerror.Mask(unexpectedNumberOfNodesError)
+	}
+
+	return nil
+}
+
+func assertRightNumberOfNodesByVmSize(nodes *v1.NodeList, vmSize string, expectedNumberOfNodes int) error {
+	existingNodesInNodePool, err := getNumberOfNodesByLabel(nodes, LabelVmSize, vmSize)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if existingNodesInNodePool != expectedNumberOfNodes {
+		return microerror.Mask(unexpectedNumberOfNodesError)
+	}
+
+	return nil
+}
+
+// getNumberOfNodesByLabel returns how many nodes contain the given label with the passed value.
+func getNumberOfNodesByLabel(nodes *v1.NodeList, labelName, labelValue string) (int, error) {
+	existingNodes := 0
+
+	for _, node := range nodes.Items {
+		existingLabelValue, exists := node.GetLabels()[labelName]
+		if !exists {
+			return 0, microerror.Mask(missingNodePoolLabelError)
+		}
+
+		if existingLabelValue == labelValue {
+			existingNodes++
+		}
+	}
+
+	return existingNodes, nil
+}
+
+func getWorkerNodes(ctx context.Context, ctrlClient client.Client) (*v1.NodeList, error) {
+	nodes := &v1.NodeList{}
+
+	var labelSelector client.MatchingLabels
+	{
+		labelSelector = make(map[string]string)
+		labelSelector["kubernetes.io/role"] = "worker"
+	}
+
+	err := ctrlClient.List(ctx, nodes, labelSelector, client.InNamespace(metav1.NamespaceDefault))
+	if err != nil {
+		return nodes, microerror.Mask(err)
+	}
+
+	return nodes, nil
+}
+
+func (s *Nodepool) CreateNodePool(ctx context.Context, nodepoolID string, replicas int32, vmSize string) error {
+	s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating new node pool %#q with vmsize %#q and %d replicas", nodepoolID, vmSize, replicas))
+
+	var giantSwarmRelease releasev1alpha1.Release
+	{
+		err := s.ctrlClient.Get(ctx, client.ObjectKey{Namespace: metav1.NamespaceDefault, Name: setup.ReleaseName}, &giantSwarmRelease)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var azureMachinePool *expcapzv1alpha3.AzureMachinePool
+	{
+		azureMachinePool = &expcapzv1alpha3.AzureMachinePool{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: expcapzv1alpha3.GroupVersion.String(),
+				Kind:       "AzureMachinePool",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodepoolID,
+				Namespace: metav1.NamespaceDefault,
+				Labels: map[string]string{
+					capiv1alpha3.ClusterLabelName: env.ClusterID(),
+					label.AzureOperatorVersion:    env.GetOperatorVersion(),
+					label.Cluster:                 env.ClusterID(),
+					label.MachinePool:             nodepoolID,
+					label.Organization:            "giantswarm",
+					label.ReleaseVersion:          strings.TrimPrefix(giantSwarmRelease.GetName(), "v"),
+				},
+			},
+			Spec: expcapzv1alpha3.AzureMachinePoolSpec{
+				Location: env.AzureLocation(),
+				Template: expcapzv1alpha3.AzureMachineTemplate{
+					VMSize:       vmSize,
+					SSHPublicKey: base64.StdEncoding.EncodeToString([]byte(env.SSHPublicKey())),
+				},
+			},
+		}
+
+		err := config.K8sClients.CtrlClient().Create(ctx, azureMachinePool)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	{
+		var infrastructureCRRef *v1.ObjectReference
+		{
+			s := runtime.NewScheme()
+			err := expcapzv1alpha3.AddToScheme(s)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			infrastructureCRRef, err = reference.GetReference(s, azureMachinePool)
+			if err != nil {
+				config.Logger.LogCtx(ctx, "level", "warning", fmt.Sprintf("cannot create reference to infrastructure CR: %q", err))
+				return microerror.Mask(err)
+			}
+		}
+
+		clusterOperatorVersion, err := key2.ComponentVersion(giantSwarmRelease, "cluster-operator")
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		machinePool := &expcapiv1alpha3.MachinePool{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: expcapiv1alpha3.GroupVersion.String(),
+				Kind:       "MachinePool",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nodepoolID,
+				Namespace: azureMachinePool.Namespace,
+				Labels: map[string]string{
+					capiv1alpha3.ClusterLabelName: env.ClusterID(),
+					label.AzureOperatorVersion:    env.GetOperatorVersion(),
+					label.Cluster:                 env.ClusterID(),
+					label.ClusterOperatorVersion:  clusterOperatorVersion,
+					label.MachinePool:             nodepoolID,
+					label.Organization:            "giantswarm",
+					label.ReleaseVersion:          strings.TrimPrefix(giantSwarmRelease.GetName(), "v"),
+				},
+			},
+			Spec: expcapiv1alpha3.MachinePoolSpec{
+				ClusterName:    env.ClusterID(),
+				Replicas:       to.Int32Ptr(replicas),
+				FailureDomains: env.AzureAvailabilityZonesAsStrings(),
+				Template: capiv1alpha3.MachineTemplateSpec{
+					Spec: capiv1alpha3.MachineSpec{
+						ClusterName:       env.ClusterID(),
+						InfrastructureRef: *infrastructureCRRef,
+					},
+				},
+			},
+		}
+
+		err = config.K8sClients.CtrlClient().Create(ctx, machinePool)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	s.logger.LogCtx(ctx, "level", "debug", "message", "created new node pool")
+
+	return nil
+}
+
+func (s *Nodepool) WaitForNodesReady(ctx context.Context, expectedNodes int) error {
+	s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for %d k8s nodes to be in %#q state", expectedNodes, v1.NodeReady))
+
+	o := func() error {
+		nodes, err := getWorkerNodes(ctx, s.ctrlClient)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		var nodesReady int
+		for _, n := range nodes.Items {
+			for _, c := range n.Status.Conditions {
+				if c.Type == v1.NodeReady && c.Status == v1.ConditionTrue {
+					nodesReady++
+				}
+			}
+		}
+
+		if nodesReady != expectedNodes {
+			return microerror.Maskf(waitError, "found %d/%d k8s nodes in %#q state but %d are expected", nodesReady, len(nodes.Items), v1.NodeReady, expectedNodes)
+		}
+
+		return nil
+	}
+	b := backoff.NewConstant(backoff.LongMaxWait, backoff.LongMaxInterval)
+	n := backoff.NewNotifier(s.logger, ctx)
+
+	err := backoff.RetryNotify(o, b, n)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for %d k8s nodes to be in %#q state", expectedNodes, v1.NodeReady))
+	return nil
+}

--- a/e2e/test/nodepool/nodepool_test.go
+++ b/e2e/test/nodepool/nodepool_test.go
@@ -234,7 +234,7 @@ func getNumberOfNodesByLabel(nodes *v1.NodeList, labelName, labelValue string) (
 	for _, node := range nodes.Items {
 		existingLabelValue, exists := node.GetLabels()[labelName]
 		if !exists {
-			return 0, microerror.Mask(missingNodePoolLabelError)
+			return 0, microerror.Maskf(missingNodePoolLabelError, fmt.Sprintf("Label %#q is missing from node %#q", labelName, node.Name))
 		}
 
 		if existingLabelValue == labelValue {

--- a/e2e/test/nodepool/nodepool_test.go
+++ b/e2e/test/nodepool/nodepool_test.go
@@ -225,13 +225,7 @@ func getNumberOfNodesByLabel(nodes *v1.NodeList, labelName, labelValue string) (
 func getWorkerNodes(ctx context.Context, ctrlClient client.Client) (*v1.NodeList, error) {
 	nodes := &v1.NodeList{}
 
-	var labelSelector client.MatchingLabels
-	{
-		labelSelector = make(map[string]string)
-		labelSelector["role"] = "worker"
-	}
-
-	err := ctrlClient.List(ctx, nodes, labelSelector)
+	err := ctrlClient.List(ctx, nodes)
 	if err != nil {
 		return nodes, microerror.Mask(err)
 	}

--- a/e2e/test/nodepool/nodepool_test.go
+++ b/e2e/test/nodepool/nodepool_test.go
@@ -89,7 +89,7 @@ func New(config Config) (*Nodepool, error) {
 	return s, nil
 }
 
-const LabelVmSize = "beta.kubernetes.io/instance-type"
+const LabelVmSize = "node.kubernetes.io/instance-type"
 
 func (s *Nodepool) Test(ctx context.Context) error {
 	clusterID := s.clusterID
@@ -234,7 +234,7 @@ func getNumberOfNodesByLabel(nodes *v1.NodeList, labelName, labelValue string) (
 	for _, node := range nodes.Items {
 		existingLabelValue, exists := node.GetLabels()[labelName]
 		if !exists {
-			return 0, microerror.Maskf(missingNodePoolLabelError, fmt.Sprintf("Label %#q is missing from node %#q", labelName, node.Name))
+			return 0, microerror.Maskf(missingNodePoolLabelError, fmt.Sprintf("Label %#q is missing from node %#q. Present labels are %v", labelName, node.Name, node.GetLabels()))
 		}
 
 		if existingLabelValue == labelValue {

--- a/e2e/test/nodepool/nodepool_test.go
+++ b/e2e/test/nodepool/nodepool_test.go
@@ -13,11 +13,13 @@ import (
 	releasev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/release/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/label"
 	"github.com/giantswarm/backoff"
+	"github.com/giantswarm/e2e-harness/pkg/framework"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/reference"
 	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
@@ -39,6 +41,7 @@ func Test_Nodepool(t *testing.T) {
 type Config struct {
 	ClusterID  string
 	CtrlClient client.Client
+	Guest      *framework.Guest
 	Logger     micrologger.Logger
 	Provider   *Provider
 	NodePoolID string
@@ -47,6 +50,7 @@ type Config struct {
 type Nodepool struct {
 	clusterID  string
 	ctrlClient client.Client
+	guest      *framework.Guest
 	logger     micrologger.Logger
 	provider   *Provider
 	nodePoolID string
@@ -58,6 +62,9 @@ func New(config Config) (*Nodepool, error) {
 	}
 	if config.CtrlClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Guest == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Guest must not be empty", config)
 	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
@@ -72,6 +79,7 @@ func New(config Config) (*Nodepool, error) {
 	s := &Nodepool{
 		clusterID:  config.ClusterID,
 		ctrlClient: config.CtrlClient,
+		guest:      config.Guest,
 		logger:     config.Logger,
 		nodePoolID: config.NodePoolID,
 		provider:   config.Provider,
@@ -140,7 +148,7 @@ func (s *Nodepool) Test(ctx context.Context) error {
 // Since normally node pools will have different virtual machine sizes, I'm selecting nodes by nodepool label or by vm size label, and making sure there are the right number.
 func (s *Nodepool) assertRightNumberOfNodes(ctx context.Context, setupNodePoolID, newNodePoolID string, setupNodePoolReplicas, newNodePoolReplicas int, setupNodePoolVMSize, newNodePoolVMSize string) error {
 	o := func() error {
-		nodes, err := getWorkerNodes(ctx, s.ctrlClient)
+		nodes, err := getWorkerNodes(ctx, s.guest.K8sClient())
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -222,12 +230,15 @@ func getNumberOfNodesByLabel(nodes *v1.NodeList, labelName, labelValue string) (
 	return existingNodes, nil
 }
 
-func getWorkerNodes(ctx context.Context, ctrlClient client.Client) (*v1.NodeList, error) {
-	nodes := &v1.NodeList{}
+func getWorkerNodes(ctx context.Context, k8sclient kubernetes.Interface) (*v1.NodeList, error) {
+	labelSelector := fmt.Sprintf("role=%s", "worker")
 
-	err := ctrlClient.List(ctx, nodes)
+	listOptions := metav1.ListOptions{
+		LabelSelector: labelSelector,
+	}
+	nodes, err := k8sclient.CoreV1().Nodes().List(listOptions)
 	if err != nil {
-		return nodes, microerror.Mask(err)
+		return &v1.NodeList{}, microerror.Mask(err)
 	}
 
 	return nodes, nil
@@ -345,7 +356,7 @@ func (s *Nodepool) WaitForNodesReady(ctx context.Context, expectedNodes int) err
 	s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for %d k8s nodes to be in %#q state", expectedNodes, v1.NodeReady))
 
 	o := func() error {
-		nodes, err := getWorkerNodes(ctx, s.ctrlClient)
+		nodes, err := getWorkerNodes(ctx, s.guest.K8sClient())
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/e2e/test/nodepool/nodepool_test.go
+++ b/e2e/test/nodepool/nodepool_test.go
@@ -191,7 +191,7 @@ func (s *Nodepool) assertRightNumberOfNodes(ctx context.Context, setupNodePoolID
 		return nil
 	}
 
-	b := backoff.NewConstant(backoff.ShortMaxWait, backoff.ShortMaxInterval)
+	b := backoff.NewConstant(backoff.LongMaxWait, backoff.LongMaxInterval)
 	n := backoff.NewNotifier(s.logger, ctx)
 	err := backoff.RetryNotify(o, b, n)
 	if err != nil {

--- a/e2e/test/nodepool/nodepool_test.go
+++ b/e2e/test/nodepool/nodepool_test.go
@@ -228,10 +228,10 @@ func getWorkerNodes(ctx context.Context, ctrlClient client.Client) (*v1.NodeList
 	var labelSelector client.MatchingLabels
 	{
 		labelSelector = make(map[string]string)
-		labelSelector["kubernetes.io/role"] = "worker"
+		labelSelector["role"] = "worker"
 	}
 
-	err := ctrlClient.List(ctx, nodes, labelSelector, client.InNamespace(metav1.NamespaceDefault))
+	err := ctrlClient.List(ctx, nodes, labelSelector)
 	if err != nil {
 		return nodes, microerror.Mask(err)
 	}

--- a/e2e/test/nodepool/nodepool_test.go
+++ b/e2e/test/nodepool/nodepool_test.go
@@ -221,7 +221,7 @@ func assertRightNumberOfNodesByVmSize(nodes *v1.NodeList, vmSize string, expecte
 	}
 
 	if existingNodesInNodePool != expectedNumberOfNodes {
-		return microerror.Mask(unexpectedNumberOfNodesError)
+		return microerror.Maskf(unexpectedNumberOfNodesError, fmt.Sprintf("Expected %d, got %d", expectedNumberOfNodes, existingNodesInNodePool))
 	}
 
 	return nil

--- a/e2e/test/nodepool/nodepool_test.go
+++ b/e2e/test/nodepool/nodepool_test.go
@@ -155,31 +155,45 @@ func (s *Nodepool) assertRightNumberOfNodes(ctx context.Context, setupNodePoolID
 		}
 
 		// Check node pool created during setup.
-		err = assertRightNumberOfNodesByNodePool(nodes, setupNodePoolID, setupNodePoolReplicas)
-		if err != nil {
-			return microerror.Mask(err)
-		}
+		{
+			s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("asserting node pool %#q has %d nodes", setupNodePoolID, setupNodePoolReplicas))
+			err = assertRightNumberOfNodesByNodePool(nodes, setupNodePoolID, setupNodePoolReplicas)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("asserted node pool %#q has %d nodes", setupNodePoolID, setupNodePoolReplicas))
 
-		err = assertRightNumberOfNodesByVmSize(nodes, setupNodePoolVMSize, setupNodePoolReplicas)
-		if err != nil {
-			return microerror.Mask(err)
+			s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("asserting node pool with VM Size %#q has %d nodes", setupNodePoolVMSize, setupNodePoolReplicas))
+			err = assertRightNumberOfNodesByVmSize(nodes, setupNodePoolVMSize, setupNodePoolReplicas)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("asserted node pool with VM Size %#q has %d nodes", setupNodePoolVMSize, setupNodePoolReplicas))
 		}
 
 		// Check node pool created in test.
-		err = assertRightNumberOfNodesByNodePool(nodes, newNodePoolID, newNodePoolReplicas)
-		if err != nil {
-			return microerror.Mask(err)
-		}
+		{
+			s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("asserting node pool %#q has %d nodes", newNodePoolID, newNodePoolReplicas))
+			err = assertRightNumberOfNodesByNodePool(nodes, newNodePoolID, newNodePoolReplicas)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("asserted node pool %#q has %d nodes", newNodePoolID, newNodePoolReplicas))
 
-		err = assertRightNumberOfNodesByVmSize(nodes, newNodePoolVMSize, newNodePoolReplicas)
-		if err != nil {
-			return microerror.Mask(err)
+			s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("asserting node pool with VM Size %#q has %d nodes", newNodePoolVMSize, newNodePoolReplicas))
+			err = assertRightNumberOfNodesByVmSize(nodes, newNodePoolVMSize, newNodePoolReplicas)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("asserted node pool with VM Size %#q has %d nodes", newNodePoolVMSize, newNodePoolReplicas))
 		}
 
 		return nil
 	}
+
 	b := backoff.NewConstant(backoff.ShortMaxWait, backoff.ShortMaxInterval)
-	err := backoff.Retry(o, b)
+	n := backoff.NewNotifier(s.logger, ctx)
+	err := backoff.RetryNotify(o, b, n)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/e2e/test/nodepool/provider.go
+++ b/e2e/test/nodepool/provider.go
@@ -1,0 +1,117 @@
+// +build k8srequired
+
+package nodepool
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/giantswarm/apiextensions/pkg/label"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1alpha32 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ProviderConfig struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+}
+
+type Provider struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+}
+
+func NewProvider(config ProviderConfig) (*Provider, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	p := &Provider{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return p, nil
+}
+
+func (p *Provider) AddWorker(ctx context.Context, clusterID, nodepoolID string) error {
+	p.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("scaling up one worker in node pool %#q", nodepoolID))
+
+	machinePool, err := p.findMachinePool(ctx, clusterID, nodepoolID)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	machinePool.Spec.Replicas = to.Int32Ptr(*machinePool.Spec.Replicas + int32(1))
+
+	err = p.ctrlClient.Update(ctx, machinePool)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	p.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("scaled up one worker in node pool %#q", nodepoolID))
+
+	return nil
+}
+
+func (p *Provider) ChangeVmSize(ctx context.Context, clusterID, nodepoolID, vmSize string) error {
+	p.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("changing virtual machine size in node pool %#q to %s", nodepoolID, vmSize))
+
+	machinePool, err := p.findMachinePool(ctx, clusterID, nodepoolID)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	azureMachinePool := &v1alpha32.AzureMachinePool{}
+	err = p.ctrlClient.Get(ctx, client.ObjectKey{Namespace: machinePool.Namespace, Name: nodepoolID}, azureMachinePool)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if azureMachinePool.Spec.Template.VMSize == vmSize {
+		return microerror.Maskf(sameVmSizeError, "choose a different VMSize than the current one")
+	}
+
+	azureMachinePool.Spec.Template.VMSize = vmSize
+
+	err = p.ctrlClient.Update(ctx, azureMachinePool)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	p.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("changed virtual machine size in node pool %#q to %s", nodepoolID, vmSize))
+
+	return nil
+}
+
+func (p *Provider) findMachinePool(ctx context.Context, clusterID, nodepoolID string) (*v1alpha3.MachinePool, error) {
+	crs := &v1alpha3.MachinePoolList{}
+
+	var labelSelector client.MatchingLabels
+	{
+		labelSelector = make(map[string]string)
+		labelSelector[capiv1alpha3.ClusterLabelName] = clusterID
+		labelSelector[label.MachinePool] = nodepoolID
+	}
+
+	err := p.ctrlClient.List(ctx, crs, labelSelector, client.InNamespace(metav1.NamespaceDefault))
+	if err != nil {
+		return &v1alpha3.MachinePool{}, microerror.Mask(err)
+	}
+	if len(crs.Items) < 1 {
+		p.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("MachinePool CR for cluster id %q not found", clusterID))
+		return &v1alpha3.MachinePool{}, microerror.Maskf(notFoundError, fmt.Sprintf("MachinePool CR for cluster id %q not found", clusterID))
+	}
+
+	return &crs.Items[0], nil
+}

--- a/service/controller/cloudconfig/worker_template.go
+++ b/service/controller/cloudconfig/worker_template.go
@@ -3,6 +3,7 @@ package cloudconfig
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 
 	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v7/pkg/template"
 	"github.com/giantswarm/microerror"
@@ -62,6 +63,8 @@ func (c CloudConfig) NewWorkerTemplate(ctx context.Context, data IgnitionTemplat
 			return "", microerror.Mask(err)
 		}
 	}
+
+	c.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("rendering cloudconfig with kubelet labels %v", params.Cluster.Kubernetes.Kubelet.Labels))
 
 	return newCloudConfig(k8scloudconfig.WorkerTemplate, params)
 }

--- a/service/controller/key/error.go
+++ b/service/controller/key/error.go
@@ -40,3 +40,12 @@ var wrongTypeError = &microerror.Error{
 func IsWrongTypeError(err error) bool {
 	return microerror.Cause(err) == wrongTypeError
 }
+
+var missingMachinePoolLabelError = &microerror.Error{
+	Kind: "missingMachinePoolLabelError",
+}
+
+// IsMissingMachinePoolLabelError asserts missingMachinePoolLabelError.
+func IsMissingMachinePoolLabelError(err error) bool {
+	return microerror.Cause(err) == missingMachinePoolLabelError
+}

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/go-autorest/autorest/to"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	apiextensionslabels "github.com/giantswarm/apiextensions/pkg/label"
 	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v7/pkg/template"
 	"github.com/giantswarm/microerror"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
@@ -347,6 +348,7 @@ func KubeletLabelsNodePool(getter LabelsGetter) string {
 
 	labels = ensureLabel(labels, label.Provider, "azure")
 	labels = ensureLabel(labels, label.OperatorVersion, OperatorVersion(getter))
+	labels = ensureLabel(labels, apiextensionslabels.MachinePool, MachinePoolID(getter))
 
 	return labels
 }
@@ -599,6 +601,10 @@ func WorkerInstanceName(clusterID, instanceID string) string {
 
 func NodePoolDeploymentName(azureMachinePool *expcapzv1alpha3.AzureMachinePool) string {
 	return NodePoolVMSSName(azureMachinePool)
+}
+
+func MachinePoolID(getter LabelsGetter) string {
+	return getter.GetLabels()[apiextensionslabels.MachinePool]
 }
 
 func NodePoolVMSSName(azureMachinePool *expcapzv1alpha3.AzureMachinePool) string {

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -350,8 +350,8 @@ func KubeletLabelsNodePool(getter LabelsGetter) (string, error) {
 	labels = ensureLabel(labels, label.OperatorVersion, OperatorVersion(getter))
 
 	machinePoolID, err := MachinePoolID(getter)
-	if err != nil {
-		return labels, microerror.Mask(err)
+	if err != nil || machinePoolID == "" {
+		return labels, microerror.Mask(missingMachinePoolLabelError)
 	}
 
 	labels = ensureLabel(labels, apiextensionslabels.MachinePool, machinePoolID)

--- a/service/controller/resource/azureconfig/create.go
+++ b/service/controller/resource/azureconfig/create.go
@@ -368,8 +368,11 @@ func (r *Resource) newCluster(cluster capiv1alpha3.Cluster, azureCluster capzv1a
 			return providerv1alpha1.Cluster{}, microerror.Mask(err)
 		}
 
+		// We ingore the error here. It happens because AzureCluster or AzureConfig don't know about MachinePoolID.
+		kubeletLabels, _ := key.KubeletLabelsNodePool(&azureCluster)
+
 		commonCluster.Kubernetes.Kubelet.Domain = kubeletDomain
-		commonCluster.Kubernetes.Kubelet.Labels = key.KubeletLabelsNodePool(&azureCluster)
+		commonCluster.Kubernetes.Kubelet.Labels = kubeletLabels
 	}
 
 	{

--- a/service/controller/resource/nodepool/status.go
+++ b/service/controller/resource/nodepool/status.go
@@ -36,12 +36,11 @@ func (r *Resource) saveCurrentState(ctx context.Context, customObject v1alpha3.A
 		return microerror.Mask(err)
 	}
 
-	annotations := azureMachinePool.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
+	if azureMachinePool.Annotations == nil {
+		azureMachinePool.Annotations = map[string]string{}
 	}
 
-	annotations[annotation.StateMachineCurrentState] = state
+	azureMachinePool.Annotations[annotation.StateMachineCurrentState] = state
 
 	err = r.CtrlClient.Update(ctx, azureMachinePool)
 	if err != nil {
@@ -58,12 +57,11 @@ func (r *Resource) getCurrentState(ctx context.Context, customObject v1alpha3.Az
 		return "", microerror.Mask(err)
 	}
 
-	annotations := azureMachinePool.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
+	if azureMachinePool.Annotations == nil {
+		azureMachinePool.Annotations = map[string]string{}
 	}
 
-	status, exists := annotations[annotation.StateMachineCurrentState]
+	status, exists := azureMachinePool.Annotations[annotation.StateMachineCurrentState]
 	if !exists {
 		return "", nil
 	}

--- a/service/controller/resource/spark/create.go
+++ b/service/controller/resource/spark/create.go
@@ -482,6 +482,10 @@ func (r *Resource) buildAzureConfig(cluster *capiv1alpha3.Cluster, azureCluster 
 		hostResourceGroup = r.azure.HostCluster.ResourceGroup
 	)
 
+	{
+		azureConfig.Spec.Azure.VirtualNetwork.CIDR = azureCluster.Spec.NetworkSpec.Vnet.CidrBlock
+	}
+
 	azureConfig.Spec.Azure.DNSZones.API.Name = hostDNSZone
 	azureConfig.Spec.Azure.DNSZones.API.ResourceGroup = hostResourceGroup
 	azureConfig.Spec.Azure.DNSZones.Etcd.Name = hostDNSZone

--- a/service/controller/resource/spark/create.go
+++ b/service/controller/resource/spark/create.go
@@ -585,8 +585,13 @@ func (r *Resource) newCluster(cluster *capiv1alpha3.Cluster, azureCluster *capzv
 			return providerv1alpha1.Cluster{}, microerror.Mask(err)
 		}
 
+		kubeletLabels, err := key.KubeletLabelsNodePool(machinePool)
+		if err != nil {
+			return providerv1alpha1.Cluster{}, microerror.Mask(err)
+		}
+
 		commonCluster.Kubernetes.Kubelet.Domain = kubeletDomain
-		commonCluster.Kubernetes.Kubelet.Labels = key.KubeletLabelsNodePool(machinePool)
+		commonCluster.Kubernetes.Kubelet.Labels = kubeletLabels
 	}
 
 	{

--- a/service/controller/resource/spark/create.go
+++ b/service/controller/resource/spark/create.go
@@ -586,7 +586,7 @@ func (r *Resource) newCluster(cluster *capiv1alpha3.Cluster, azureCluster *capzv
 		}
 
 		commonCluster.Kubernetes.Kubelet.Domain = kubeletDomain
-		commonCluster.Kubernetes.Kubelet.Labels = key.KubeletLabelsNodePool(azureCluster)
+		commonCluster.Kubernetes.Kubelet.Labels = key.KubeletLabelsNodePool(machinePool)
 	}
 
 	{

--- a/service/controller/resource/subnet/resource.go
+++ b/service/controller/resource/subnet/resource.go
@@ -185,7 +185,7 @@ func (r *Resource) ensureSubnets(ctx context.Context, deploymentsClient *azurere
 		}
 
 		if shouldSubmitDeployment {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "template or parameters changed")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "template or parameters changed", "subnet", azureCluster.Spec.NetworkSpec.Subnets[i].Name)
 			err = r.createDeployment(ctx, deploymentsClient, key.ClusterID(&azureCluster), deploymentName, desiredDeployment)
 			if err != nil {
 				return microerror.Mask(err)
@@ -197,7 +197,7 @@ func (r *Resource) ensureSubnets(ctx context.Context, deploymentsClient *azurere
 			return nil
 		}
 
-		r.logger.LogCtx(ctx, "level", "debug", "message", "template and parameters unchanged")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "template and parameters unchanged", "subnet", azureCluster.Spec.NetworkSpec.Subnets[i].Name)
 		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deployment is in state %#q", *currentDeployment.Properties.ProvisioningState))
 
 		if key.IsFailedProvisioningState(*currentDeployment.Properties.ProvisioningState) {
@@ -255,7 +255,7 @@ func (r *Resource) ensureSubnets(ctx context.Context, deploymentsClient *azurere
 func (r *Resource) garbageCollectSubnets(ctx context.Context, deploymentsClient *azureresource.DeploymentsClient, subnetsClient *network.SubnetsClient, azureCluster capzv1alpha3.AzureCluster) error {
 	subnetsIterator, err := subnetsClient.ListComplete(ctx, key.ClusterID(&azureCluster), azureCluster.Spec.NetworkSpec.Vnet.Name)
 	if IsNotFound(err) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Vnet not %#q found, cancelling resource", azureCluster.Spec.NetworkSpec.Vnet.Name))
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Vnet %#q not found, cancelling resource", azureCluster.Spec.NetworkSpec.Vnet.Name))
 		return nil
 	} else if err != nil {
 		return microerror.Mask(err)


### PR DESCRIPTION
We add a new label to the `Node` object in k8s so that it contains the node pool id. This will allow customers to schedule different workloads on different node pools using the label.