### PR TITLE
Encryption secret should live in the same namespace than the CR

### DIFF
--- a/service/controller/cloudconfig/cloud_config.go
+++ b/service/controller/cloudconfig/cloud_config.go
@@ -101,7 +101,7 @@ func (c CloudConfig) getEncryptionkey(ctx context.Context, customObject provider
 		err := c.ctrlClient.List(
 			ctx,
 			secretList,
-			ctrl.InNamespace(key.OrganizationNamespace(&customObject)),
+			ctrl.InNamespace(customObject.Namespace),
 			ctrl.MatchingLabels{
 				randomKeyLabel:              randomKeyLabelValue,
 				apiextensionslabels.Cluster: key.ClusterID(&customObject),

--- a/service/controller/key/common.go
+++ b/service/controller/key/common.go
@@ -50,10 +50,6 @@ func OrganizationID(getter LabelsGetter) string {
 	return getter.GetLabels()[label.Organization]
 }
 
-func OrganizationNamespace(getter LabelsGetter) string {
-	return fmt.Sprintf("org-%s", getter.GetLabels()[label.Organization])
-}
-
 func ReleaseVersion(getter LabelsGetter) string {
 	return getter.GetLabels()[label.ReleaseVersion]
 }


### PR DESCRIPTION
We were using the wrong namespace name, because org namespaces are all lowercase, but the organization label is not lowercase.

So I figured: this was the only part in azure-operator where the `organization` namespace shows up. So what about removing that and just use the CR namespace? That way azure-operator doesn't care about the org namespace , or its format: it just uses whatever namespace the CR is in.