### PR TITLE
Gracefully handle if owner reference is not set

### DIFF
--- a/service/controller/resource/spark/error.go
+++ b/service/controller/resource/spark/error.go
@@ -53,15 +53,6 @@ func IsMissingOrganizationLabel(err error) bool {
 	return microerror.Cause(err) == missingOrganizationLabel
 }
 
-var ownerReferenceNotSet = &microerror.Error{
-	Kind: "ownerReferenceNotSet",
-}
-
-// IsOwnerReferenceNotSet asserts ownerReferenceNotSet.
-func IsOwnerReferenceNotSet(err error) bool {
-	return microerror.Cause(err) == ownerReferenceNotSet
-}
-
 var unknownKindError = &microerror.Error{
 	Kind: "unknownKindError",
 }


### PR DESCRIPTION
Instead of printing out an error in this case, let's just cancel the whole reconciliation and wait until it's done.