### PR TITLE
Add MachinePool Upgrading condition

### DIFF
--- a/pkg/conditions/check.go
+++ b/pkg/conditions/check.go
@@ -1,0 +1,35 @@
+package conditions
+
+import (
+	aeconditions "github.com/giantswarm/apiextensions/v3/pkg/conditions"
+	corev1 "k8s.io/api/core/v1"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
+)
+
+func IsUpgradingTrue(from capiconditions.Getter) bool {
+	return capiconditions.IsTrue(from, aeconditions.UpgradingCondition)
+}
+
+func IsUpgradingFalse(from capiconditions.Getter) bool {
+	return capiconditions.IsFalse(from, aeconditions.UpgradingCondition)
+}
+
+func IsUnexpected(from capiconditions.Getter, t capi.ConditionType) bool {
+	condition := capiconditions.Get(from, t)
+
+	// We expect that condition is not set and that case should be handled
+	// separately where necessary.
+	if condition == nil {
+		return false
+	}
+
+	switch condition.Status {
+	// We expect currently known upstream values: True, False and Unknown.
+	case corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionUnknown:
+		return false
+	// Everything else is not supported.
+	default:
+		return true
+	}
+}

--- a/pkg/conditions/cr.go
+++ b/pkg/conditions/cr.go
@@ -1,0 +1,12 @@
+package conditions
+
+import (
+	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
+
+	"github.com/giantswarm/azure-operator/v5/service/controller/key"
+)
+
+type CR interface {
+	key.LabelsGetter
+	capiconditions.Setter
+}

--- a/pkg/conditions/error.go
+++ b/pkg/conditions/error.go
@@ -1,0 +1,24 @@
+package conditions
+
+import (
+	"github.com/giantswarm/microerror"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
+)
+
+var unexpectedConditionStatusError = &microerror.Error{
+	Kind: "UnexpectedConditionStatus",
+}
+
+func UnexpectedConditionStatusError(cr CR, t capi.ConditionType) error {
+	c := capiconditions.Get(cr, t)
+
+	return microerror.Maskf(
+		unexpectedConditionStatusError,
+		"Unexpected status for condition %s, got %s", t, c.Status)
+}
+
+// IsInvalidCondition asserts invalidConditionError.
+func IsUnexpectedConditionStatus(err error) bool {
+	return microerror.Cause(err) == unexpectedConditionStatusError
+}

--- a/pkg/conditions/upgrading.go
+++ b/pkg/conditions/upgrading.go
@@ -1,0 +1,55 @@
+package conditions
+
+import (
+	aeconditions "github.com/giantswarm/apiextensions/v3/pkg/conditions"
+	"github.com/giantswarm/microerror"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
+
+	"github.com/giantswarm/azure-operator/v5/service/controller/key"
+)
+
+func MarkUpgradingNotStarted(cr CR) error {
+	// Cluster is just being created, no upgrade yet.
+	message := aeconditions.UpgradingConditionMessage{
+		Message:        "Upgrade not started",
+		ReleaseVersion: key.ReleaseVersion(cr),
+	}
+	messageString, err := aeconditions.SerializeUpgradingConditionMessage(message)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	capiconditions.MarkFalse(
+		cr,
+		aeconditions.UpgradingCondition,
+		aeconditions.UpgradeNotStartedReason,
+		capi.ConditionSeverityInfo,
+		messageString)
+
+	return nil
+}
+
+func MarkUpgradingStarted(cr CR) {
+	capiconditions.MarkTrue(cr, aeconditions.UpgradingCondition)
+}
+
+func MarkUpgradingCompleted(cr CR) error {
+	message := aeconditions.UpgradingConditionMessage{
+		Message:        "Upgrade has been completed",
+		ReleaseVersion: key.ReleaseVersion(cr),
+	}
+	messageString, err := aeconditions.SerializeUpgradingConditionMessage(message)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	capiconditions.MarkFalse(
+		cr,
+		aeconditions.UpgradingCondition,
+		aeconditions.UpgradeCompletedReason,
+		capi.ConditionSeverityInfo,
+		messageString)
+
+	return nil
+}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.1-dev"
+	version            = "5.0.1-machinepoolupgrading"
 )
 
 func Description() string {

--- a/pkg/upgrade/checks.go
+++ b/pkg/upgrade/checks.go
@@ -1,0 +1,79 @@
+package upgrade
+
+import (
+	"context"
+
+	"github.com/coreos/go-semver/semver"
+	aeconditions "github.com/giantswarm/apiextensions/v3/pkg/conditions"
+	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func IsNodePoolUpgradeCompleted(ctx context.Context, c client.Client, machinePool *capiexp.MachinePool, desiredReleaseVersion, desiredAzureOperatorVersion string) (bool, error) {
+	// Check desired release version
+	currentReleaseVersion := machinePool.GetLabels()[label.ReleaseVersion]
+	if currentReleaseVersion != desiredReleaseVersion {
+		return false, nil
+	}
+
+	// Check desired azure-operator version
+	currentAzureOperatorVersion := machinePool.GetLabels()[label.AzureOperatorVersion]
+	if currentAzureOperatorVersion != desiredAzureOperatorVersion {
+		return false, nil
+	}
+
+	// Check MachinePool Upgrading condition
+	isUpgrading := capiconditions.IsTrue(machinePool, aeconditions.UpgradingCondition)
+
+	// Node pool is still being upgraded
+	if isUpgrading {
+		return false, nil
+	}
+
+	// And finally check the actual nodes
+	anyNodePoolNodeOutOfDate, err := AnyNodePoolNodeOutOfDate(ctx, c, machinePool.Name, desiredAzureOperatorVersion)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	// When all nodes are up-to-date, the upgrade has been completed
+	upgradeCompleted := !anyNodePoolNodeOutOfDate
+
+	return upgradeCompleted, nil
+}
+
+func AnyNodePoolNodeOutOfDate(ctx context.Context, c client.Client, nodepoolID string, desiredAzureOperatorVersion string) (bool, error) {
+	nodes := &corev1.NodeList{}
+	var labelSelector client.MatchingLabels
+	{
+		labelSelector = map[string]string{
+			label.MachinePool: nodepoolID,
+		}
+	}
+
+	err := c.List(ctx, nodes, labelSelector)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	desiredVersion := semver.New(desiredAzureOperatorVersion)
+
+	for _, node := range nodes.Items {
+		operatorVersionLabel, exists := node.GetLabels()[label.AzureOperatorVersion]
+		if !exists {
+			return true, nil
+		}
+
+		operatorVersion := semver.New(operatorVersionLabel)
+
+		if operatorVersion.LessThan(*desiredVersion) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/service/controller/resource/azuremachinepoolconditions/deploymentchecks.go
+++ b/service/controller/resource/azuremachinepoolconditions/deploymentchecks.go
@@ -8,6 +8,7 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
 
+	"github.com/giantswarm/azure-operator/v5/pkg/conditions"
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
 )
 
@@ -19,12 +20,7 @@ const (
 	DeploymentProvisioningStateFailed        = "Failed"
 )
 
-type CRWithConditions interface {
-	key.LabelsGetter
-	capiconditions.Setter
-}
-
-func (r *Resource) checkIfDeploymentIsSuccessful(ctx context.Context, deploymentsClient *resources.DeploymentsClient, cr CRWithConditions, deploymentName string, conditionType capi.ConditionType) (bool, error) {
+func (r *Resource) checkIfDeploymentIsSuccessful(ctx context.Context, deploymentsClient *resources.DeploymentsClient, cr conditions.CR, deploymentName string, conditionType capi.ConditionType) (bool, error) {
 	deployment, err := deploymentsClient.Get(ctx, key.ClusterName(cr), deploymentName)
 	if IsNotFound(err) {
 		// Deployment has not been found, which means that we still

--- a/service/controller/resource/machinepoolconditions/conditionready.go
+++ b/service/controller/resource/machinepoolconditions/conditionready.go
@@ -5,7 +5,6 @@ import (
 
 	aeconditions "github.com/giantswarm/apiextensions/v3/pkg/conditions"
 	"github.com/giantswarm/microerror"
-	corev1 "k8s.io/api/core/v1"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
@@ -35,22 +34,7 @@ func (r *Resource) ensureReadyCondition(ctx context.Context, machinePool *capiex
 		capiconditions.AddSourceRef())
 
 	// Log condition change
-	readyCondition := capiconditions.Get(machinePool, capi.ReadyCondition)
-
-	if readyCondition == nil {
-		r.logWarning(ctx, "condition Ready not set")
-	} else {
-		messageFormat := "condition Ready set to %s"
-		messageArgs := []interface{}{readyCondition.Status}
-		if readyCondition.Status != corev1.ConditionTrue {
-			messageFormat += ", Reason=%s, Severity=%s, Message=%s"
-			messageArgs = append(messageArgs, readyCondition.Reason)
-			messageArgs = append(messageArgs, readyCondition.Severity)
-			messageArgs = append(messageArgs, readyCondition.Message)
-		}
-		r.logDebug(ctx, messageFormat, messageArgs...)
-	}
-
+	r.logConditionStatus(ctx, machinePool, capi.ReadyCondition)
 	r.logDebug(ctx, "ensured condition Ready")
 	return nil
 }

--- a/service/controller/resource/machinepoolconditions/conditionupgrading.go
+++ b/service/controller/resource/machinepoolconditions/conditionupgrading.go
@@ -1,0 +1,55 @@
+package machinepoolconditions
+
+import (
+	"context"
+
+	aeconditions "github.com/giantswarm/apiextensions/v3/pkg/conditions"
+	"github.com/giantswarm/microerror"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
+
+	"github.com/giantswarm/azure-operator/v5/pkg/conditions"
+	"github.com/giantswarm/azure-operator/v5/pkg/upgrade"
+	"github.com/giantswarm/azure-operator/v5/service/controller/key"
+)
+
+func (r *Resource) ensureUpgradingCondition(ctx context.Context, machinePool *capiexp.MachinePool) error {
+	r.logDebug(ctx, "ensuring condition Upgrading")
+	var err error
+
+	// Let's make sure that the condition status is set to a supported value.
+	if conditions.IsUnexpected(machinePool, aeconditions.UpgradingCondition) {
+		return conditions.UnexpectedConditionStatusError(machinePool, aeconditions.UpgradingCondition)
+	}
+
+	// Set initial Upgrading condition status to false, since the MachinePool
+	// is just created.
+	if capiconditions.IsUnknown(machinePool, aeconditions.UpgradingCondition) {
+		err = conditions.MarkUpgradingNotStarted(machinePool)
+	}
+
+	// Let's now check if desired versions are set and deployed.
+	desiredReleaseVersion := key.ReleaseVersion(machinePool)
+	desiredAzureOperatorVersion := key.OperatorVersion(machinePool)
+
+	upgradeIsCompletedForDesiredVersion, err := upgrade.IsNodePoolUpgradeCompleted(ctx, r.ctrlClient, machinePool, desiredReleaseVersion, desiredAzureOperatorVersion)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if conditions.IsUpgradingTrue(machinePool) && upgradeIsCompletedForDesiredVersion {
+		// MachinePool was being upgraded, and the upgrade has been completed.
+		err = conditions.MarkUpgradingCompleted(machinePool)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	} else if conditions.IsUpgradingFalse(machinePool) && !upgradeIsCompletedForDesiredVersion {
+		// Machine pool was not being upgraded, but upgrade is needed to reach
+		// the desired version.
+		conditions.MarkUpgradingStarted(machinePool)
+	}
+
+	r.logConditionStatus(ctx, machinePool, aeconditions.UpgradingCondition)
+	r.logDebug(ctx, "ensured condition Upgrading")
+	return nil
+}

--- a/service/controller/resource/machinepoolconditions/create.go
+++ b/service/controller/resource/machinepoolconditions/create.go
@@ -15,8 +15,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, cr interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	// ensure Ready condition
 	err = r.ensureReadyCondition(ctx, &machinePool)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.ensureUpgradingCondition(ctx, &machinePool)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/machinepoolconditions/resource.go
+++ b/service/controller/resource/machinepoolconditions/resource.go
@@ -6,6 +6,10 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	corev1 "k8s.io/api/core/v1"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -53,4 +57,22 @@ func (r *Resource) logDebug(ctx context.Context, message string, messageArgs ...
 
 func (r *Resource) logWarning(ctx context.Context, message string, messageArgs ...interface{}) {
 	r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf(message, messageArgs...))
+}
+
+func (r *Resource) logConditionStatus(ctx context.Context, machinePool *capiexp.MachinePool, conditionType capi.ConditionType) {
+	condition := capiconditions.Get(machinePool, conditionType)
+
+	if condition == nil {
+		r.logWarning(ctx, "condition %s not set", conditionType)
+	} else {
+		messageFormat := "condition %s set to %s"
+		messageArgs := []interface{}{conditionType, condition.Status}
+		if condition.Status != corev1.ConditionTrue {
+			messageFormat += ", Reason=%s, Severity=%s, Message=%s"
+			messageArgs = append(messageArgs, condition.Reason)
+			messageArgs = append(messageArgs, condition.Severity)
+			messageArgs = append(messageArgs, condition.Message)
+		}
+		r.logDebug(ctx, messageFormat, messageArgs...)
+	}
 }


### PR DESCRIPTION
What's in the box:
- Setting `MachinePool` `Upgrading` condition in `machinepoolconditionshandler`
  - Initializing to `False`, when the `MachinePool` is just created
  - Setting to `True` when the upgrade has been started, which is determined by checking desired release and azure-operator version, as well as actual azure-operator version set on Nodes.
  - Setting to `False` when the upgrade has been completed, which is determined by checking desired release and azure-operator version, as well as actual azure-operator version set on Nodes.
- Added new subpackage `pkg/conditions` with common condition functionalities (more stuff will be moved here).