### PR TITLE
Upgrade from NP release to NP release

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.1-dev"
+	version            = "5.0.1-upgrade"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.0-alpha4"
+	version            = "5.0.1-dev"
 )
 
 func Description() string {

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -19,6 +19,7 @@ import (
 	"github.com/giantswarm/azure-operator/v5/service/controller/resource/clusterconditions"
 	"github.com/giantswarm/azure-operator/v5/service/controller/resource/clusterdependents"
 	"github.com/giantswarm/azure-operator/v5/service/controller/resource/clusterownerreference"
+	"github.com/giantswarm/azure-operator/v5/service/controller/resource/clusterupgrade"
 	"github.com/giantswarm/azure-operator/v5/service/controller/setting"
 )
 
@@ -119,10 +120,24 @@ func NewClusterResourceSet(config ClusterConfig) ([]resource.Interface, error) {
 		}
 	}
 
+	var clusterUpgradeResource resource.Interface
+	{
+		c := clusterupgrade.Config{
+			CtrlClient: config.K8sClient.CtrlClient(),
+			Logger:     config.Logger,
+		}
+
+		clusterUpgradeResource, err = clusterupgrade.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []resource.Interface{
 		clusterConditionsResource,
 		clusterDependentsResource,
 		ownerReferencesResource,
+		clusterUpgradeResource,
 	}
 
 	{

--- a/service/controller/machine_pool.go
+++ b/service/controller/machine_pool.go
@@ -22,6 +22,7 @@ import (
 	"github.com/giantswarm/azure-operator/v5/service/controller/resource/machinepoolconditions"
 	"github.com/giantswarm/azure-operator/v5/service/controller/resource/machinepooldependents"
 	"github.com/giantswarm/azure-operator/v5/service/controller/resource/machinepoolownerreference"
+	"github.com/giantswarm/azure-operator/v5/service/controller/resource/machinepoolupgrade"
 	"github.com/giantswarm/azure-operator/v5/service/controller/resource/nodestatus"
 )
 
@@ -159,11 +160,25 @@ func NewMachinePoolResourceSet(config MachinePoolConfig) ([]resource.Interface, 
 		}
 	}
 
+	var machinepoolUpgradeResource resource.Interface
+	{
+		c := machinepoolupgrade.Config{
+			CtrlClient: config.K8sClient.CtrlClient(),
+			Logger:     config.Logger,
+		}
+
+		machinepoolUpgradeResource, err = machinepoolupgrade.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []resource.Interface{
 		machinePoolConditionsResource,
 		machinepoolDependentsResource,
 		ownerReferencesResource,
 		nodestatusResource,
+		machinepoolUpgradeResource,
 	}
 
 	{

--- a/service/controller/resource/capzcrs/create.go
+++ b/service/controller/resource/capzcrs/create.go
@@ -68,31 +68,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			needUpdateFunc: detectAzureClusterUpdate,
 			mergeFunc:      mergeAzureCluster,
 		})
-
-		infraRef := &corev1.ObjectReference{
-			Kind:      "AzureCluster",
-			Name:      cr.Name,
-			Namespace: key.OrganizationNamespace(&cr),
-		}
-		o, err = r.mapAzureConfigToCluster(ctx, cr, infraRef)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-		mappedCRs = append(mappedCRs, crmapping{
-			obj:            o,
-			needUpdateFunc: genericUpdateDetection,
-			mergeFunc:      genericObjectMerge,
-		})
-
-		o, err = r.mapAzureConfigToAzureMachine(ctx, cr)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-		mappedCRs = append(mappedCRs, crmapping{
-			obj:            o,
-			needUpdateFunc: genericUpdateDetection,
-			mergeFunc:      genericObjectMerge,
-		})
 	}
 
 	err = r.updateCRs(ctx, mappedCRs)
@@ -318,14 +293,6 @@ func detectAzureClusterUpdate(orig, desired runtime.Object) (bool, error) {
 	o := orig.(*capzv1alpha3.AzureCluster)
 	d := desired.(*capzv1alpha3.AzureCluster)
 
-	if !cmp.Equal(d.GetLabels(), o.GetLabels()) {
-		return true, nil
-	}
-
-	if !cmp.Equal(d.GetAnnotations(), o.GetAnnotations()) {
-		return true, nil
-	}
-
 	if !cmp.Equal(d, o, cmpopts.IgnoreTypes(&metav1.ObjectMeta{}), cmpopts.IgnoreTypes(&metav1.TypeMeta{}, cmpopts.IgnoreTypes(&capzv1alpha3.Subnets{}))) {
 		return true, nil
 	}
@@ -337,84 +304,13 @@ func mergeAzureCluster(orig, desired runtime.Object) (runtime.Object, error) {
 	o := orig.(*capzv1alpha3.AzureCluster)
 	d := desired.(*capzv1alpha3.AzureCluster)
 
-	labels := o.GetLabels()
-	for k, v := range d.GetLabels() {
-		labels[k] = v
-	}
-	// Set merged labels on desired object as that's the one we write
-	// in update.
-	d.SetLabels(labels)
-
-	annotations := o.GetAnnotations()
-	for k, v := range d.GetAnnotations() {
-		annotations[k] = v
-	}
-	// Set merged labels on desired object as that's the one we write
-	// in update.
-	d.SetAnnotations(annotations)
-
-	// Maintain existing subnets.
-	d.Spec.NetworkSpec.Subnets = o.Spec.NetworkSpec.Subnets
+	// Only copy specific parts of desired opbject
+	o.Spec.NetworkSpec.Vnet = d.Spec.NetworkSpec.Vnet
+	o.Spec.ResourceGroup = d.Spec.ResourceGroup
+	o.Spec.Location = d.Spec.Location
+	o.Spec.ControlPlaneEndpoint = d.Spec.ControlPlaneEndpoint
 
 	return d, nil
-}
-
-func genericUpdateDetection(orig, desired runtime.Object) (bool, error) {
-	// Acquire accessors for ObjectMeta fields of CR.
-	desiredMeta, err := meta.Accessor(desired)
-	if err != nil {
-		return false, microerror.Mask(err)
-	}
-
-	readMeta, err := meta.Accessor(orig)
-	if err != nil {
-		return false, microerror.Mask(err)
-	}
-
-	if !cmp.Equal(desiredMeta.GetLabels(), readMeta.GetLabels()) {
-		return true, nil
-	}
-
-	if !cmp.Equal(desiredMeta.GetAnnotations(), readMeta.GetAnnotations()) {
-		return true, nil
-	}
-
-	if !cmp.Equal(desired, orig, cmpopts.IgnoreTypes(&metav1.ObjectMeta{}), cmpopts.IgnoreTypes(&metav1.TypeMeta{})) {
-		return true, nil
-	}
-
-	return false, nil
-}
-
-func genericObjectMerge(orig, desired runtime.Object) (runtime.Object, error) {
-	// Acquire accessors for ObjectMeta fields of CR.
-	desiredMeta, err := meta.Accessor(desired)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	readMeta, err := meta.Accessor(orig)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	labels := readMeta.GetLabels()
-	for k, v := range desiredMeta.GetLabels() {
-		labels[k] = v
-	}
-	// Set merged labels on desired object as that's the one we write
-	// in update.
-	desiredMeta.SetLabels(labels)
-
-	annotations := readMeta.GetAnnotations()
-	for k, v := range desiredMeta.GetAnnotations() {
-		annotations[k] = v
-	}
-	// Set merged labels on desired object as that's the one we write
-	// in update.
-	desiredMeta.SetAnnotations(annotations)
-
-	return desired, nil
 }
 
 func toInt32P(v int32) *int32 {

--- a/service/controller/resource/clusterupgrade/create.go
+++ b/service/controller/resource/clusterupgrade/create.go
@@ -1,0 +1,131 @@
+package clusterupgrade
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	expcapiv1alpha3 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-operator/v5/service/controller/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring that azurecluster has same release label")
+
+	err = r.ensureAzureClusterHasSameRelease(ctx, cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensured that azurecluster has same release label")
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring that machinepools has same release label")
+
+	err = r.propagateReleaseToMachinePools(ctx, cr)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensured that machinepools has same release label")
+
+	return nil
+}
+
+func (r *Resource) ensureAzureClusterHasSameRelease(ctx context.Context, cr capiv1alpha3.Cluster) error {
+	if cr.Spec.InfrastructureRef == nil {
+		return microerror.Maskf(notFoundError, "infrastructure reference not yet set")
+	}
+
+	azureCluster := capzv1alpha3.AzureCluster{}
+	err := r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cr.Namespace, Name: cr.Spec.InfrastructureRef.Name}, &azureCluster)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if cr.Labels[label.ReleaseVersion] == azureCluster.Labels[label.ReleaseVersion] &&
+		cr.Labels[label.AzureOperatorVersion] == azureCluster.Labels[label.AzureOperatorVersion] {
+		// AzureCluster release & operator version already matches. Nothing to do here.
+		return nil
+	}
+
+	azureCluster.Labels[label.AzureOperatorVersion] = cr.Labels[label.AzureOperatorVersion]
+	azureCluster.Labels[label.ReleaseVersion] = cr.Labels[label.ReleaseVersion]
+	err = r.ctrlClient.Update(ctx, &azureCluster)
+	if apierrors.IsConflict(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "conflict trying to save object in k8s API concurrently", "stack", microerror.JSON(microerror.Mask(err)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "cancelling resource")
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) propagateReleaseToMachinePools(ctx context.Context, cr capiv1alpha3.Cluster) error {
+	lst := expcapiv1alpha3.MachinePoolList{}
+	err := r.ctrlClient.List(ctx, &lst, client.MatchingLabels{capiv1alpha3.ClusterLabelName: key.ClusterName(&cr)})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if !hasMachinePoolsUpgradeCompleted(lst.Items, cr.Labels[label.ReleaseVersion]) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "machinepool still upgrading; skipping release propagation")
+		return nil
+	}
+
+	for _, mp := range lst.Items {
+		if cr.Labels[label.ReleaseVersion] != mp.Labels[label.ReleaseVersion] ||
+			cr.Labels[label.AzureOperatorVersion] != mp.Labels[label.AzureOperatorVersion] {
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating release to machinepool %q", mp.Name))
+
+			mp.Labels[label.ReleaseVersion] = cr.Labels[label.ReleaseVersion]
+			mp.Labels[label.AzureOperatorVersion] = cr.Labels[label.AzureOperatorVersion]
+
+			err = r.ctrlClient.Update(ctx, &mp)
+			if apierrors.IsConflict(err) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", "conflict trying to save object in k8s API concurrently", "stack", microerror.JSON(microerror.Mask(err)))
+				r.logger.LogCtx(ctx, "level", "debug", "message", "cancelling resource")
+				return nil
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated release to machinepool %q", mp.Name))
+
+			// Only update one MachinePool CR at a time.
+			break
+		}
+	}
+
+	return nil
+}
+
+func hasMachinePoolsUpgradeCompleted(mps []expcapiv1alpha3.MachinePool, desiredRelease string) bool {
+	for _, mp := range mps {
+		if !IsUpgradeCompleted(mp, desiredRelease) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// XXX: This is just a placeholder for proper IsUpgradeCompleted implementation.
+func IsUpgradeCompleted(mp expcapiv1alpha3.MachinePool, desiredRelease string) bool {
+	condition := capiconditions.Get(&mp, capiv1alpha3.ReadyCondition)
+	return condition.Status == corev1.ConditionTrue
+}

--- a/service/controller/resource/clusterupgrade/delete.go
+++ b/service/controller/resource/clusterupgrade/delete.go
@@ -1,0 +1,9 @@
+package clusterupgrade
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/resource/clusterupgrade/error.go
+++ b/service/controller/resource/clusterupgrade/error.go
@@ -25,9 +25,5 @@ func IsNotFound(err error) bool {
 
 	c := microerror.Cause(err)
 
-	if c == notFoundError {
-		return true
-	}
-
-	return false
+	return c == notFoundError
 }

--- a/service/controller/resource/clusterupgrade/error.go
+++ b/service/controller/resource/clusterupgrade/error.go
@@ -1,0 +1,33 @@
+package clusterupgrade
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	c := microerror.Cause(err)
+
+	if c == notFoundError {
+		return true
+	}
+
+	return false
+}

--- a/service/controller/resource/clusterupgrade/resource.go
+++ b/service/controller/resource/clusterupgrade/resource.go
@@ -1,0 +1,45 @@
+package clusterupgrade
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "clusterupgrade"
+)
+
+type Config struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+}
+
+// Resource ensures that AzureCluster Status Conditions are set.
+type Resource struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return r, nil
+}
+
+// Name returns the resource name.
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/resource/machinepoolownerreference/resource.go
+++ b/service/controller/resource/machinepoolownerreference/resource.go
@@ -64,7 +64,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensuring %#q label and 'ownerReference' fields on MachinePool '%s/%s' and AzureMachinePool '%s/%s'", capiv1alpha3.ClusterLabelName, machinePool.Namespace, machinePool.Name, machinePool.Namespace, machinePool.Spec.Template.Spec.InfrastructureRef.Name))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Ensuring %#q label and 'ownerReference' fields on MachinePool '%s/%s' and AzureMachinePool '%s/%s'", capiv1alpha3.ClusterLabelName, machinePool.Namespace, machinePool.Name, machinePool.Namespace, machinePool.Spec.Template.Spec.InfrastructureRef.Name))
 
 	azureMachinePool := expcapzv1alpha3.AzureMachinePool{}
 	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: machinePool.Namespace, Name: machinePool.Spec.Template.Spec.InfrastructureRef.Name}, &azureMachinePool)

--- a/service/controller/resource/machinepoolupgrade/error.go
+++ b/service/controller/resource/machinepoolupgrade/error.go
@@ -1,0 +1,14 @@
+package machinepoolupgrade
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/machinepoolupgrade/resource.go
+++ b/service/controller/resource/machinepoolupgrade/resource.go
@@ -1,0 +1,101 @@
+package machinepoolupgrade
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	expcapzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-operator/v5/service/controller/key"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "machinepoolupgrade"
+)
+
+type Config struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+}
+
+// Resource ensures that corresponding AzureMachinePool has same release label as reconciled MachinePool.
+type Resource struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return r, nil
+}
+
+// EnsureCreated ensures corresponding AzureMachinePool has same release label as reconciled MachinePool CR.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToMachinePool(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring release labels are set on respective AzureMachinePool")
+
+	azureMachinePool := expcapzv1alpha3.AzureMachinePool{}
+	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cr.Namespace, Name: cr.Spec.Template.Spec.InfrastructureRef.Name}, &azureMachinePool)
+	if apierrors.IsNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("AzureMachinePool %s/%s was not found for MachinePool %#q, skipping setting owner reference", cr.Namespace, cr.Spec.Template.Spec.InfrastructureRef.Name, cr.Name))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "cancelling resource")
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if azureMachinePool.Labels == nil {
+		azureMachinePool.Labels = make(map[string]string)
+	}
+
+	if azureMachinePool.Labels[label.AzureOperatorVersion] != cr.Labels[label.AzureOperatorVersion] ||
+		azureMachinePool.Labels[label.ReleaseVersion] != cr.Labels[label.ReleaseVersion] {
+
+		azureMachinePool.Labels[label.AzureOperatorVersion] = cr.Labels[label.AzureOperatorVersion]
+		azureMachinePool.Labels[label.ReleaseVersion] = cr.Labels[label.ReleaseVersion]
+
+		err = r.ctrlClient.Update(ctx, &azureMachinePool)
+		if apierrors.IsConflict(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "conflict trying to save object in k8s API concurrently", "stack", microerror.JSON(microerror.Mask(err)))
+			r.logger.LogCtx(ctx, "level", "debug", "message", "cancelling resource")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensured release labels are set on respective AzureMachinePool")
+
+	return nil
+}
+
+// EnsureDeleted is no-op.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}
+
+// Name returns the resource name.
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/resource/masters/create_cluster_upgrade_requirement_check.go
+++ b/service/controller/resource/masters/create_cluster_upgrade_requirement_check.go
@@ -2,9 +2,17 @@ package masters
 
 import (
 	"context"
+	"fmt"
 
+	providerv1alpha1 "github.com/giantswarm/apiextensions/v2/pkg/apis/provider/v1alpha1"
+	aeconditions "github.com/giantswarm/apiextensions/v3/pkg/conditions"
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
 	"github.com/giantswarm/microerror"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/azure-operator/v5/pkg/normalize"
 	"github.com/giantswarm/azure-operator/v5/service/controller/internal/state"
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
 	"github.com/giantswarm/azure-operator/v5/service/controller/resource/nodes"
@@ -16,7 +24,11 @@ func (r *Resource) clusterUpgradeRequirementCheckTransition(ctx context.Context,
 		return "", microerror.Mask(err)
 	}
 
-	isCreating := key.IsClusterCreating(cr)
+	isCreating, err := r.isClusterCreating(ctx, &cr)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
 	anyOldNodes, err := nodes.AnyOutOfDate(ctx)
 	if nodes.IsClientNotFound(err) {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster client not found")
@@ -33,4 +45,29 @@ func (r *Resource) clusterUpgradeRequirementCheckTransition(ctx context.Context,
 
 	// Skip instance rolling by default.
 	return WaitForMastersToBecomeReady, nil
+}
+
+func (r *Resource) isClusterCreating(ctx context.Context, cr *providerv1alpha1.AzureConfig) (bool, error) {
+	orgNs := normalize.AsDNSLabelName(fmt.Sprintf("org-%s", cr.Labels[label.Organization]))
+
+	cluster := &capiv1alpha3.Cluster{}
+	err := r.ctrlClient.Get(ctx, client.ObjectKey{Name: cr.Labels[capiv1alpha3.ClusterLabelName], Namespace: orgNs}, cluster)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	// Missing CreatingCondition means that initial reconciliation hasn't
+	// properly kicked in yet. This means the cluster is in very early phase of
+	// creation.
+	if capiconditions.IsUnknown(cluster, aeconditions.CreatingCondition) {
+		return true, nil
+	}
+
+	// Creating == true.
+	if capiconditions.IsTrue(cluster, aeconditions.CreatingCondition) {
+		return true, nil
+	}
+
+	// Creation work is done for now.
+	return false, nil
 }


### PR DESCRIPTION
This change provides first version of implementation that propagates
cluster upgrade in controlled manner over all cluster node pools.

It ensures that Cluster -> AzureCluster CRs have matching release labels
and then propagates these labels to MachinePools one-by-one while
ensuring that there's only one node pool upgrading at a time.

MachinePool labels are then directly ensured on respective
AzureMachinePool CR and corresponding CR's conditions are used to
monitor when given cluster-subset has been upgraded.