### PR TITLE
Use cluster CIDR for security groups & configuration with node pools

### DIFF
--- a/service/controller/resource/deployment/deployment.go
+++ b/service/controller/resource/deployment/deployment.go
@@ -46,7 +46,7 @@ func (r Resource) newDeployment(ctx context.Context, customObject providerv1alph
 		"virtualNetworkName":         key.VnetName(customObject),
 		"vnetGatewaySubnetName":      key.VNetGatewaySubnetName(),
 		"vpnSubnetCidr":              vpnSubnet.String(),
-		"workerSubnetCidr":           key.WorkersSubnetCIDR(customObject),
+		"workerSubnetCidr":           key.AzureConfigNetworkCIDR(customObject),
 	}
 
 	armTemplate, err := template.GetARMTemplate()


### PR DESCRIPTION
Since there are no built-in workers anymore but each node pool gets own subnet,
it makes more sense to relax security rules to whole tenant cluster CIDR.