### PR TITLE
Add normalization function for organization namespaces

### DIFF
--- a/pkg/normalize/normalize.go
+++ b/pkg/normalize/normalize.go
@@ -1,0 +1,51 @@
+package normalize
+
+import (
+	"strings"
+	"unicode"
+)
+
+const maxDNSLabelLength = 63
+
+// AsDNSLabelName normalizes input string to be valid DNS label name so that it
+// can be used as Kubernetes object identifier such as namespace name.
+//
+// NOTE: This function returns an empty string if input string consists of only
+//		 non-allowed characters.
+//
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+func AsDNSLabelName(v string) string {
+	var xs []rune
+
+	for _, x := range []rune(strings.ToLower(v)) {
+
+		// Is x in whitelisted characters?
+		if x == '-' || unicode.IsDigit(x) || ('a' <= x && x <= 'z') {
+			xs = append(xs, x)
+		} else if len(xs) > 0 && xs[len(xs)-1] != '-' {
+			// If not, append dash and coalesce consequtive ones.
+			xs = append(xs, '-')
+		}
+	}
+
+	// Ensure that the string doesn't start or end with dash.
+	for len(xs) > 0 {
+		if xs[0] == '-' {
+			xs = xs[1:]
+			continue
+		}
+
+		if xs[len(xs)-1] == '-' {
+			xs = xs[:len(xs)-1]
+			continue
+		}
+
+		break
+	}
+
+	if len(xs) > maxDNSLabelLength {
+		xs = xs[:maxDNSLabelLength]
+	}
+
+	return string(xs)
+}

--- a/pkg/normalize/normalize.go
+++ b/pkg/normalize/normalize.go
@@ -17,7 +17,7 @@ const maxDNSLabelLength = 63
 func AsDNSLabelName(v string) string {
 	var xs []rune
 
-	for _, x := range []rune(strings.ToLower(v)) {
+	for _, x := range strings.ToLower(v) {
 
 		// Is x in whitelisted characters?
 		if x == '-' || unicode.IsDigit(x) || ('a' <= x && x <= 'z') {

--- a/pkg/normalize/normalize_test.go
+++ b/pkg/normalize/normalize_test.go
@@ -1,0 +1,99 @@
+package normalize
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Test_AsDNSLabelName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "case 0: Uppercase input",
+			input:    "Foobar",
+			expected: "foobar",
+		},
+		{
+			name:     "case 1: Uppercase input",
+			input:    "FooBar",
+			expected: "foobar",
+		},
+		{
+			name:     "case 2: Uppercase input",
+			input:    "FOOBAR",
+			expected: "foobar",
+		},
+		{
+			name:     "case 3: Lower input",
+			input:    "foobar",
+			expected: "foobar",
+		},
+		{
+			name:     "case 4: Input with dot",
+			input:    "foo.bar",
+			expected: "foo-bar",
+		},
+		{
+			name:     "case 5: Input with consequtive dots",
+			input:    "foo..bar",
+			expected: "foo-bar",
+		},
+		{
+			name:     "case 6: Input with different punctuations",
+			input:    "f\"\"oo!;ba_r",
+			expected: "f-oo-ba-r",
+		},
+		{
+			name:     "case 7: Input with dot in the beginning",
+			input:    ".foobar",
+			expected: "foobar",
+		},
+		{
+			name:     "case 8: Input with dot in the end",
+			input:    "foobar.",
+			expected: "foobar",
+		},
+		{
+			name:     "case 9: Input with dot all over the place",
+			input:    ".foo-bar.",
+			expected: "foo-bar",
+		},
+		{
+			name:     "case 10: Input with dot all over the place",
+			input:    "...foo-bar.",
+			expected: "foo-bar",
+		},
+		{
+			name:     "case 11: Input with dot all over the place",
+			input:    "...foo-bar.....",
+			expected: "foo-bar",
+		},
+		{
+			name:     "case 12: Input without whitelisted characters",
+			input:    ".*/!_*()[]%^\\.",
+			expected: "",
+		},
+		{
+			name:     "case 13: Way too long input",
+			input:    "my.input.string.is.way.too.long.to.be.an.individual.dns.label.name.given.that.there.are.all.these.letters.and.other.punctuations.",
+			expected: "my-input-string-is-way-too-long-to-be-an-individual-dns-label-n",
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			t.Log(tc.name)
+
+			output := AsDNSLabelName(tc.input)
+
+			if !cmp.Equal(output, tc.expected) {
+				t.Fatalf("\n\n%s\n", cmp.Diff(tc.expected, output))
+			}
+		})
+	}
+}


### PR DESCRIPTION
In order to normalize free form organization names into namespaces, it must be
converted into lower case string and non-alphanumeric (+ dash) characters must
be converted / stripped. The length of the string must also be limited.