### PR TITLE
Copy AzureConfig cluster description to Cluster

### DIFF
--- a/service/controller/resource/capzcrs/create.go
+++ b/service/controller/resource/capzcrs/create.go
@@ -114,6 +114,9 @@ func (r *Resource) mapAzureConfigToCluster(ctx context.Context, cr providerv1alp
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name,
 			Namespace: key.OrganizationNamespace(&cr),
+			Annotations: map[string]string{
+				annotation.ClusterDescription: cr.Annotations[annotation.ClusterDescription],
+			},
 			Labels: map[string]string{
 				// XXX: azure-operator reconciles Cluster & MachinePool to set OwnerReferences (for now).
 				label.AzureOperatorVersion:          key.OperatorVersion(&cr),

--- a/service/controller/resource/capzcrs/testdata/case-0-Simple-AzureConfig-migration-to-create-CAPI-CAPZ-CRs_AzureCluster.golden
+++ b/service/controller/resource/capzcrs/testdata/case-0-Simple-AzureConfig-migration-to-create-CAPI-CAPZ-CRs_AzureCluster.golden
@@ -2,7 +2,7 @@ apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureCluster
 metadata:
   annotations:
-    cluster.giantswarm.io/description: ""
+    cluster.giantswarm.io/description: my-test-cluster
   creationTimestamp: null
   labels:
     azure-operator.giantswarm.io/version: 4.2.0

--- a/service/controller/resource/capzcrs/testdata/case-0-Simple-AzureConfig-migration-to-create-CAPI-CAPZ-CRs_Cluster.golden
+++ b/service/controller/resource/capzcrs/testdata/case-0-Simple-AzureConfig-migration-to-create-CAPI-CAPZ-CRs_Cluster.golden
@@ -1,6 +1,8 @@
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: Cluster
 metadata:
+  annotations:
+    cluster.giantswarm.io/description: my-test-cluster
   creationTimestamp: null
   labels:
     azure-operator.giantswarm.io/version: 4.2.0

--- a/service/controller/resource/capzcrs/testdata/simple_azureconfig.yaml
+++ b/service/controller/resource/capzcrs/testdata/simple_azureconfig.yaml
@@ -4,6 +4,8 @@ metadata:
   finalizers:
   - operatorkit.giantswarm.io/azure-operator
   - operatorkit.giantswarm.io/legacy-controller
+  annotations:
+    cluster.giantswarm.io/description: "my-test-cluster"
   labels:
     azure-operator.giantswarm.io/version: 4.2.0
     giantswarm.io/cluster: c6fme


### PR DESCRIPTION
For some reason this was missing. Needed when upgrading from
pre-nodepool cluster to nodepool cluster.