### PR TITLE
Compute tenant cluster k8sclient instead of relying on context

### DIFF
--- a/service/controller/resource/nodepool/create_cordon_old_workers.go
+++ b/service/controller/resource/nodepool/create_cordon_old_workers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/coreos/go-semver/semver"
+	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -15,7 +16,6 @@ import (
 
 	"github.com/giantswarm/azure-operator/v4/pkg/label"
 	"github.com/giantswarm/azure-operator/v4/pkg/project"
-	"github.com/giantswarm/azure-operator/v4/service/controller/controllercontext"
 	"github.com/giantswarm/azure-operator/v4/service/controller/internal/state"
 	"github.com/giantswarm/azure-operator/v4/service/controller/key"
 )
@@ -44,17 +44,12 @@ func (r *Resource) cordonOldWorkersTransition(ctx context.Context, obj interface
 
 	virtualMachineScaleSetVMsClient, err := r.ClientFactory.GetVirtualMachineScaleSetVMsClient(credentialSecret.Namespace, credentialSecret.Name)
 	if err != nil {
-		return DeploymentUninitialized, microerror.Mask(err)
+		return currentState, microerror.Mask(err)
 	}
 
-	cc, err := controllercontext.FromContext(ctx)
+	tenantClusterK8sClient, err := r.getTenantClusterK8sClient(ctx, cluster)
 	if err != nil {
-		return DeploymentUninitialized, microerror.Mask(err)
-	}
-
-	if cc.Client.TenantCluster.K8s == nil {
-		r.Logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster client not available yet")
-		return currentState, nil
+		return currentState, microerror.Mask(err)
 	}
 
 	var allWorkerInstances []compute.VirtualMachineScaleSetVM
@@ -73,7 +68,7 @@ func (r *Resource) cordonOldWorkersTransition(ctx context.Context, obj interface
 
 	var nodes []corev1.Node
 	{
-		nodeList, err := cc.Client.TenantCluster.K8s.CoreV1().Nodes().List(metav1.ListOptions{})
+		nodeList, err := tenantClusterK8sClient.K8sClient().CoreV1().Nodes().List(metav1.ListOptions{})
 		if err != nil {
 			return DeploymentUninitialized, microerror.Mask(err)
 		}
@@ -91,7 +86,7 @@ func (r *Resource) cordonOldWorkersTransition(ctx context.Context, obj interface
 	r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d old and %d new nodes from tenant cluster", len(oldNodes), len(newNodes)))
 	r.Logger.LogCtx(ctx, "level", "debug", "message", "ensuring old nodes are cordoned")
 
-	oldNodesCordoned, err := r.ensureNodesCordoned(ctx, oldNodes)
+	oldNodesCordoned, err := r.ensureNodesCordoned(ctx, tenantClusterK8sClient, oldNodes)
 	if err != nil {
 		return DeploymentUninitialized, microerror.Mask(err)
 	}
@@ -108,12 +103,7 @@ func (r *Resource) cordonOldWorkersTransition(ctx context.Context, obj interface
 }
 
 // ensureNodesCordoned ensures that given tenant cluster nodes are cordoned.
-func (r *Resource) ensureNodesCordoned(ctx context.Context, nodes []corev1.Node) (int, error) {
-	cc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return 0, microerror.Mask(err)
-	}
-
+func (r *Resource) ensureNodesCordoned(ctx context.Context, tenantClusterK8sClient k8sclient.Interface, nodes []corev1.Node) (int, error) {
 	var count int
 	for _, n := range nodes {
 		// Node already cordoned?
@@ -125,7 +115,7 @@ func (r *Resource) ensureNodesCordoned(ctx context.Context, nodes []corev1.Node)
 		t := types.StrategicMergePatchType
 		p := []byte(UnschedulablePatch)
 
-		_, err = cc.Client.TenantCluster.K8s.CoreV1().Nodes().Patch(n.Name, t, p)
+		_, err := tenantClusterK8sClient.K8sClient().CoreV1().Nodes().Patch(n.Name, t, p)
 		if apierrors.IsNotFound(err) {
 			// On manual operations or during auto-scaling it may happen that
 			// node gets terminated while instances are processed. It's ok from
@@ -179,15 +169,10 @@ func sortNodesByTenantVMState(nodes []corev1.Node, instances []compute.VirtualMa
 	return
 }
 
-func (r *Resource) getK8sWorkerNodeForInstance(ctx context.Context, clusterID string, instance compute.VirtualMachineScaleSetVM) (*corev1.Node, error) {
-	cc, err := controllercontext.FromContext(ctx)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
+func (r *Resource) getK8sWorkerNodeForInstance(ctx context.Context, tenantClusterK8sClient k8sclient.Interface, clusterID string, instance compute.VirtualMachineScaleSetVM) (*corev1.Node, error) {
 	name := key.WorkerInstanceName(clusterID, *instance.InstanceID)
 
-	nodeList, err := cc.Client.TenantCluster.K8s.CoreV1().Nodes().List(metav1.ListOptions{})
+	nodeList, err := tenantClusterK8sClient.K8sClient().CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -203,11 +188,11 @@ func (r *Resource) getK8sWorkerNodeForInstance(ctx context.Context, clusterID st
 	return nil, nil
 }
 
-func (r *Resource) isWorkerInstanceFromPreviousRelease(ctx context.Context, clusterID string, instance compute.VirtualMachineScaleSetVM) (*bool, error) {
+func (r *Resource) isWorkerInstanceFromPreviousRelease(ctx context.Context, tenantClusterK8sClient k8sclient.Interface, clusterID string, instance compute.VirtualMachineScaleSetVM) (*bool, error) {
 	t := true
 	f := false
 
-	n, err := r.getK8sWorkerNodeForInstance(ctx, clusterID, instance)
+	n, err := r.getK8sWorkerNodeForInstance(ctx, tenantClusterK8sClient, clusterID, instance)
 	if err != nil {
 		return nil, err
 	}

--- a/service/controller/resource/nodepool/create_drain_old_worker_nodes.go
+++ b/service/controller/resource/nodepool/create_drain_old_worker_nodes.go
@@ -36,6 +36,11 @@ func (r *Resource) drainOldWorkerNodesTransition(ctx context.Context, obj interf
 		return currentState, microerror.Mask(err)
 	}
 
+	tenantClusterK8sClient, err := r.getTenantClusterK8sClient(ctx, cluster)
+	if err != nil {
+		return currentState, microerror.Mask(err)
+	}
+
 	r.Logger.LogCtx(ctx, "level", "debug", "message", "finding all drainerconfigs")
 
 	drainerConfigs := make(map[string]corev1alpha1.DrainerConfig)
@@ -68,7 +73,7 @@ func (r *Resource) drainOldWorkerNodesTransition(ctx context.Context, obj interf
 
 	var nodesPendingDraining int
 	for _, i := range allWorkerInstances {
-		old, err := r.isWorkerInstanceFromPreviousRelease(ctx, key.ClusterID(&azureMachinePool), i)
+		old, err := r.isWorkerInstanceFromPreviousRelease(ctx, tenantClusterK8sClient, key.ClusterID(&azureMachinePool), i)
 		if err != nil {
 			return DeploymentUninitialized, nil
 		}

--- a/service/controller/resource/nodepool/create_terminate_old_workers.go
+++ b/service/controller/resource/nodepool/create_terminate_old_workers.go
@@ -39,6 +39,11 @@ func (r *Resource) terminateOldWorkersTransition(ctx context.Context, obj interf
 		return currentState, microerror.Mask(err)
 	}
 
+	tenantClusterK8sClient, err := r.getTenantClusterK8sClient(ctx, cluster)
+	if err != nil {
+		return currentState, microerror.Mask(err)
+	}
+
 	var allWorkerInstances []compute.VirtualMachineScaleSetVM
 	{
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "finding all worker VMSS instances")
@@ -59,7 +64,7 @@ func (r *Resource) terminateOldWorkersTransition(ctx context.Context, obj interf
 	{
 		var strIds []string
 		for _, i := range allWorkerInstances {
-			old, err := r.isWorkerInstanceFromPreviousRelease(ctx, key.ClusterID(&azureMachinePool), i)
+			old, err := r.isWorkerInstanceFromPreviousRelease(ctx, tenantClusterK8sClient, key.ClusterID(&azureMachinePool), i)
 			if err != nil {
 				return DeploymentUninitialized, nil
 			}

--- a/service/controller/resource/nodepool/resource.go
+++ b/service/controller/resource/nodepool/resource.go
@@ -1,11 +1,20 @@
 package nodepool
 
 import (
+	"context"
+
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/giantswarm/errors/tenant"
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/tenantcluster/v2/pkg/tenantcluster"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-operator/v4/pkg/credential"
+	"github.com/giantswarm/azure-operator/v4/service/controller/key"
 	"github.com/giantswarm/azure-operator/v4/service/controller/resource/nodes"
 )
 
@@ -18,6 +27,7 @@ type Config struct {
 	CredentialProvider        credential.Provider
 	CtrlClient                ctrlclient.Client
 	GSClientCredentialsConfig auth.ClientCredentialsConfig
+	TenantRestConfigProvider  tenantcluster.Interface
 }
 
 // Resource takes care of node pool life cycle.
@@ -27,6 +37,7 @@ type Resource struct {
 	CtrlClient                ctrlclient.Client
 	GSClientCredentialsConfig auth.ClientCredentialsConfig
 	k8sClient                 kubernetes.Interface
+	tenantRestConfigProvider  tenantcluster.Interface
 }
 
 func New(config Config) (*Resource, error) {
@@ -43,6 +54,7 @@ func New(config Config) (*Resource, error) {
 		CtrlClient:                config.CtrlClient,
 		GSClientCredentialsConfig: config.GSClientCredentialsConfig,
 		k8sClient:                 config.K8sClient,
+		tenantRestConfigProvider:  config.TenantRestConfigProvider,
 	}
 	stateMachine := r.createStateMachine()
 	r.SetStateMachine(stateMachine)
@@ -52,4 +64,34 @@ func New(config Config) (*Resource, error) {
 
 func (r *Resource) Name() string {
 	return Name
+}
+
+func (r *Resource) getTenantClusterK8sClient(ctx context.Context, cluster *capiv1alpha3.Cluster) (k8sclient.Interface, error) {
+	var k8sClient k8sclient.Interface
+	{
+		restConfig, err := r.tenantRestConfigProvider.NewRestConfig(ctx, key.ClusterID(cluster), cluster.Spec.ControlPlaneEndpoint.String())
+		if tenantcluster.IsTimeout(err) {
+			r.Logger.LogCtx(ctx, "level", "debug", "message", "timeout fetching certificates")
+			r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return k8sClient, nil
+		} else if err != nil {
+			return k8sClient, microerror.Mask(err)
+		}
+
+		c := k8sclient.ClientsConfig{
+			Logger:     r.Logger,
+			RestConfig: rest.CopyConfig(restConfig),
+		}
+
+		k8sClient, err := k8sclient.NewClients(c)
+		if tenant.IsAPINotAvailable(err) {
+			r.Logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
+			r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+			return k8sClient, nil
+		} else if err != nil {
+			return k8sClient, microerror.Mask(err)
+		}
+	}
+
+	return k8sClient, nil
 }


### PR DESCRIPTION
Before nodepools we had a handler called `tenantcluster` that added the k8sclient for the tenant cluster to the `controllercontext`. Since `nodepool` handler reacts to `AzureMachinePool`, the `tenantcluster` handler wasn't being called, and we need the client. So I compute it for the `nodepool` handler, but I don't save it in the context.

Not using the `controllercontext` meant passing the tenant cluster client to a bunch of functions.