### PR TITLE
Fix first node pool upgrade annotation

### DIFF
--- a/service/controller/resource/capzcrs/create.go
+++ b/service/controller/resource/capzcrs/create.go
@@ -115,17 +115,17 @@ func (r *Resource) mapAzureConfigToCluster(ctx context.Context, cr providerv1alp
 			Name:      cr.Name,
 			Namespace: key.OrganizationNamespace(&cr),
 			Annotations: map[string]string{
-				annotation.ClusterDescription: cr.Annotations[annotation.ClusterDescription],
+				annotation.ClusterDescription:       cr.Annotations[annotation.ClusterDescription],
+				azopannotation.UpgradingToNodePools: "True",
 			},
 			Labels: map[string]string{
 				// XXX: azure-operator reconciles Cluster & MachinePool to set OwnerReferences (for now).
-				label.AzureOperatorVersion:          key.OperatorVersion(&cr),
-				label.ClusterOperatorVersion:        cr.Labels[label.ClusterOperatorVersion],
-				label.Cluster:                       cr.Name,
-				capiv1alpha3.ClusterLabelName:       cr.Name,
-				label.Organization:                  key.OrganizationID(&cr),
-				label.ReleaseVersion:                key.ReleaseVersion(&cr),
-				azopannotation.UpgradingToNodePools: "True",
+				label.AzureOperatorVersion:    key.OperatorVersion(&cr),
+				label.ClusterOperatorVersion:  cr.Labels[label.ClusterOperatorVersion],
+				label.Cluster:                 cr.Name,
+				capiv1alpha3.ClusterLabelName: cr.Name,
+				label.Organization:            key.OrganizationID(&cr),
+				label.ReleaseVersion:          key.ReleaseVersion(&cr),
 			},
 		},
 		Spec: capiv1alpha3.ClusterSpec{

--- a/service/controller/resource/capzcrs/testdata/case-0-Simple-AzureConfig-migration-to-create-CAPI-CAPZ-CRs_Cluster.golden
+++ b/service/controller/resource/capzcrs/testdata/case-0-Simple-AzureConfig-migration-to-create-CAPI-CAPZ-CRs_Cluster.golden
@@ -3,6 +3,7 @@ kind: Cluster
 metadata:
   annotations:
     cluster.giantswarm.io/description: my-test-cluster
+    release.giantswarm.io/upgrading-to-node-pools: "True"
   creationTimestamp: null
   labels:
     azure-operator.giantswarm.io/version: 4.2.0
@@ -10,7 +11,6 @@ metadata:
     cluster.x-k8s.io/cluster-name: c6fme
     giantswarm.io/cluster: c6fme
     giantswarm.io/organization: giantswarm
-    release.giantswarm.io/upgrading-to-node-pools: "True"
     release.giantswarm.io/version: 12.0.0
   name: c6fme
   namespace: org-giantswarm


### PR DESCRIPTION
This annotation is used to signal that the cluster is being upgraded to the node pools release for the first time. It is then used to set conditions to appropriate values (to distinguish between new and existing clusters when seeing some Cluster CR for the first time).

It was incorrectly set as label :see_no_evil: 