### PR TITLE
Use bootstrap cloudconfig generated by spark handler

### DIFF
--- a/service/controller/cloudconfig/base_extension.go
+++ b/service/controller/cloudconfig/base_extension.go
@@ -30,6 +30,16 @@ func (e *baseExtension) templateData(certFiles []certs.File) templateData {
 		certsPaths = append(certsPaths, file.AbsolutePath)
 	}
 
+	primaryScaleSetName := key.WorkerVMSSName(e.customObject)
+	if e.azureMachinePool != nil {
+		primaryScaleSetName = key.NodePoolVMSSName(e.azureMachinePool)
+	}
+
+	subnetName := key.WorkerSubnetName(e.customObject)
+	if e.azureMachinePool != nil {
+		subnetName = e.azureMachinePool.Name
+	}
+
 	return templateData{
 		azureCNIFileParams{
 			VnetCIDR: e.vnetCIDR,
@@ -43,11 +53,11 @@ func (e *baseExtension) templateData(certFiles []certs.File) templateData {
 			AADClientSecret:             e.azureClientCredentialsConfig.ClientSecret,
 			EnvironmentName:             e.azure.EnvironmentName,
 			Location:                    e.azure.Location,
-			PrimaryScaleSetName:         key.NodePoolVMSSName(e.azureMachinePool),
+			PrimaryScaleSetName:         primaryScaleSetName,
 			ResourceGroup:               key.ResourceGroupName(e.customObject),
 			RouteTableName:              key.RouteTableName(e.customObject),
 			SecurityGroupName:           key.WorkerSecurityGroupName(e.customObject),
-			SubnetName:                  e.azureMachinePool.Name,
+			SubnetName:                  subnetName,
 			SubscriptionID:              e.subscriptionID,
 			TenantID:                    e.azureClientCredentialsConfig.TenantID,
 			VnetName:                    key.VnetName(e.customObject),

--- a/service/controller/cloudconfig/base_extension.go
+++ b/service/controller/cloudconfig/base_extension.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	providerv1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs/v2/pkg/certs"
+	capzexpv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 
 	"github.com/giantswarm/azure-operator/v4/service/controller/encrypter"
 	"github.com/giantswarm/azure-operator/v4/service/controller/key"
@@ -13,6 +14,7 @@ import (
 type baseExtension struct {
 	azure                        setting.Azure
 	azureClientCredentialsConfig auth.ClientCredentialsConfig
+	azureMachinePool             *capzexpv1alpha3.AzureMachinePool
 	calicoCIDR                   string
 	certFiles                    []certs.File
 	customObject                 providerv1alpha1.AzureConfig
@@ -41,11 +43,11 @@ func (e *baseExtension) templateData(certFiles []certs.File) templateData {
 			AADClientSecret:             e.azureClientCredentialsConfig.ClientSecret,
 			EnvironmentName:             e.azure.EnvironmentName,
 			Location:                    e.azure.Location,
-			PrimaryScaleSetName:         key.WorkerVMSSName(e.customObject),
+			PrimaryScaleSetName:         key.NodePoolVMSSName(e.azureMachinePool),
 			ResourceGroup:               key.ResourceGroupName(e.customObject),
 			RouteTableName:              key.RouteTableName(e.customObject),
 			SecurityGroupName:           key.WorkerSecurityGroupName(e.customObject),
-			SubnetName:                  key.WorkerSubnetName(e.customObject),
+			SubnetName:                  e.azureMachinePool.Name,
 			SubscriptionID:              e.subscriptionID,
 			TenantID:                    e.azureClientCredentialsConfig.TenantID,
 			VnetName:                    key.VnetName(e.customObject),

--- a/service/controller/cloudconfig/worker_template.go
+++ b/service/controller/cloudconfig/worker_template.go
@@ -24,6 +24,7 @@ func (c CloudConfig) NewWorkerTemplate(ctx context.Context, data IgnitionTemplat
 			certFiles:                    data.WorkerCertFiles,
 			customObject:                 data.CustomObject,
 			encrypter:                    encrypter,
+			azureMachinePool:             data.AzureMachinePool,
 			subscriptionID:               c.subscriptionID,
 			vnetCIDR:                     data.CustomObject.Spec.Azure.VirtualNetwork.CIDR,
 		}

--- a/service/controller/resource/blobobject/desired.go
+++ b/service/controller/resource/blobobject/desired.go
@@ -154,21 +154,5 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		output = append(output, containerObjectState)
 	}
 
-	{
-		b, err := cc.CloudConfig.NewWorkerTemplate(ctx, ignitionTemplateData, encrypter)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-		k := key.BlobName(&cr, prefixWorker)
-		containerObjectState := ContainerObjectState{
-			Body:               b,
-			ContainerName:      containerName,
-			Key:                k,
-			StorageAccountName: storageAccountName,
-		}
-
-		output = append(output, containerObjectState)
-	}
-
 	return output, nil
 }

--- a/service/controller/resource/nodepool/deployment.go
+++ b/service/controller/resource/nodepool/deployment.go
@@ -36,14 +36,13 @@ func (r Resource) newDeployment(ctx context.Context, storageAccountsClient *stor
 		return azureresource.Deployment{}, microerror.Mask(missingOperatorVersionLabel)
 	}
 
-	certificateEncryptionSecretName := fmt.Sprintf("%s-certificate-encryption", azureCluster.GetName())
-	encrypterObject, err := r.getEncrypterObject(ctx, certificateEncryptionSecretName)
+	encrypterObject, err := r.getEncrypterObject(ctx, key.CertificateEncryptionSecretName(azureCluster))
 	if err != nil {
 		return azureresource.Deployment{}, microerror.Mask(err)
 	}
 
 	storageAccountName := strings.Replace(fmt.Sprintf("%s%s", "gssa", azureCluster.GetName()), "-", "", -1)
-	workerCloudConfig, err := r.getWorkerCloudConfig(ctx, storageAccountsClient, azureCluster.GetName(), storageAccountName, key.WorkerBlobName(operatorVersion), encrypterObject)
+	workerCloudConfig, err := r.getWorkerCloudConfig(ctx, storageAccountsClient, azureCluster.GetName(), storageAccountName, key.BootstrapBlobName(*azureMachinePool), key.WorkerBlobName(operatorVersion), encrypterObject)
 	if err != nil {
 		return azureresource.Deployment{}, microerror.Mask(err)
 	}
@@ -115,7 +114,7 @@ func (r Resource) getSubnetName(azureMachinePool *capzexpv1alpha3.AzureMachinePo
 	return "", "", microerror.Maskf(notFoundError, "there is no allocated subnet for nodepool %#q in virtual network called %#q", azureMachinePool.Name, azureCluster.Spec.NetworkSpec.Vnet.ID)
 }
 
-func (r *Resource) getWorkerCloudConfig(ctx context.Context, storageAccountsClient *storage.AccountsClient, resourceGroupName, storageAccountName, workerBlobName string, encrypterObject encrypter.Interface) (string, error) {
+func (r *Resource) getWorkerCloudConfig(ctx context.Context, storageAccountsClient *storage.AccountsClient, resourceGroupName, storageAccountName, containerName, workerBlobName string, encrypterObject encrypter.Interface) (string, error) {
 	encryptionKey := encrypterObject.GetEncryptionKey()
 	initialVector := encrypterObject.GetInitialVector()
 
@@ -136,7 +135,6 @@ func (r *Resource) getWorkerCloudConfig(ctx context.Context, storageAccountsClie
 		return "", microerror.Maskf(executionFailedError, "storage account key's list is empty")
 	}
 	primaryKey := *(((*keys.Keys)[0]).Value)
-	containerName := key.BlobContainerName()
 
 	sc, err := azblob.NewSharedKeyCredential(storageAccountName, primaryKey)
 	if err != nil {
@@ -146,7 +144,7 @@ func (r *Resource) getWorkerCloudConfig(ctx context.Context, storageAccountsClie
 	p := azblob.NewPipeline(sc, azblob.PipelineOptions{})
 	u, _ := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net", storageAccountName))
 	serviceURL := azblob.NewServiceURL(*u, p)
-	containerURL := serviceURL.NewContainerURL(key.BlobContainerName())
+	containerURL := serviceURL.NewContainerURL(containerName)
 
 	workerBlobURL, err := blobclient.GetBlobURL(workerBlobName, containerName, storageAccountName, primaryKey, &containerURL)
 	if err != nil {

--- a/service/controller/resource/nodepool/deployment.go
+++ b/service/controller/resource/nodepool/deployment.go
@@ -31,18 +31,13 @@ import (
 )
 
 func (r Resource) newDeployment(ctx context.Context, storageAccountsClient *storage.AccountsClient, release *releasev1alpha1.Release, machinePool *capiexpv1alpha3.MachinePool, azureMachinePool *capzexpv1alpha3.AzureMachinePool, azureCluster *capzv1alpha3.AzureCluster) (azureresource.Deployment, error) {
-	operatorVersion, exists := azureMachinePool.GetLabels()[label.OperatorVersion]
-	if !exists {
-		return azureresource.Deployment{}, microerror.Mask(missingOperatorVersionLabel)
-	}
-
 	encrypterObject, err := r.getEncrypterObject(ctx, key.CertificateEncryptionSecretName(azureCluster))
 	if err != nil {
 		return azureresource.Deployment{}, microerror.Mask(err)
 	}
 
 	storageAccountName := strings.Replace(fmt.Sprintf("%s%s", "gssa", azureCluster.GetName()), "-", "", -1)
-	workerCloudConfig, err := r.getWorkerCloudConfig(ctx, storageAccountsClient, azureCluster.GetName(), storageAccountName, key.BootstrapBlobName(*azureMachinePool), key.WorkerBlobName(operatorVersion), encrypterObject)
+	workerCloudConfig, err := r.getWorkerCloudConfig(ctx, storageAccountsClient, azureCluster.GetName(), storageAccountName, key.BlobContainerName(), key.BootstrapBlobName(*azureMachinePool), encrypterObject)
 	if err != nil {
 		return azureresource.Deployment{}, microerror.Mask(err)
 	}

--- a/service/controller/resource/spark/create.go
+++ b/service/controller/resource/spark/create.go
@@ -350,11 +350,12 @@ func (r *Resource) createIgnitionBlob(ctx context.Context, azureMachinePool *exp
 			return nil, microerror.Mask(err)
 		}
 		ignitionTemplateData = cloudconfig.IgnitionTemplateData{
-			CustomObject:    mappedAzureConfig,
-			Images:          images,
-			MasterCertFiles: masterCertFiles,
-			Versions:        versions,
-			WorkerCertFiles: workerCertFiles,
+			AzureMachinePool: azureMachinePool,
+			CustomObject:     mappedAzureConfig,
+			Images:           images,
+			MasterCertFiles:  masterCertFiles,
+			Versions:         versions,
+			WorkerCertFiles:  workerCertFiles,
 		}
 	}
 


### PR DESCRIPTION
We were still using the old cloudconfig files. We need to use the cloudconfig generated by the `spark` handler instead.