### PR TITLE
Drop unneeded statusresource handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/giantswarm/micrologger v0.3.4
 	github.com/giantswarm/operatorkit/v2 v2.0.2
 	github.com/giantswarm/operatorkit/v4 v4.0.0
-	github.com/giantswarm/statusresource/v3 v3.0.0
 	github.com/giantswarm/tenantcluster/v3 v3.0.0
 	github.com/giantswarm/to v0.3.0
 	github.com/giantswarm/versionbundle v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -367,12 +367,8 @@ github.com/giantswarm/operatorkit/v2 v2.0.2 h1:S2O5lZBT1yeGFfR+/so5TSIXgbgCSrVce
 github.com/giantswarm/operatorkit/v2 v2.0.2/go.mod h1:Bl8gK7hYhvRQP0Ds26rwYdoSXbbr+NKRZmWtwqI7HFI=
 github.com/giantswarm/operatorkit/v4 v4.0.0 h1:rC3MZGA6Rg2HeEbn5poPH/EWHpJk6NpnbpBWc6t7w7Y=
 github.com/giantswarm/operatorkit/v4 v4.0.0/go.mod h1:9VLDXCofhooOPbRt3XCZQmMZJ0tW7X3x7G/2Sz3kb5o=
-github.com/giantswarm/statusresource/v3 v3.0.0 h1:8D5y7d0xtaaNWGiwmQKHiMSaSC6OwxImU/5drYMqx94=
-github.com/giantswarm/statusresource/v3 v3.0.0/go.mod h1:66HvGv5raokenNE3b4uVok4tv6TTLiF+CZ1wQs8LeQg=
 github.com/giantswarm/tenantcluster/v3 v3.0.0 h1:Vrx0LnItmvIUjvkJ10bkz+M8cEFOjrWl5HQv04VmJKg=
 github.com/giantswarm/tenantcluster/v3 v3.0.0/go.mod h1:gTVnGDFVG+lHzoD1ATDJtQ3zgoYcgFbFlJ8go3jvxeM=
-github.com/giantswarm/tenantcluster/v4 v4.0.0 h1:7QX1892Gx5Eza9UBwdCVhkEvMCoX23h9WAXjn2ILueA=
-github.com/giantswarm/tenantcluster/v4 v4.0.0/go.mod h1:9ASonrZOisdzr3+165qptuUfmCovu8u9rQtyebpcKYk=
 github.com/giantswarm/to v0.3.0 h1:cEzMYkWLGI3cI8x3a0L3nPCQYJTb/cAaqcIPvxnDmpQ=
 github.com/giantswarm/to v0.3.0/go.mod h1:RTRtw+Dyk6YqoiNBOGLO981BqhibtVwogdaFIMO1y/A=
 github.com/giantswarm/valuemodifier v0.2.0/go.mod h1:GYMylCMZIu9XrSXD8LE5U0bn1KA1z7U533jTRlN7CEM=

--- a/service/controller/azure_config.go
+++ b/service/controller/azure_config.go
@@ -15,7 +15,6 @@ import (
 	"github.com/giantswarm/operatorkit/v4/pkg/resource/crud"
 	"github.com/giantswarm/operatorkit/v4/pkg/resource/wrapper/metricsresource"
 	"github.com/giantswarm/operatorkit/v4/pkg/resource/wrapper/retryresource"
-	"github.com/giantswarm/statusresource/v3"
 	"github.com/giantswarm/tenantcluster/v3/pkg/tenantcluster"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -282,25 +281,6 @@ func newAzureConfigResources(config AzureConfigConfig, certsSearcher certs.Inter
 		}
 
 		capzcrsResource, err = capzcrs.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var statusResource resource.Interface
-	{
-		c := statusresource.ResourceConfig{
-			ClusterEndpointFunc:      key.ToClusterEndpoint,
-			ClusterIDFunc:            key.ToClusterID,
-			ClusterStatusFunc:        key.ToClusterStatus,
-			NodeCountFunc:            key.ToNodeCount,
-			Logger:                   config.Logger,
-			RESTClient:               config.K8sClient.G8sClient().ProviderV1alpha1().RESTClient(),
-			TenantCluster:            tenantCluster,
-			VersionBundleVersionFunc: key.ToOperatorVersion,
-		}
-
-		statusResource, err = statusresource.NewResource(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -647,7 +627,6 @@ func newAzureConfigResources(config AzureConfigConfig, certsSearcher certs.Inter
 		capzcrsResource,
 		namespaceResource,
 		ipamResource,
-		statusResource,
 		releaseResource,
 		tenantClientsResource,
 		serviceResource,


### PR DESCRIPTION
AzureConfig status conditions aren't used anymore as CAPI & CAPZ types
have superseded those. Cluster & MachinePool, together with
corresponding AzureCluster and AzureMachinePool CRs have more elaborate
status conditions that better reflect the cluster status.