### PR TITLE
Try to send only one request to VMSS Azure API from nodepool handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Try to send only one request to VMSS Azure API from `nodepool` handler.
+
 ## [5.0.0-alpha2] - 2020-10-14
 
 ### Fixed

--- a/service/controller/resource/nodepool/create_deployment_uninitialized.go
+++ b/service/controller/resource/nodepool/create_deployment_uninitialized.go
@@ -91,7 +91,7 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 	}
 
 	// Compute desired state for Azure ARM Deployment.
-	desiredDeployment, err := r.getDesiredDeployment(ctx, storageAccountsClient, release, machinePool, &azureMachinePool, cluster, azureCluster, vmss)
+	desiredDeployment, err := r.getDesiredDeployment(ctx, storageAccountsClient, release, machinePool, &azureMachinePool, azureCluster, vmss)
 	if IsNotFound(err) {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "Azure resource not found", "stack", microerror.JSON(err))
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
@@ -160,7 +160,7 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "ARM deployment has failed, re-applying")
 		r.Debugger.LogFailedDeployment(ctx, currentDeployment, err)
 
-		err := r.saveAzureIDsInCR(ctx, virtualMachineScaleSetsClient, virtualMachineScaleSetVMsClient, &azureMachinePool, vmss)
+		err := r.saveAzureIDsInCR(ctx, virtualMachineScaleSetVMsClient, &azureMachinePool, vmss)
 		if err != nil {
 			r.Logger.LogCtx(ctx, "level", "debug", "message", "error trying to save object in k8s API", "stack", microerror.JSON(microerror.Mask(err)))
 			r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
@@ -182,7 +182,7 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 	default:
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "template and parameters unchanged")
 
-		err := r.saveAzureIDsInCR(ctx, virtualMachineScaleSetsClient, virtualMachineScaleSetVMsClient, &azureMachinePool, vmss)
+		err := r.saveAzureIDsInCR(ctx, virtualMachineScaleSetVMsClient, &azureMachinePool, vmss)
 		if err != nil {
 			r.Logger.LogCtx(ctx, "level", "debug", "message", "error trying to save object in k8s API", "stack", microerror.JSON(microerror.Mask(err)))
 			r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
@@ -194,7 +194,7 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 	}
 }
 
-func (r *Resource) saveAzureIDsInCR(ctx context.Context, virtualMachineScaleSetsClient *compute.VirtualMachineScaleSetsClient, virtualMachineScaleSetVMsClient *compute.VirtualMachineScaleSetVMsClient, azureMachinePool *capzexpv1alpha3.AzureMachinePool, vmss compute.VirtualMachineScaleSet) error {
+func (r *Resource) saveAzureIDsInCR(ctx context.Context, virtualMachineScaleSetVMsClient *compute.VirtualMachineScaleSetVMsClient, azureMachinePool *capzexpv1alpha3.AzureMachinePool, vmss compute.VirtualMachineScaleSet) error {
 	r.Logger.LogCtx(ctx, "level", "debug", "message", "saving provider status info in CR")
 
 	instances, err := r.GetVMSSInstances(ctx, virtualMachineScaleSetVMsClient, key.ClusterID(azureMachinePool), key.NodePoolVMSSName(azureMachinePool))

--- a/service/controller/resource/nodepool/create_deployment_uninitialized.go
+++ b/service/controller/resource/nodepool/create_deployment_uninitialized.go
@@ -83,8 +83,15 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 		return currentState, microerror.Mask(err)
 	}
 
+	vmss, err := virtualMachineScaleSetsClient.Get(ctx, key.ClusterID(&azureMachinePool), key.NodePoolVMSSName(&azureMachinePool))
+	if IsNotFound(err) {
+		// We haven't created the VMSS just yet, it's fine.
+	} else if err != nil {
+		return currentState, microerror.Mask(err)
+	}
+
 	// Compute desired state for Azure ARM Deployment.
-	desiredDeployment, err := r.getDesiredDeployment(ctx, storageAccountsClient, release, machinePool, &azureMachinePool, cluster, azureCluster)
+	desiredDeployment, err := r.getDesiredDeployment(ctx, storageAccountsClient, release, machinePool, &azureMachinePool, cluster, azureCluster, vmss)
 	if IsNotFound(err) {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "Azure resource not found", "stack", microerror.JSON(err))
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
@@ -153,7 +160,7 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "ARM deployment has failed, re-applying")
 		r.Debugger.LogFailedDeployment(ctx, currentDeployment, err)
 
-		err := r.saveAzureIDsInCR(ctx, virtualMachineScaleSetsClient, virtualMachineScaleSetVMsClient, &azureMachinePool)
+		err := r.saveAzureIDsInCR(ctx, virtualMachineScaleSetsClient, virtualMachineScaleSetVMsClient, &azureMachinePool, vmss)
 		if err != nil {
 			r.Logger.LogCtx(ctx, "level", "debug", "message", "error trying to save object in k8s API", "stack", microerror.JSON(microerror.Mask(err)))
 			r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
@@ -175,7 +182,7 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 	default:
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "template and parameters unchanged")
 
-		err := r.saveAzureIDsInCR(ctx, virtualMachineScaleSetsClient, virtualMachineScaleSetVMsClient, &azureMachinePool)
+		err := r.saveAzureIDsInCR(ctx, virtualMachineScaleSetsClient, virtualMachineScaleSetVMsClient, &azureMachinePool, vmss)
 		if err != nil {
 			r.Logger.LogCtx(ctx, "level", "debug", "message", "error trying to save object in k8s API", "stack", microerror.JSON(microerror.Mask(err)))
 			r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
@@ -187,13 +194,8 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 	}
 }
 
-func (r *Resource) saveAzureIDsInCR(ctx context.Context, virtualMachineScaleSetsClient *compute.VirtualMachineScaleSetsClient, virtualMachineScaleSetVMsClient *compute.VirtualMachineScaleSetVMsClient, azureMachinePool *capzexpv1alpha3.AzureMachinePool) error {
+func (r *Resource) saveAzureIDsInCR(ctx context.Context, virtualMachineScaleSetsClient *compute.VirtualMachineScaleSetsClient, virtualMachineScaleSetVMsClient *compute.VirtualMachineScaleSetVMsClient, azureMachinePool *capzexpv1alpha3.AzureMachinePool, vmss compute.VirtualMachineScaleSet) error {
 	r.Logger.LogCtx(ctx, "level", "debug", "message", "saving provider status info in CR")
-
-	vmss, err := virtualMachineScaleSetsClient.Get(ctx, key.ClusterID(azureMachinePool), key.NodePoolVMSSName(azureMachinePool))
-	if err != nil {
-		return microerror.Mask(err)
-	}
 
 	instances, err := r.GetVMSSInstances(ctx, virtualMachineScaleSetVMsClient, key.ClusterID(azureMachinePool), key.NodePoolVMSSName(azureMachinePool))
 	if err != nil {

--- a/service/controller/resource/nodepool/deployment.go
+++ b/service/controller/resource/nodepool/deployment.go
@@ -31,7 +31,7 @@ import (
 	"github.com/giantswarm/azure-operator/v5/service/controller/resource/nodepool/template"
 )
 
-func (r Resource) getDesiredDeployment(ctx context.Context, storageAccountsClient *storage.AccountsClient, release *releasev1alpha1.Release, machinePool *capiexpv1alpha3.MachinePool, azureMachinePool *capzexpv1alpha3.AzureMachinePool, cluster *capiv1alpha3.Cluster, azureCluster *capzv1alpha3.AzureCluster) (azureresource.Deployment, error) {
+func (r Resource) getDesiredDeployment(ctx context.Context, storageAccountsClient *storage.AccountsClient, release *releasev1alpha1.Release, machinePool *capiexpv1alpha3.MachinePool, azureMachinePool *capzexpv1alpha3.AzureMachinePool, cluster *capiv1alpha3.Cluster, azureCluster *capzv1alpha3.AzureCluster, vmss compute.VirtualMachineScaleSet) (azureresource.Deployment, error) {
 	encrypterObject, err := r.getEncrypterObject(ctx, key.CertificateEncryptionSecretName(azureCluster))
 	if err != nil {
 		return azureresource.Deployment{}, microerror.Mask(err)
@@ -60,17 +60,9 @@ func (r Resource) getDesiredDeployment(ctx context.Context, storageAccountsClien
 
 	currentReplicas := key.NodePoolMinReplicas(machinePool)
 	if key.NodePoolMinReplicas(machinePool) != key.NodePoolMaxReplicas(machinePool) {
-		// Autoscaler is enabled, will need to get the current number of replicas from the VMSS.
-		candidate, err := r.getVMSScurrentScaling(ctx, cluster, azureCluster.GetName(), key.NodePoolVMSSName(azureMachinePool))
-		if IsNotFound(err) {
-			// It's ok. VMSS not created yet.
-		} else if err != nil {
-			return azureresource.Deployment{}, microerror.Mask(err)
-		}
-
-		// Function getVMSScurrentScaling returns 0 when the VMSS is not found.
-		if candidate > 0 {
-			currentReplicas = candidate
+		// Autoscaler is enabled. Will need to use the current number of replicas from the VMSS if it exists.
+		if !vmss.IsHTTPStatus(404) {
+			currentReplicas = int32(*vmss.Sku.Capacity)
 		}
 	}
 
@@ -81,19 +73,21 @@ func (r Resource) getDesiredDeployment(ctx context.Context, storageAccountsClien
 			enableAcceleratedNetworking = *azureMachinePool.Spec.Template.AcceleratedNetworking
 		} else {
 			// The flag is not set.
-			enabled, err := r.vmssHasAcceleratedNetworkingEnabled(ctx, cluster, azureCluster.GetName(), key.NodePoolVMSSName(azureMachinePool))
-			if IsNotFound(err) {
+			if vmss.IsHTTPStatus(404) {
 				// Scale set does not exist yet.
 				// We want to enable accelerated networking only if VM type supports it.
 				enableAcceleratedNetworking, err = r.vmsku.HasCapability(ctx, azureMachinePool.Spec.Template.VMSize, vmsku.CapabilityAcceleratedNetworking)
 				if err != nil {
 					return azureresource.Deployment{}, microerror.Mask(err)
 				}
-			} else if err != nil {
-				return azureresource.Deployment{}, microerror.Mask(err)
 			} else {
 				// VMSS already exists, we want to stick with what is the current situation.
-				enableAcceleratedNetworking = enabled
+				cfgs := vmss.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
+				if cfgs != nil && len(*cfgs) > 0 {
+					enableAcceleratedNetworking = *(*cfgs)[0].EnableAcceleratedNetworking
+				} else {
+					return azureresource.Deployment{}, microerror.Mask(unexpectedUpstreamResponseError)
+				}
 			}
 		}
 	}
@@ -143,48 +137,6 @@ func (r Resource) getSubnetName(azureMachinePool *capzexpv1alpha3.AzureMachinePo
 	}
 
 	return "", "", microerror.Maskf(notFoundError, "there is no allocated subnet for nodepool %#q in virtual network called %#q", azureMachinePool.Name, azureCluster.Spec.NetworkSpec.Vnet.ID)
-}
-
-func (r *Resource) vmssHasAcceleratedNetworkingEnabled(ctx context.Context, cluster *capiv1alpha3.Cluster, resourceGroupName string, vmssName string) (bool, error) {
-	npVMSS, err := r.getVMSS(ctx, cluster, resourceGroupName, vmssName)
-	if err != nil {
-		return false, microerror.Mask(err)
-	}
-
-	cfgs := npVMSS.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
-	if cfgs != nil && len(*cfgs) > 0 {
-		cfg := (*cfgs)[0]
-		return *cfg.EnableAcceleratedNetworking, nil
-	}
-
-	// Unexpected response from azure.
-	return false, microerror.Mask(unexpectedUpstreamResponseError)
-}
-
-func (r *Resource) getVMSScurrentScaling(ctx context.Context, cluster *capiv1alpha3.Cluster, resourceGroupName string, vmssName string) (int32, error) {
-	npVMSS, err := r.getVMSS(ctx, cluster, resourceGroupName, vmssName)
-	if err != nil {
-		return -1, microerror.Mask(err)
-	}
-
-	capacity64 := *npVMSS.Sku.Capacity
-
-	// Unsafe type casting in theory, but in practice the capacity will never reach numbers not even close to 2^32.
-	return int32(capacity64), nil
-}
-
-func (r *Resource) getVMSS(ctx context.Context, cluster *capiv1alpha3.Cluster, resourceGroupName string, vmssName string) (*compute.VirtualMachineScaleSet, error) {
-	client, err := r.ClientFactory.GetVirtualMachineScaleSetsClient(ctx, cluster.ObjectMeta)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	npVMSS, err := client.Get(ctx, resourceGroupName, vmssName)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	return &npVMSS, nil
 }
 
 func (r *Resource) getWorkerCloudConfig(ctx context.Context, storageAccountsClient *storage.AccountsClient, resourceGroupName, storageAccountName, containerName, workerBlobName string, encrypterObject encrypter.Interface) (string, error) {

--- a/service/controller/resource/nodepool/deployment.go
+++ b/service/controller/resource/nodepool/deployment.go
@@ -31,7 +31,7 @@ import (
 	"github.com/giantswarm/azure-operator/v5/service/controller/resource/nodepool/template"
 )
 
-func (r Resource) getDesiredDeployment(ctx context.Context, storageAccountsClient *storage.AccountsClient, release *releasev1alpha1.Release, machinePool *capiexpv1alpha3.MachinePool, azureMachinePool *capzexpv1alpha3.AzureMachinePool, cluster *capiv1alpha3.Cluster, azureCluster *capzv1alpha3.AzureCluster, vmss compute.VirtualMachineScaleSet) (azureresource.Deployment, error) {
+func (r Resource) getDesiredDeployment(ctx context.Context, storageAccountsClient *storage.AccountsClient, release *releasev1alpha1.Release, machinePool *capiexpv1alpha3.MachinePool, azureMachinePool *capzexpv1alpha3.AzureMachinePool, azureCluster *capzv1alpha3.AzureCluster, vmss compute.VirtualMachineScaleSet) (azureresource.Deployment, error) {
 	encrypterObject, err := r.getEncrypterObject(ctx, key.CertificateEncryptionSecretName(azureCluster))
 	if err != nil {
 		return azureresource.Deployment{}, microerror.Mask(err)


### PR DESCRIPTION
I realized that we were sending several different requests from the `nodepool` handler to fetch the same VMSS. I tried to fetch it once and pass it around so we can save some requests on every reconciliation loop.

I haven't tested it yet. What do you think? 