### PR TITLE
Set cluster domain so that kubernetes DNS service discovery works

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.0-dev"
+	version            = "5.0.0-dns"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.0-dns"
+	version            = "5.0.0-dev"
 )
 
 func Description() string {

--- a/service/controller/resource/azureconfig/create.go
+++ b/service/controller/resource/azureconfig/create.go
@@ -25,8 +25,9 @@ import (
 const (
 	dockerVolumeSizeGB  = 50
 	kubeletVolumeSizeGB = 100
-
-	kubeDNSIPLastOctet = 10
+	// DNS domain for dns searches in pods.
+	kubeletClusterDomain = "cluster.local"
+	kubeDNSIPLastOctet   = 10
 
 	ProviderAzure = "azure"
 )
@@ -379,6 +380,10 @@ func (r *Resource) newCluster(cluster capiv1alpha3.Cluster, azureCluster capzv1a
 
 		commonCluster.Kubernetes.Kubelet.Domain = kubeletDomain
 		commonCluster.Kubernetes.Kubelet.Labels = kubeletLabels
+	}
+
+	{
+		commonCluster.Kubernetes.Domain = kubeletClusterDomain
 	}
 
 	{

--- a/service/controller/resource/spark/create.go
+++ b/service/controller/resource/spark/create.go
@@ -41,8 +41,10 @@ import (
 const (
 	dockerVolumeSizeGB  = 50
 	kubeletVolumeSizeGB = 100
-	kubeDNSIPLastOctet  = 10
-	ProviderAzure       = "azure"
+	// DNS domain for dns searches in pods.
+	kubeletClusterDomain = "cluster.local"
+	kubeDNSIPLastOctet   = 10
+	ProviderAzure        = "azure"
 )
 
 // EnsureCreated is checking if corresponding Spark CRD exists. In that case it renders
@@ -621,6 +623,10 @@ func (r *Resource) newCluster(cluster *capiv1alpha3.Cluster, azureCluster *capzv
 
 		commonCluster.Kubernetes.Kubelet.Domain = kubeletDomain
 		commonCluster.Kubernetes.Kubelet.Labels = kubeletLabels
+	}
+
+	{
+		commonCluster.Kubernetes.Domain = kubeletClusterDomain
 	}
 
 	{


### PR DESCRIPTION
Service discovery was not working on kubernetes unless using the FQDN.

I found [this kubelet property](https://github.com/kubernetes/kubernetes/blob/ee297b6f4d78daaf2f71c78a05203698581ca40a/staging/src/k8s.io/kubelet/config/v1beta1/types.go#L288-L290) that controls the DNS queries, and we are setting that configuration [in our templates](https://github.com/giantswarm/k8scloudconfig/blob/a7a5b5e2054ff0e5d3e5892b035a301c7b4a7653/files/config/kubelet-worker.yaml.tmpl#L9). The problem is that the variable is empty: we are never setting that field.

It was working before because [`kubernetesd` was setting that field](https://github.com/giantswarm/kubernetesd/blob/ceef853b2ec6693f588191be224e48d59db83b6e/service/creator/cluster.go#L92) when creating the `AzureConfig`.

I don't think CAPI/CAPZ types allow to customize this value, so we only need to set it when the mapping creates the `AzureConfig` CR, not the other way around. Once we finish the migration, this value would be hardcoded/defaulted: it won't come from the CAPI/CAPZ CR.