### PR TITLE
Cache tenant cluster k8s client look up and avoid errors if not ready yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Only submit Subnet ARM deployment when Subnet name or Subnet CIDR change.
 
+### Added
+
+- Tenant cluster k8s client lookup is cached.
+
 ### Fixed
 
 - Avoid returning errors when still waiting for tenant cluster k8s API to be ready.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Only submit Subnet ARM deployment when Subnet name or Subnet CIDR change.
 
+### Fixed
+
+- Avoid returning errors when still waiting for tenant cluster k8s API to be ready.
+
 ## [5.0.0-beta5] - 2020-11-18
 
 ### Fixed

--- a/pkg/tenantcluster/cached.go
+++ b/pkg/tenantcluster/cached.go
@@ -1,0 +1,48 @@
+package tenantcluster
+
+import (
+	"context"
+	"time"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	gocache "github.com/patrickmn/go-cache"
+	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-operator/v5/service/controller/key"
+)
+
+const (
+	expiration = 5 * time.Minute
+)
+
+type cachedTenantClientFactory struct {
+	cache   *gocache.Cache
+	logger  micrologger.Logger
+	factory Factory
+}
+
+func NewCachedFactory(tenantClientFactory Factory, logger micrologger.Logger) Factory {
+	return &cachedTenantClientFactory{
+		cache:   gocache.New(expiration, expiration/2),
+		logger:  logger,
+		factory: tenantClientFactory,
+	}
+}
+
+func (ctcf *cachedTenantClientFactory) GetClient(ctx context.Context, cr *capiv1alpha3.Cluster) (client.Client, error) {
+	tenantClusterClient, inCache := ctcf.cache.Get(key.ClusterID(cr))
+	if inCache {
+		return tenantClusterClient.(client.Client), nil
+	}
+
+	tenantClusterClient, err := ctcf.factory.GetClient(ctx, cr)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	ctcf.cache.SetDefault(key.ClusterID(cr), tenantClusterClient)
+
+	return tenantClusterClient.(client.Client), nil
+}

--- a/pkg/tenantcluster/cached.go
+++ b/pkg/tenantcluster/cached.go
@@ -40,10 +40,10 @@ func NewCachedFactory(tenantClientFactory Factory, logger micrologger.Logger) (F
 }
 
 func (ctcf *cachedTenantClientFactory) GetClient(ctx context.Context, cr *capiv1alpha3.Cluster) (client.Client, error) {
-	ctcf.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Fetching tenant cluster k8s client for cluster %#q from cache", key.ClusterID(cr)))
+	ctcf.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("trying to fetch tenant cluster %#q k8s client from cache before creating it", key.ClusterID(cr)))
 	tenantClusterClient, inCache := ctcf.cache.Get(key.ClusterID(cr))
 	if inCache {
-		ctcf.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Tenant cluster k8s client for cluster %#q found in cache", key.ClusterID(cr)))
+		ctcf.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("tenant cluster k8s client for cluster %#q found in cache", key.ClusterID(cr)))
 		return tenantClusterClient.(client.Client), nil
 	}
 
@@ -53,7 +53,7 @@ func (ctcf *cachedTenantClientFactory) GetClient(ctx context.Context, cr *capiv1
 	}
 
 	ctcf.cache.SetDefault(key.ClusterID(cr), tenantClusterClient)
-	ctcf.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Saved tenant cluster k8s client for cluster %#q in cache", key.ClusterID(cr)))
+	ctcf.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("saved tenant cluster k8s client for cluster %#q in cache", key.ClusterID(cr)))
 
 	return tenantClusterClient.(client.Client), nil
 }

--- a/pkg/tenantcluster/cached.go
+++ b/pkg/tenantcluster/cached.go
@@ -2,6 +2,7 @@ package tenantcluster
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/giantswarm/microerror"
@@ -39,10 +40,10 @@ func NewCachedFactory(tenantClientFactory Factory, logger micrologger.Logger) (F
 }
 
 func (ctcf *cachedTenantClientFactory) GetClient(ctx context.Context, cr *capiv1alpha3.Cluster) (client.Client, error) {
-	ctcf.logger.LogCtx(ctx, "level", "debug", "message", "Fetching tenant cluster k8s client for cluster %#q from cache", key.ClusterID(cr))
+	ctcf.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Fetching tenant cluster k8s client for cluster %#q from cache", key.ClusterID(cr)))
 	tenantClusterClient, inCache := ctcf.cache.Get(key.ClusterID(cr))
 	if inCache {
-		ctcf.logger.LogCtx(ctx, "level", "debug", "message", "Tenant cluster k8s client for cluster %#q found in cache", key.ClusterID(cr))
+		ctcf.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Tenant cluster k8s client for cluster %#q found in cache", key.ClusterID(cr)))
 		return tenantClusterClient.(client.Client), nil
 	}
 
@@ -52,7 +53,7 @@ func (ctcf *cachedTenantClientFactory) GetClient(ctx context.Context, cr *capiv1
 	}
 
 	ctcf.cache.SetDefault(key.ClusterID(cr), tenantClusterClient)
-	ctcf.logger.LogCtx(ctx, "level", "debug", "message", "Saved tenant cluster k8s client for cluster %#q in cache", key.ClusterID(cr))
+	ctcf.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Saved tenant cluster k8s client for cluster %#q in cache", key.ClusterID(cr)))
 
 	return tenantClusterClient.(client.Client), nil
 }

--- a/pkg/tenantcluster/error.go
+++ b/pkg/tenantcluster/error.go
@@ -13,11 +13,11 @@ func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
 
-var APINotAvailableError = &microerror.Error{
-	Kind: "APINotAvailableError",
+var apiNotAvailableError = &microerror.Error{
+	Kind: "apiNotAvailableError",
 }
 
-// IsAPINotAvailableError asserts APINotAvailableError.
+// IsAPINotAvailableError asserts apiNotAvailableError.
 func IsAPINotAvailableError(err error) bool {
-	return microerror.Cause(err) == APINotAvailableError
+	return microerror.Cause(err) == apiNotAvailableError
 }

--- a/pkg/tenantcluster/error.go
+++ b/pkg/tenantcluster/error.go
@@ -1,0 +1,23 @@
+package tenantcluster
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var APINotAvailableError = &microerror.Error{
+	Kind: "APINotAvailableError",
+}
+
+// IsAPINotAvailableError asserts APINotAvailableError.
+func IsAPINotAvailableError(err error) bool {
+	return microerror.Cause(err) == APINotAvailableError
+}

--- a/pkg/tenantcluster/factory.go
+++ b/pkg/tenantcluster/factory.go
@@ -51,11 +51,11 @@ func NewFactory(certsSearcher certs.Interface, logger micrologger.Logger) (Facto
 }
 
 func (tcf *tenantClientFactory) GetClient(ctx context.Context, cr *capiv1alpha3.Cluster) (client.Client, error) {
-	tcf.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Creating tenant cluster k8s client for cluster %#q", key.ClusterID(cr)))
+	tcf.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating tenant cluster k8s client for cluster %#q", key.ClusterID(cr)))
 	var k8sClient k8sclient.Interface
 	{
 		restConfig, err := tcf.tenantRestConfigProvider.NewRestConfig(ctx, key.ClusterID(cr), cr.Spec.ControlPlaneEndpoint.String())
-		if tenant.IsAPINotAvailable(err) {
+		if tenant.IsAPINotAvailable(err) || tenantcluster.IsTimeout(err) {
 			return nil, microerror.Mask(apiNotAvailableError)
 		} else if err != nil {
 			return nil, microerror.Mask(err)

--- a/pkg/tenantcluster/factory.go
+++ b/pkg/tenantcluster/factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/giantswarm/certs/v3/pkg/certs"
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -45,7 +46,9 @@ func (tcf *tenantClientFactory) GetClient(ctx context.Context, cr *capiv1alpha3.
 	var k8sClient k8sclient.Interface
 	{
 		restConfig, err := tcf.tenantRestConfigProvider.NewRestConfig(ctx, key.ClusterID(cr), cr.Spec.ControlPlaneEndpoint.String())
-		if err != nil {
+		if tenant.IsAPINotAvailable(err) {
+			return nil, microerror.Mask(APINotAvailableError)
+		} else if err != nil {
 			return nil, microerror.Mask(err)
 		}
 

--- a/pkg/tenantcluster/factory.go
+++ b/pkg/tenantcluster/factory.go
@@ -2,6 +2,7 @@ package tenantcluster
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/giantswarm/certs/v3/pkg/certs"
 	"github.com/giantswarm/errors/tenant"
@@ -50,7 +51,7 @@ func NewFactory(certsSearcher certs.Interface, logger micrologger.Logger) (Facto
 }
 
 func (tcf *tenantClientFactory) GetClient(ctx context.Context, cr *capiv1alpha3.Cluster) (client.Client, error) {
-	tcf.logger.LogCtx(ctx, "level", "debug", "message", "Creating tenant cluster k8s client for cluster %#q", key.ClusterID(cr))
+	tcf.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Creating tenant cluster k8s client for cluster %#q", key.ClusterID(cr)))
 	var k8sClient k8sclient.Interface
 	{
 		restConfig, err := tcf.tenantRestConfigProvider.NewRestConfig(ctx, key.ClusterID(cr), cr.Spec.ControlPlaneEndpoint.String())
@@ -64,7 +65,9 @@ func (tcf *tenantClientFactory) GetClient(ctx context.Context, cr *capiv1alpha3.
 			Logger:     tcf.logger,
 			RestConfig: rest.CopyConfig(restConfig),
 		})
-		if err != nil {
+		if tenant.IsAPINotAvailable(err) {
+			return nil, microerror.Mask(apiNotAvailableError)
+		} else if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}

--- a/service/controller/azure_machine_pool.go
+++ b/service/controller/azure_machine_pool.go
@@ -179,12 +179,14 @@ func NewAzureMachinePoolResourceSet(config AzureMachinePoolConfig) ([]resource.I
 		}
 	}
 
-	var tenantClientFactory tenantcluster.Factory
+	var cachedTenantClientFactory tenantcluster.Factory
 	{
-		tenantClientFactory, err = tenantcluster.NewFactory(certsSearcher, config.Logger)
+		tenantClientFactory, err := tenantcluster.NewFactory(certsSearcher, config.Logger)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
+
+		cachedTenantClientFactory = tenantcluster.NewCachedFactory(tenantClientFactory, config.Logger)
 	}
 
 	nodesConfig := nodes.Config{
@@ -215,7 +217,7 @@ func NewAzureMachinePoolResourceSet(config AzureMachinePoolConfig) ([]resource.I
 			Config:              nodesConfig,
 			CredentialProvider:  config.CredentialProvider,
 			CtrlClient:          config.K8sClient.CtrlClient(),
-			TenantClientFactory: tenantClientFactory,
+			TenantClientFactory: cachedTenantClientFactory,
 			VMSKU:               vmSKU,
 		}
 

--- a/service/controller/azure_machine_pool.go
+++ b/service/controller/azure_machine_pool.go
@@ -186,7 +186,10 @@ func NewAzureMachinePoolResourceSet(config AzureMachinePoolConfig) ([]resource.I
 			return nil, microerror.Mask(err)
 		}
 
-		cachedTenantClientFactory = tenantcluster.NewCachedFactory(tenantClientFactory, config.Logger)
+		cachedTenantClientFactory, err = tenantcluster.NewCachedFactory(tenantClientFactory, config.Logger)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
 	}
 
 	nodesConfig := nodes.Config{

--- a/service/controller/resource/clusterownerreference/resource.go
+++ b/service/controller/resource/clusterownerreference/resource.go
@@ -91,7 +91,7 @@ func (r *Resource) Name() string {
 
 func (r *Resource) ensureAzureCluster(ctx context.Context, cluster capiv1alpha3.Cluster) error {
 	var err error
-	r.logger.LogCtx(ctx, "message", fmt.Sprintf("Ensuring %s label and 'ownerReference' fields on AzureCluster '%s/%s'", capiv1alpha3.ClusterLabelName, cluster.Namespace, cluster.Spec.InfrastructureRef.Name))
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("Ensuring %s label and 'ownerReference' fields on AzureCluster '%s/%s'", capiv1alpha3.ClusterLabelName, cluster.Namespace, cluster.Spec.InfrastructureRef.Name))
 
 	azureCluster := v1alpha3.AzureCluster{}
 	err = r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: cluster.Spec.InfrastructureRef.Name}, &azureCluster)

--- a/service/controller/resource/clusterupgrade/create.go
+++ b/service/controller/resource/clusterupgrade/create.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
-	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -17,6 +16,7 @@ import (
 	"github.com/giantswarm/azure-operator/v5/pkg/conditions"
 	"github.com/giantswarm/azure-operator/v5/pkg/helpers"
 	"github.com/giantswarm/azure-operator/v5/pkg/project"
+	"github.com/giantswarm/azure-operator/v5/pkg/tenantcluster"
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
 )
 
@@ -135,7 +135,7 @@ func (r *Resource) ensureAzureClusterHasSameRelease(ctx context.Context, cr capi
 
 func (r *Resource) ensureMasterHasUpgraded(ctx context.Context, cluster capiv1alpha3.Cluster) (bool, error) {
 	tenantClusterK8sClient, err := r.tenantClientFactory.GetClient(ctx, &cluster)
-	if tenant.IsAPINotAvailable(err) {
+	if tenantcluster.IsAPINotAvailableError(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 

--- a/service/controller/resource/machinepoolupgrade/lastdeployedreleaseversion.go
+++ b/service/controller/resource/machinepoolupgrade/lastdeployedreleaseversion.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
-	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
 
+	"github.com/giantswarm/azure-operator/v5/pkg/tenantcluster"
 	"github.com/giantswarm/azure-operator/v5/pkg/upgrade"
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
 )
@@ -36,7 +36,7 @@ func (r *Resource) ensureLastDeployedReleaseVersion(ctx context.Context, machine
 	}
 
 	tenantClusterClient, err := r.tenantClientFactory.GetClient(ctx, cluster)
-	if tenant.IsAPINotAvailable(err) {
+	if tenantcluster.IsAPINotAvailableError(err) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 

--- a/service/controller/resource/machinepoolupgrade/lastdeployedreleaseversion.go
+++ b/service/controller/resource/machinepoolupgrade/lastdeployedreleaseversion.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
 	capiexp "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
@@ -35,7 +36,12 @@ func (r *Resource) ensureLastDeployedReleaseVersion(ctx context.Context, machine
 	}
 
 	tenantClusterClient, err := r.tenantClientFactory.GetClient(ctx, cluster)
-	if err != nil {
+	if tenant.IsAPINotAvailable(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil
+	} else if err != nil {
 		return microerror.Mask(err)
 	}
 	upgradeIsCompletedForDesiredVersion, err := upgrade.IsNodePoolUpgradeCompleted(

--- a/service/controller/resource/nodepool/create_cordon_old_workers.go
+++ b/service/controller/resource/nodepool/create_cordon_old_workers.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/coreos/go-semver/semver"
 	apiextensionslabels "github.com/giantswarm/apiextensions/v3/pkg/label"
-	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/giantswarm/azure-operator/v5/pkg/label"
 	"github.com/giantswarm/azure-operator/v5/pkg/project"
+	"github.com/giantswarm/azure-operator/v5/pkg/tenantcluster"
 	"github.com/giantswarm/azure-operator/v5/service/controller/internal/state"
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
 )
@@ -45,7 +45,7 @@ func (r *Resource) cordonOldWorkersTransition(ctx context.Context, obj interface
 	}
 
 	tenantClusterK8sClient, err := r.tenantClientFactory.GetClient(ctx, cluster)
-	if tenant.IsAPINotAvailable(err) {
+	if tenantcluster.IsAPINotAvailableError(err) {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 

--- a/service/controller/resource/nodepool/create_drain_old_worker_nodes.go
+++ b/service/controller/resource/nodepool/create_drain_old_worker_nodes.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 
 	corev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
-	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/util"
 
 	"github.com/giantswarm/azure-operator/v5/pkg/label"
+	"github.com/giantswarm/azure-operator/v5/pkg/tenantcluster"
 	"github.com/giantswarm/azure-operator/v5/service/controller/internal/state"
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
 )
@@ -43,7 +43,7 @@ func (r *Resource) drainOldWorkerNodesTransition(ctx context.Context, obj interf
 	}
 
 	tenantClusterK8sClient, err := r.tenantClientFactory.GetClient(ctx, cluster)
-	if tenant.IsAPINotAvailable(err) {
+	if tenantcluster.IsAPINotAvailableError(err) {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 

--- a/service/controller/resource/nodepool/create_terminate_old_workers.go
+++ b/service/controller/resource/nodepool/create_terminate_old_workers.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
 	"sigs.k8s.io/cluster-api/util"
 
+	"github.com/giantswarm/azure-operator/v5/pkg/tenantcluster"
 	"github.com/giantswarm/azure-operator/v5/service/controller/internal/state"
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
 )
@@ -41,7 +41,7 @@ func (r *Resource) terminateOldWorkersTransition(ctx context.Context, obj interf
 	}
 
 	tenantClusterK8sClient, err := r.tenantClientFactory.GetClient(ctx, cluster)
-	if tenant.IsAPINotAvailable(err) {
+	if tenantcluster.IsAPINotAvailableError(err) {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 

--- a/service/controller/resource/nodepool/create_wait_for_nodes_to_become_ready.go
+++ b/service/controller/resource/nodepool/create_wait_for_nodes_to_become_ready.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	apiextensionslabels "github.com/giantswarm/apiextensions/v3/pkg/label"
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
@@ -31,11 +32,13 @@ func (r *Resource) waitForWorkersToBecomeReadyTransition(ctx context.Context, ob
 	}
 
 	tenantClusterK8sClient, err := r.tenantClientFactory.GetClient(ctx, cluster)
-	if err != nil {
-		r.Logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet", "stack", microerror.JSON(err))
+	if tenant.IsAPINotAvailable(err) {
+		r.Logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 		return currentState, nil
+	} else if err != nil {
+		return currentState, microerror.Mask(err)
 	}
 
 	r.Logger.LogCtx(ctx, "level", "debug", "message", "finding out if all tenant cluster worker nodes are Ready")

--- a/service/controller/resource/nodepool/create_wait_for_nodes_to_become_ready.go
+++ b/service/controller/resource/nodepool/create_wait_for_nodes_to_become_ready.go
@@ -4,13 +4,13 @@ import (
 	"context"
 
 	apiextensionslabels "github.com/giantswarm/apiextensions/v3/pkg/label"
-	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/azure-operator/v5/pkg/tenantcluster"
 	"github.com/giantswarm/azure-operator/v5/service/controller/internal/state"
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
 )
@@ -32,7 +32,7 @@ func (r *Resource) waitForWorkersToBecomeReadyTransition(ctx context.Context, ob
 	}
 
 	tenantClusterK8sClient, err := r.tenantClientFactory.GetClient(ctx, cluster)
-	if tenant.IsAPINotAvailable(err) {
+	if tenantcluster.IsAPINotAvailableError(err) {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 

--- a/service/controller/resource/nodepool/delete.go
+++ b/service/controller/resource/nodepool/delete.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
-	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
@@ -13,6 +12,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/azure-operator/v5/pkg/tenantcluster"
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
 )
 
@@ -35,7 +35,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	}
 
 	tenantClusterK8sClient, err := r.tenantClientFactory.GetClient(ctx, cluster)
-	if tenant.IsAPINotAvailable(err) {
+	if tenantcluster.IsAPINotAvailableError(err) {
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 

--- a/service/controller/resource/nodepool/delete.go
+++ b/service/controller/resource/nodepool/delete.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/apiextensions/v3/pkg/label"
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
@@ -34,11 +35,13 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	}
 
 	tenantClusterK8sClient, err := r.tenantClientFactory.GetClient(ctx, cluster)
-	if err != nil {
-		r.Logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet", "stack", microerror.JSON(err))
+	if tenant.IsAPINotAvailable(err) {
+		r.Logger.LogCtx(ctx, "level", "debug", "message", "tenant API not available yet")
 		r.Logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 
 		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
 	}
 
 	err = r.removeNodesFromK8s(ctx, tenantClusterK8sClient, &azureMachinePool)

--- a/service/controller/resource/workermigration/resource.go
+++ b/service/controller/resource/workermigration/resource.go
@@ -54,11 +54,16 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Mask(err)
 	}
 
+	cachedTenantClientFactory, err := tenantcluster.NewCachedFactory(tenantClientFactory, config.Logger)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	newResource := &Resource{
 		clientFactory:       config.ClientFactory,
 		ctrlClient:          config.CtrlClient,
 		logger:              config.Logger,
-		tenantClientFactory: tenantClientFactory,
+		tenantClientFactory: cachedTenantClientFactory,
 		wrapAzureAPI:        azure.GetAPI,
 
 		location: config.Location,


### PR DESCRIPTION
While trying to connect to the tenant cluster k8s API we return errors like these

```
D 11/19 10:20:27 /apis/cluster.x-k8s.io/v1alpha3/namespaces/org-giantswarm/clusters/8t2uh clusterupgrade tenant API not available yet | azure-operator/v5/service/controller/resource/clusterupgrade/create.go:138 | controller=azure-operator-cluster-controller | event=update | loop=25 | version=215792872
        /root/project/pkg/tenantcluster/factory.go:49
        /go/pkg/mod/github.com/giantswarm/tenantcluster/v3@v3.0.0/pkg/tenantcluster/tenantcluster.go:62
        timeout error: timeout error: waiting secrets, selector = "giantswarm.io/certificate=api, giantswarm.io/cluster=8t2uh"
```

```
D 11/19 10:20:27 /apis/cluster.x-k8s.io/v1alpha3/namespaces/org-giantswarm/clusters/8t2uh clusterupgrade tenant API not available yet | azure-operator/v5/service/controller/resource/clusterupgrade/create.go:138 | controller=azure-operator-cluster-controller | event=update | loop=26 | version=215792875
        /root/project/pkg/tenantcluster/factory.go:57
        /go/pkg/mod/github.com/giantswarm/k8sclient/v5@v5.0.0/pkg/k8sclient/clients.go:117
        unknown: Get "https://api.8t2uh.k8s.ghost.westeurope.azure.gigantic.io:443/api?timeout=10s": dial tcp: lookup api.8t2uh.k8s.ghost.westeurope.azure.gigantic.io on 172.31.0.10:53: no such host
```

This PR also adds a cache mechanism so that we don't fetch the same client over and over for the same cluster.