### PR TITLE
Use organization credential secret fallback everywhere

### DIFF
--- a/service/controller/resource/azureclusterconfig/create.go
+++ b/service/controller/resource/azureclusterconfig/create.go
@@ -162,7 +162,7 @@ func (r *Resource) buildAzureClusterConfig(ctx context.Context, cluster capiv1al
 		return corev1alpha1.AzureClusterConfig{}, microerror.Mask(err)
 	}
 
-	credentialSecret, err := r.getCredentialSecret(ctx, cluster)
+	credentialSecret, err := r.getCredentialSecret(ctx, cluster.ObjectMeta)
 	if err != nil {
 		return corev1alpha1.AzureClusterConfig{}, microerror.Mask(err)
 	}

--- a/service/controller/resource/azureclusterconfig/credential.go
+++ b/service/controller/resource/azureclusterconfig/credential.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/v2/pkg/apis/provider/v1alpha1"
+	apiextensionslabels "github.com/giantswarm/apiextensions/v2/pkg/label"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
-	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-operator/v4/pkg/label"
@@ -15,21 +16,47 @@ import (
 )
 
 const (
-	credentialDefaultName = "credential-default"
+	credentialDefaultName      = "credential-default"
+	credentialDefaultNamespace = "giantswarm"
 )
 
-func (r *Resource) getCredentialSecret(ctx context.Context, cluster capiv1alpha3.Cluster) (*v1alpha1.CredentialSecret, error) {
+func (r *Resource) getCredentialSecret(ctx context.Context, objectMeta v1.ObjectMeta) (*v1alpha1.CredentialSecret, error) {
 	r.logger.LogCtx(ctx, "level", "debug", "message", "finding credential secret")
 
+	var err error
+	var credentialSecret *v1alpha1.CredentialSecret
+
+	credentialSecret, err = r.getOrganizationCredentialSecret(ctx, objectMeta)
+	if IsCredentialsNotFoundError(err) {
+		credentialSecret, err = r.getLegacyCredentialSecret(ctx, objectMeta)
+		if IsCredentialsNotFoundError(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find credential secret, using default '%s/%s'", credentialDefaultNamespace, credentialDefaultName))
+			return &v1alpha1.CredentialSecret{
+				Namespace: credentialDefaultNamespace,
+				Name:      credentialDefaultName,
+			}, nil
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return credentialSecret, nil
+}
+
+// getOrganizationCredentialSecret tries to find a Secret in the organization namespace.
+func (r *Resource) getOrganizationCredentialSecret(ctx context.Context, objectMeta v1.ObjectMeta) (*v1alpha1.CredentialSecret, error) {
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("try in namespace %#q filtering by organization %#q", objectMeta.Namespace, key.OrganizationID(&objectMeta)))
 	secretList := &corev1.SecretList{}
 	{
 		err := r.ctrlClient.List(
 			ctx,
 			secretList,
-			client.InNamespace(cluster.Namespace),
+			client.InNamespace(objectMeta.Namespace),
 			client.MatchingLabels{
-				label.App:          "credentiald",
-				label.Organization: key.OrganizationID(&cluster),
+				label.App:                        "credentiald",
+				apiextensionslabels.Organization: key.OrganizationID(&objectMeta),
 			},
 		)
 		if err != nil {
@@ -43,27 +70,62 @@ func (r *Resource) getCredentialSecret(ctx context.Context, cluster capiv1alpha3
 		return nil, microerror.Mask(tooManyCredentialsError)
 	}
 
+	if len(secretList.Items) < 1 {
+		return nil, microerror.Mask(credentialsNotFoundError)
+	}
+
 	// If one credential secret is found, we use that.
-	if len(secretList.Items) == 1 {
-		secret := secretList.Items[0]
+	secret := secretList.Items[0]
 
-		credentialSecret := &v1alpha1.CredentialSecret{
-			Namespace: secret.Namespace,
-			Name:      secret.Name,
-		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found credential secret %s/%s", credentialSecret.Namespace, credentialSecret.Name))
-
-		return credentialSecret, nil
-	}
-
-	// If no credential secrets are found, we use the default.
 	credentialSecret := &v1alpha1.CredentialSecret{
-		Namespace: cluster.Namespace,
-		Name:      credentialDefaultName,
+		Namespace: secret.Namespace,
+		Name:      secret.Name,
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", "did not find credential secret, using default secret")
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found credential secret %s/%s", credentialSecret.Namespace, credentialSecret.Name))
+
+	return credentialSecret, nil
+}
+
+// getLegacyCredentialSecret tries to find a Secret in the default credentials namespace but labeled with the organization name.
+// This is needed while we migrate everything to the org namespace and org credentials are created in the org namespace instead of the default namespace.
+func (r *Resource) getLegacyCredentialSecret(ctx context.Context, objectMeta v1.ObjectMeta) (*v1alpha1.CredentialSecret, error) {
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("try in namespace %#q filtering by organization %#q", objectMeta.Namespace, key.OrganizationID(&objectMeta)))
+	secretList := &corev1.SecretList{}
+	{
+		err := r.ctrlClient.List(
+			ctx,
+			secretList,
+			client.InNamespace(credentialDefaultNamespace),
+			client.MatchingLabels{
+				label.App:                        "credentiald",
+				apiextensionslabels.Organization: key.OrganizationID(&objectMeta),
+			},
+		)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	// We currently only support one credential secret per organization.
+	// If there are more than one, return an error.
+	if len(secretList.Items) > 1 {
+		return nil, microerror.Mask(tooManyCredentialsError)
+	}
+
+	if len(secretList.Items) < 1 {
+		return nil, microerror.Mask(credentialsNotFoundError)
+	}
+
+	// If one credential secret is found, we use that.
+	secret := secretList.Items[0]
+
+	credentialSecret := &v1alpha1.CredentialSecret{
+		Namespace: secret.Namespace,
+		Name:      secret.Name,
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found credential secret %s/%s", credentialSecret.Namespace, credentialSecret.Name))
 
 	return credentialSecret, nil
 }

--- a/service/controller/resource/azureclusterconfig/error.go
+++ b/service/controller/resource/azureclusterconfig/error.go
@@ -45,3 +45,12 @@ var tooManyCredentialsError = &microerror.Error{
 func IsTooManyCredentials(err error) bool {
 	return microerror.Cause(err) == tooManyCredentialsError
 }
+
+var credentialsNotFoundError = &microerror.Error{
+	Kind: "credentialsNotFoundError",
+}
+
+// IsCredentialsNotFoundError asserts credentialsNotFoundError.
+func IsCredentialsNotFoundError(err error) bool {
+	return microerror.Cause(err) == credentialsNotFoundError
+}

--- a/service/controller/resource/spark/error.go
+++ b/service/controller/resource/spark/error.go
@@ -70,3 +70,12 @@ var unknownKindError = &microerror.Error{
 func IsUnknownKindError(err error) bool {
 	return microerror.Cause(err) == unknownKindError
 }
+
+var credentialsNotFoundError = &microerror.Error{
+	Kind: "credentialsNotFoundError",
+}
+
+// IsCredentialsNotFoundError asserts credentialsNotFoundError.
+func IsCredentialsNotFoundError(err error) bool {
+	return microerror.Cause(err) == credentialsNotFoundError
+}

--- a/service/controller/resource/spark/resource.go
+++ b/service/controller/resource/spark/resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/v2/pkg/apis/provider/v1alpha1"
+	apiextensionslabels "github.com/giantswarm/apiextensions/v2/pkg/label"
 	"github.com/giantswarm/randomkeys/v2"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -25,7 +26,8 @@ import (
 const (
 	Name = "spark"
 
-	credentialDefaultName = "credential-default"
+	credentialDefaultName      = "credential-default"
+	credentialDefaultNamespace = "giantswarm"
 )
 
 type Config struct {
@@ -182,23 +184,47 @@ func (r *Resource) toEncrypterObject(ctx context.Context, secretName string) (en
 	return enc, nil
 }
 
-func (r *Resource) getCredentialSecret(ctx context.Context, azureMachinePool v1.ObjectMeta) (*v1alpha1.CredentialSecret, error) {
+func secretName(base string) string {
+	return base + "-machine-pool-ignition"
+}
+
+func (r *Resource) getCredentialSecret(ctx context.Context, objectMeta v1.ObjectMeta) (*v1alpha1.CredentialSecret, error) {
 	r.logger.LogCtx(ctx, "level", "debug", "message", "finding credential secret")
 
-	organization, exists := azureMachinePool.GetLabels()[label.Organization]
-	if !exists {
-		return nil, microerror.Mask(missingOrganizationLabel)
+	var err error
+	var credentialSecret *v1alpha1.CredentialSecret
+
+	credentialSecret, err = r.getOrganizationCredentialSecret(ctx, objectMeta)
+	if IsCredentialsNotFoundError(err) {
+		credentialSecret, err = r.getLegacyCredentialSecret(ctx, objectMeta)
+		if IsCredentialsNotFoundError(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("did not find credential secret, using default '%s/%s'", credentialDefaultNamespace, credentialDefaultName))
+			return &v1alpha1.CredentialSecret{
+				Namespace: credentialDefaultNamespace,
+				Name:      credentialDefaultName,
+			}, nil
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	} else if err != nil {
+		return nil, microerror.Mask(err)
 	}
 
+	return credentialSecret, nil
+}
+
+// getOrganizationCredentialSecret tries to find a Secret in the organization namespace.
+func (r *Resource) getOrganizationCredentialSecret(ctx context.Context, objectMeta v1.ObjectMeta) (*v1alpha1.CredentialSecret, error) {
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("try in namespace %#q filtering by organization %#q", objectMeta.Namespace, key.OrganizationID(&objectMeta)))
 	secretList := &corev1.SecretList{}
 	{
 		err := r.ctrlClient.List(
 			ctx,
 			secretList,
-			client.InNamespace(azureMachinePool.Namespace),
+			client.InNamespace(objectMeta.Namespace),
 			client.MatchingLabels{
-				label.App:          "credentiald",
-				label.Organization: organization,
+				label.App:                        "credentiald",
+				apiextensionslabels.Organization: key.OrganizationID(&objectMeta),
 			},
 		)
 		if err != nil {
@@ -212,31 +238,62 @@ func (r *Resource) getCredentialSecret(ctx context.Context, azureMachinePool v1.
 		return nil, microerror.Mask(tooManyCredentialsError)
 	}
 
+	if len(secretList.Items) < 1 {
+		return nil, microerror.Mask(credentialsNotFoundError)
+	}
+
 	// If one credential secret is found, we use that.
-	if len(secretList.Items) == 1 {
-		secret := secretList.Items[0]
+	secret := secretList.Items[0]
 
-		credentialSecret := &v1alpha1.CredentialSecret{
-			Namespace: secret.Namespace,
-			Name:      secret.Name,
-		}
-
-		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found credential secret %s/%s", credentialSecret.Namespace, credentialSecret.Name))
-
-		return credentialSecret, nil
-	}
-
-	// If no credential secrets are found, we use the default.
 	credentialSecret := &v1alpha1.CredentialSecret{
-		Namespace: azureMachinePool.Namespace,
-		Name:      credentialDefaultName,
+		Namespace: secret.Namespace,
+		Name:      secret.Name,
 	}
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", "did not find credential secret, using default secret")
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found credential secret %s/%s", credentialSecret.Namespace, credentialSecret.Name))
 
 	return credentialSecret, nil
 }
 
-func secretName(base string) string {
-	return base + "-machine-pool-ignition"
+// getLegacyCredentialSecret tries to find a Secret in the default credentials namespace but labeled with the organization name.
+// This is needed while we migrate everything to the org namespace and org credentials are created in the org namespace instead of the default namespace.
+func (r *Resource) getLegacyCredentialSecret(ctx context.Context, objectMeta v1.ObjectMeta) (*v1alpha1.CredentialSecret, error) {
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("try in namespace %#q filtering by organization %#q", objectMeta.Namespace, key.OrganizationID(&objectMeta)))
+	secretList := &corev1.SecretList{}
+	{
+		err := r.ctrlClient.List(
+			ctx,
+			secretList,
+			client.InNamespace(credentialDefaultNamespace),
+			client.MatchingLabels{
+				label.App:                        "credentiald",
+				apiextensionslabels.Organization: key.OrganizationID(&objectMeta),
+			},
+		)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	// We currently only support one credential secret per organization.
+	// If there are more than one, return an error.
+	if len(secretList.Items) > 1 {
+		return nil, microerror.Mask(tooManyCredentialsError)
+	}
+
+	if len(secretList.Items) < 1 {
+		return nil, microerror.Mask(credentialsNotFoundError)
+	}
+
+	// If one credential secret is found, we use that.
+	secret := secretList.Items[0]
+
+	credentialSecret := &v1alpha1.CredentialSecret{
+		Namespace: secret.Namespace,
+		Name:      secret.Name,
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found credential secret %s/%s", credentialSecret.Namespace, credentialSecret.Name))
+
+	return credentialSecret, nil
 }


### PR DESCRIPTION
Using the same fallback approach in the handlers that own their own logic to fetch the credentials.