### PR TITLE
Safe scale up

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.0-whites"
+	version            = "5.0.0-dev"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.0-dev"
+	version            = "5.0.0-whites"
 )
 
 func Description() string {

--- a/service/controller/resource/nodepool/create_scale_workers.go
+++ b/service/controller/resource/nodepool/create_scale_workers.go
@@ -69,6 +69,7 @@ func (r *Resource) scaleUpWorkerVMSSTransition(ctx context.Context, obj interfac
 	switch *currentDeployment.Properties.ProvisioningState {
 	case "Failed", "Canceled":
 		// Deployment is failed or canceled, I need to go back and re-apply it.
+		r.Logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Node Pool deployment is in state %s, we need to reapply it.", *currentDeployment.Properties.ProvisioningState))
 		return DeploymentUninitialized, nil
 	case "Succeeded":
 		// Deployment is succeeded, safe to go on.


### PR DESCRIPTION
When there is a change that requires the rollout of all nodes in a node pool, we apply the deployment and then we proceed with the rollout (we double the size of the NP, cordon old nodes and delete them once drained).
This PR ensures the deployment is applied successfully before it proceeds with the scaling operations, because it happened that we rolled out the nodes despite the deployment was not applied (thus doing the rollout for no reason).