### PR TITLE
Allow volume expansion for PVCs on the default storage classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add monitoring label
 - Add provider independent controllers to manage labeling and setting owner references in other provider dependent objects.
 - Export container logs for e2e tests to azure analytics.
+- Enable persistent volume `expansion` support in the default `Storage Classes`.
 
 ### Changed
 

--- a/service/controller/templates/ignition/default_storage_class.go
+++ b/service/controller/templates/ignition/default_storage_class.go
@@ -12,6 +12,7 @@ provisioner: kubernetes.io/azure-disk
 parameters:
   kind: Managed
   storageaccounttype: Premium_LRS
+allowVolumeExpansion: true
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -24,6 +25,7 @@ provisioner: kubernetes.io/azure-disk
 parameters:
   kind: Managed
   storageaccounttype: Premium_LRS
+allowVolumeExpansion: true
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -36,6 +38,7 @@ provisioner: kubernetes.io/azure-disk
 parameters:
   kind: Managed
   storageaccounttype: Standard_LRS
+allowVolumeExpansion: true
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/13211

Allow to expand PVCs created using the default storage classes we deploy on tenant clusters.