### PR TITLE
Don't rely on old CR's status conditions on upgrade

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.1-nodepoolsrelease101"
+	version            = "5.0.1-dev"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.1-dev"
+	version            = "5.0.1-nodepoolsrelease101"
 )
 
 func Description() string {

--- a/service/controller/resource/masters/create_master_instances_upgrading.go
+++ b/service/controller/resource/masters/create_master_instances_upgrading.go
@@ -34,7 +34,7 @@ func (r *Resource) masterInstancesUpgradingTransition(ctx context.Context, obj i
 		return "", microerror.Mask(err)
 	}
 
-	if areNodesReadyForUpgrading(tenantNodes) {
+	if !areNodesReadyForUpgrading(tenantNodes) {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "found out that at least one master node is not ready")
 		return currentState, nil
 	}
@@ -144,7 +144,7 @@ func areNodesReadyForUpgrading(nodes []corev1.Node) bool {
 	}
 
 	// There must be at least one node registered for the cluster.
-	return numNodes >= 1
+	return numNodes > 0
 }
 
 func (r *Resource) reimageInstance(ctx context.Context, customObject providerv1alpha1.AzureConfig, instance *compute.VirtualMachineScaleSetVM, deploymentNameFunc func(customObject providerv1alpha1.AzureConfig) string, instanceNameFunc func(customObject providerv1alpha1.AzureConfig, instanceID string) string) error {

--- a/service/controller/resource/masters/create_master_instances_upgrading.go
+++ b/service/controller/resource/masters/create_master_instances_upgrading.go
@@ -144,11 +144,7 @@ func areNodesReadyForUpgrading(nodes []corev1.Node) bool {
 	}
 
 	// There must be at least one node registered for the cluster.
-	if numNodes < 1 {
-		return false
-	}
-
-	return true
+	return numNodes >= 1
 }
 
 func (r *Resource) reimageInstance(ctx context.Context, customObject providerv1alpha1.AzureConfig, instance *compute.VirtualMachineScaleSetVM, deploymentNameFunc func(customObject providerv1alpha1.AzureConfig) string, instanceNameFunc func(customObject providerv1alpha1.AzureConfig, instanceID string) string) error {

--- a/service/controller/resource/masters/create_master_instances_upgrading.go
+++ b/service/controller/resource/masters/create_master_instances_upgrading.go
@@ -25,27 +25,25 @@ func (r *Resource) masterInstancesUpgradingTransition(ctx context.Context, obj i
 	}
 
 	r.Logger.LogCtx(ctx, "level", "debug", "message", "finding out if all tenant cluster master nodes are Ready")
-	{
-		allMasterNodesAreReady, err := r.areNodesReadyForUpgrading(ctx)
-		if IsClientNotFound(err) {
-			r.Logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster client not available yet")
-			return currentState, nil
-		} else if err != nil {
-			return "", microerror.Mask(err)
-		}
 
-		if !allMasterNodesAreReady {
-			r.Logger.LogCtx(ctx, "level", "debug", "message", "found out that at least one master node is not ready")
-			return currentState, nil
-		}
+	tenantNodes, err := r.getTenantClusterNodes(ctx)
+	if IsClientNotFound(err) {
+		r.Logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster client not available yet")
+		return currentState, nil
+	} else if err != nil {
+		return "", microerror.Mask(err)
 	}
+
+	if areNodesReadyForUpgrading(tenantNodes) {
+		r.Logger.LogCtx(ctx, "level", "debug", "message", "found out that at least one master node is not ready")
+		return currentState, nil
+	}
+
 	r.Logger.LogCtx(ctx, "level", "debug", "message", "found out that all tenant cluster master nodes are Ready")
 
 	versionValue := map[string]string{}
-	{
-		for _, node := range cr.Status.Cluster.Nodes {
-			versionValue[node.Name] = node.Version
-		}
+	for _, node := range tenantNodes {
+		versionValue[node.Name] = key.OperatorVersion(&node)
 	}
 
 	var masterUpgradeInProgress bool
@@ -114,39 +112,43 @@ func (r *Resource) masterInstancesUpgradingTransition(ctx context.Context, obj i
 	return currentState, nil
 }
 
-func (r *Resource) areNodesReadyForUpgrading(ctx context.Context) (bool, error) {
+func (r *Resource) getTenantClusterNodes(ctx context.Context) ([]corev1.Node, error) {
 	cc, err := controllercontext.FromContext(ctx)
 	if err != nil {
-		return false, microerror.Mask(err)
+		return nil, microerror.Mask(err)
 	}
 
 	if cc.Client.TenantCluster.K8s == nil {
-		return false, clientNotFoundError
+		return nil, clientNotFoundError
 	}
 
 	nodeList, err := cc.Client.TenantCluster.K8s.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return false, microerror.Mask(err)
+		return nil, microerror.Mask(err)
 	}
 
+	return nodeList.Items, nil
+}
+
+func areNodesReadyForUpgrading(nodes []corev1.Node) bool {
 	var numNodes int
-	for _, n := range nodeList.Items {
+	for _, n := range nodes {
 		if isMaster(n) {
 			numNodes++
 
 			if !isReady(n) {
 				// If there's even one node that is not ready, then wait.
-				return false, nil
+				return false
 			}
 		}
 	}
 
 	// There must be at least one node registered for the cluster.
 	if numNodes < 1 {
-		return false, nil
+		return false
 	}
 
-	return true, nil
+	return true
 }
 
 func (r *Resource) reimageInstance(ctx context.Context, customObject providerv1alpha1.AzureConfig, instance *compute.VirtualMachineScaleSetVM, deploymentNameFunc func(customObject providerv1alpha1.AzureConfig) string, instanceNameFunc func(customObject providerv1alpha1.AzureConfig, instanceID string) string) error {


### PR DESCRIPTION
AzureConfig status conditions / node states aren't updated anymore so
the information is not present there. When the tenant cluster nodes are
fetched anyway, it's best to use fresh information from them.