### PR TITLE
Increase Upgrading condition threshold time

### DIFF
--- a/service/controller/resource/clusterreleaseversion/checkupgradeprogress.go
+++ b/service/controller/resource/clusterreleaseversion/checkupgradeprogress.go
@@ -49,7 +49,7 @@ func (r *Resource) isUpgradeCompleted(ctx context.Context, cluster *capi.Cluster
 	// (2) Or we declare Upgrading to be completed if nothing happened for 20
 	// minutes, which could currently happen if we were upgrading some
 	// component which is not covered by any Ready status condition.
-	const upgradingWithoutReadyUpdateThreshold = 20 * time.Minute
+	const upgradingWithoutReadyUpdateThreshold = 45 * time.Minute
 	isReadyDuringEntireUpgradeProcess := time.Now().After(upgradingCondition.LastTransitionTime.Add(upgradingWithoutReadyUpdateThreshold))
 
 	if becameReadyWhileUpgrading || isReadyDuringEntireUpgradeProcess {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14140

When cluster upgrade is initiated, it takes a lot of time for the first node pool to start being upgraded, so for more than 20 minutes all `*Ready` conditions are unchanged, therefore it is considered that the cluster upgrade is completed.

This change mitigates the issue by increasing that waiting time from 20 to 45 minutes. See above linked issue for more details, a fix where entire upgrade process is more correctly reflected in conditions will be implemented later on.