### PR TITLE
Refactor ipam.Check() to return existing subnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Release allocated subnet when deleting node pool.
+
 ## [5.0.0-beta5] - 2020-11-18
 
 ### Fixed

--- a/service/controller/azure_config.go
+++ b/service/controller/azure_config.go
@@ -541,6 +541,7 @@ func newAzureConfigResources(config AzureConfigConfig, certsSearcher certs.Inter
 			NetworkRangeGetter: networkRangeGetter,
 			NetworkRangeType:   ipam.VirtualNetworkRange,
 			Persister:          azureConfigPersister,
+			Releaser:           ipam.NewNOPReleaser(),
 		}
 
 		ipamResource, err = ipam.New(c)

--- a/service/controller/azure_machine_pool.go
+++ b/service/controller/azure_machine_pool.go
@@ -251,6 +251,19 @@ func NewAzureMachinePoolResourceSet(config AzureMachinePoolConfig) ([]resource.I
 		}
 	}
 
+	var subnetReleaser *ipam.AzureMachinePoolSubnetReleaser
+	{
+		c := ipam.AzureMachinePoolSubnetReleaserConfig{
+			CtrlClient: config.K8sClient.CtrlClient(),
+			Logger:     config.Logger,
+		}
+
+		subnetReleaser, err = ipam.NewAzureMachinePoolSubnetReleaser(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var subnetCollector *ipam.AzureMachinePoolSubnetCollector
 	{
 		c := ipam.AzureMachinePoolSubnetCollectorConfig{
@@ -288,6 +301,7 @@ func NewAzureMachinePoolResourceSet(config AzureMachinePoolConfig) ([]resource.I
 			NetworkRangeGetter: networkRangeGetter,
 			NetworkRangeType:   ipam.SubnetRange,
 			Persister:          subnetPersister,
+			Releaser:           subnetReleaser,
 		}
 
 		ipamResource, err = ipam.New(c)

--- a/service/controller/resource/ipam/azure_config_checker.go
+++ b/service/controller/resource/ipam/azure_config_checker.go
@@ -47,7 +47,7 @@ func (c *AzureConfigChecker) Check(ctx context.Context, namespace string, name s
 
 	// We check the subnet we want to ensure in the CR status. In case there is no
 	// subnet tracked so far, we want to proceed with the allocation process. Thus
-	// we return true.
+	// we return nil.
 	if key.AzureConfigNetworkCIDR(*azureCluster) == "" {
 		return nil, nil
 	}

--- a/service/controller/resource/ipam/azure_machinepool_subnet_persister.go
+++ b/service/controller/resource/ipam/azure_machinepool_subnet_persister.go
@@ -19,8 +19,8 @@ type AzureMachinePoolSubnetPersisterConfig struct {
 	Logger     micrologger.Logger
 }
 
-// AzureMachinePoolSubnetPersister is a Persister implementation that saves a subnet allocated for a node
-// pool by adding it to Cluster CR.
+// AzureMachinePoolSubnetPersister is a Persister implementation that saves a
+// subnet allocated for a node pool by adding it to AzureCluster CR.
 type AzureMachinePoolSubnetPersister struct {
 	ctrlClient client.Client
 	logger     micrologger.Logger
@@ -42,9 +42,9 @@ func NewAzureMachinePoolSubnetPersister(config AzureMachinePoolSubnetPersisterCo
 	return p, nil
 }
 
-// Persist functions takes a subnet CIDR allocated for the specified AzureMachinePool (namespace/
-// name) and adds it to Subnets array in the corresponding Cluster CR that owns the specified
-// AzureMachinePool.
+// Persist functions takes a subnet CIDR allocated for the specified
+// AzureMachinePool (namespace/ name) and adds it to Subnets array in the
+// corresponding AzureCluster CR that owns the specified AzureMachinePool.
 func (p *AzureMachinePoolSubnetPersister) Persist(ctx context.Context, subnet net.IPNet, namespace string, name string) error {
 	p.logger.LogCtx(ctx, "level", "debug", "message", "persisting allocated subnet in AzureCluster CR")
 

--- a/service/controller/resource/ipam/azure_machinepool_subnet_releaser.go
+++ b/service/controller/resource/ipam/azure_machinepool_subnet_releaser.go
@@ -1,0 +1,87 @@
+package ipam
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-operator/v5/pkg/helpers"
+)
+
+type AzureMachinePoolSubnetReleaserConfig struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+}
+
+// AzureMachinePoolSubnetReleaser is a Releaser implementation that releases an
+// allocated subnet for a node pool by removing it from AzureCluster CR.
+type AzureMachinePoolSubnetReleaser struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+}
+
+func NewAzureMachinePoolSubnetReleaser(config AzureMachinePoolSubnetReleaserConfig) (*AzureMachinePoolSubnetReleaser, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	p := &AzureMachinePoolSubnetReleaser{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return p, nil
+}
+
+func (r *AzureMachinePoolSubnetReleaser) Release(ctx context.Context, subnet net.IPNet, namespace, name string) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "releasing allocated subnet from AzureCluster CR")
+
+	azureMachinePool := &v1alpha3.AzureMachinePool{}
+	err := r.ctrlClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, azureMachinePool)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.removeSubnetFromAzureCluster(ctx, subnet, azureMachinePool)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "released allocated subnet from AzureCluster CR")
+	return nil
+}
+
+func (r *AzureMachinePoolSubnetReleaser) removeSubnetFromAzureCluster(ctx context.Context, subnet net.IPNet, azureMachinePool *v1alpha3.AzureMachinePool) error {
+	azureCluster, err := helpers.GetAzureClusterFromMetadata(ctx, r.ctrlClient, azureMachinePool.ObjectMeta)
+	if err != nil {
+		errorMessage := fmt.Sprintf("error while getting AzureCluster CR from AzureMachinePool CR metadata")
+		r.logger.LogCtx(ctx, "level", "warning", "message", errorMessage)
+		return microerror.Mask(err)
+	}
+
+	for i, subnet := range azureCluster.Spec.NetworkSpec.Subnets {
+		if subnet.Name == azureMachinePool.Name {
+			azureCluster.Spec.NetworkSpec.Subnets = append(azureCluster.Spec.NetworkSpec.Subnets[:i], azureCluster.Spec.NetworkSpec.Subnets[i+1:]...)
+			break
+		}
+	}
+
+	err = r.ctrlClient.Update(ctx, azureCluster)
+	if apierrors.IsConflict(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "conflict trying to save object in k8s API concurrently", "stack", microerror.JSON(microerror.Mask(err)))
+		r.logger.LogCtx(ctx, "level", "debug", "message", "cancelling resource")
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/resource/ipam/create.go
+++ b/service/controller/resource/ipam/create.go
@@ -48,12 +48,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	// 1/4 Check if a vnet/subnet is already allocated.
 	{
-		proceed, err := r.checker.Check(ctx, m.GetNamespace(), m.GetName())
+		subnet, err := r.checker.Check(ctx, m.GetNamespace(), m.GetName())
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
-		if !proceed {
+		if subnet != nil {
 			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("%s already allocated", r.networkRangeType))
 			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 			return nil

--- a/service/controller/resource/ipam/create_test.go
+++ b/service/controller/resource/ipam/create_test.go
@@ -24,7 +24,7 @@ func Test_SubnetAllocator(t *testing.T) {
 		{
 			name: "case 0 allocate first subnet",
 
-			checker:            NewTestChecker(true),
+			checker:            NewTestChecker(nil),
 			collector:          NewTestCollector([]net.IPNet{}),
 			networkRangeGetter: NewTestNetworkRangeGetter(mustParseCIDR("10.100.0.0/16"), 24),
 			persister:          NewTestPersister(mustParseCIDR("10.100.0.0/24")),
@@ -32,7 +32,7 @@ func Test_SubnetAllocator(t *testing.T) {
 		{
 			name: "case 1 allocate fourth subnet",
 
-			checker: NewTestChecker(true),
+			checker: NewTestChecker(nil),
 			collector: NewTestCollector([]net.IPNet{
 				mustParseCIDR("10.100.0.0/24"),
 				mustParseCIDR("10.100.1.0/24"),
@@ -92,4 +92,8 @@ func mustParseCIDR(val string) net.IPNet {
 	}
 
 	return *n
+}
+
+func toIPNetP(v net.IPNet) *net.IPNet {
+	return &v
 }

--- a/service/controller/resource/ipam/create_test.go
+++ b/service/controller/resource/ipam/create_test.go
@@ -93,7 +93,3 @@ func mustParseCIDR(val string) net.IPNet {
 
 	return *n
 }
-
-func toIPNetP(v net.IPNet) *net.IPNet {
-	return &v
-}

--- a/service/controller/resource/ipam/create_test.go
+++ b/service/controller/resource/ipam/create_test.go
@@ -69,6 +69,7 @@ func Test_SubnetAllocator(t *testing.T) {
 					NetworkRangeGetter: tc.networkRangeGetter,
 					NetworkRangeType:   "unit-test-network-range",
 					Persister:          tc.persister,
+					Releaser:           NewNOPReleaser(),
 				}
 
 				newResource, err = New(c)

--- a/service/controller/resource/ipam/delete.go
+++ b/service/controller/resource/ipam/delete.go
@@ -2,8 +2,73 @@ package ipam
 
 import (
 	"context"
+	"fmt"
+	"net"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	"github.com/giantswarm/azure-operator/v5/pkg/locker"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	var err error
+
+	m, err := meta.Accessor(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "acquiring lock for IPAM")
+		err := r.locker.Lock(ctx)
+		if locker.IsAlreadyExists(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "lock for IPAM is already acquired")
+		} else if err != nil {
+			return microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "acquired lock for IPAM")
+		}
+
+		defer func() {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "releasing lock for IPAM")
+			err := r.locker.Unlock(ctx)
+			if locker.IsNotFound(err) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", "lock for IPAM is already released")
+			} else if err != nil {
+				r.logger.LogCtx(ctx, "level", "error", "message", "failed to release lock for IPAM", "stack", fmt.Sprintf("%#v", err))
+			} else {
+				r.logger.LogCtx(ctx, "level", "debug", "message", "released lock for IPAM")
+			}
+		}()
+	}
+
+	// Check if subnet is still allocated.
+	var subnet *net.IPNet
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding if subnet is still allocated")
+
+		subnet, err = r.checker.Check(ctx, m.GetNamespace(), m.GetName())
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		if subnet == nil {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find allocated subnet")
+			return nil
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found allocated subnet")
+		r.logger.LogCtx(ctx, "level", "debug", "message", "releasing allocated subnet")
+
+		// Release allocated subnet.
+		err = r.releaser.Release(ctx, *subnet, m.GetNamespace(), m.GetName())
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "released allocated subnet")
+	}
+
 	return nil
 }

--- a/service/controller/resource/ipam/nop_releaser.go
+++ b/service/controller/resource/ipam/nop_releaser.go
@@ -1,0 +1,16 @@
+package ipam
+
+import (
+	"context"
+	"net"
+)
+
+type nopReleaser struct{}
+
+func NewNOPReleaser() Releaser {
+	return &nopReleaser{}
+}
+
+func (r *nopReleaser) Release(ctx context.Context, subnet net.IPNet, namespace, name string) error {
+	return nil
+}

--- a/service/controller/resource/ipam/resource.go
+++ b/service/controller/resource/ipam/resource.go
@@ -23,6 +23,7 @@ type Config struct {
 	NetworkRangeGetter NetworkRangeGetter
 	NetworkRangeType   NetworkRangeType
 	Persister          Persister
+	Releaser           Releaser
 }
 
 // Resource finds free IP ranges:
@@ -36,6 +37,7 @@ type Resource struct {
 	networkRangeGetter NetworkRangeGetter
 	networkRangeType   NetworkRangeType
 	persister          Persister
+	releaser           Releaser
 }
 
 func New(config Config) (*Resource, error) {
@@ -60,6 +62,9 @@ func New(config Config) (*Resource, error) {
 	if config.Persister == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Persister must not be empty", config)
 	}
+	if config.Releaser == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Releaser must not be empty", config)
+	}
 
 	r := &Resource{
 		checker:            config.Checker,
@@ -69,6 +74,7 @@ func New(config Config) (*Resource, error) {
 		networkRangeGetter: config.NetworkRangeGetter,
 		networkRangeType:   config.NetworkRangeType,
 		persister:          config.Persister,
+		releaser:           config.Releaser,
 	}
 
 	return r, nil

--- a/service/controller/resource/ipam/spec.go
+++ b/service/controller/resource/ipam/spec.go
@@ -5,11 +5,12 @@ import (
 	"net"
 )
 
-// Checker determines whether a subnet has to be allocated. This decision is
+// Checker determines whether a subnet has been allocated. This decision is
 // being made based on the status of the Kubernetes runtime object defined by
-// namespace and name.
+// namespace and name. If subnet has been allocated, it's returned. Otherwise
+// return value is nil.
 type Checker interface {
-	Check(ctx context.Context, namespace string, name string) (bool, error)
+	Check(ctx context.Context, namespace string, name string) (*net.IPNet, error)
 }
 
 // Collector implementation must return all networks that are allocated on any

--- a/service/controller/resource/ipam/spec.go
+++ b/service/controller/resource/ipam/spec.go
@@ -10,7 +10,7 @@ import (
 // namespace and name. If subnet has been allocated, it's returned. Otherwise
 // return value is nil.
 type Checker interface {
-	Check(ctx context.Context, namespace string, name string) (*net.IPNet, error)
+	Check(ctx context.Context, namespace, name string) (*net.IPNet, error)
 }
 
 // Collector implementation must return all networks that are allocated on any
@@ -34,5 +34,11 @@ type NetworkRangeGetter interface {
 // Persister must mutate shared persistent state so that on successful execution
 // persisted networks are visible by Collector implementations.
 type Persister interface {
-	Persist(ctx context.Context, subnet net.IPNet, namespace string, name string) error
+	Persist(ctx context.Context, subnet net.IPNet, namespace, name string) error
+}
+
+// Releaser must mutate shared persistent state so that on successful execution
+// allocated subnet is released.
+type Releaser interface {
+	Release(ctx context.Context, subnet net.IPNet, namespace, name string) error
 }

--- a/service/controller/resource/ipam/test_checker.go
+++ b/service/controller/resource/ipam/test_checker.go
@@ -2,20 +2,21 @@ package ipam
 
 import (
 	"context"
+	"net"
 )
 
 type TestChecker struct {
-	proceed bool
+	subnet *net.IPNet
 }
 
-func NewTestChecker(proceed bool) *TestChecker {
+func NewTestChecker(subnet *net.IPNet) *TestChecker {
 	a := &TestChecker{
-		proceed: proceed,
+		subnet: subnet,
 	}
 
 	return a
 }
 
-func (c *TestChecker) Check(ctx context.Context, namespace string, name string) (bool, error) {
-	return c.proceed, nil
+func (c *TestChecker) Check(ctx context.Context, namespace string, name string) (*net.IPNet, error) {
+	return c.subnet, nil
 }


### PR DESCRIPTION
As a preparation for fixing subnet releasing on deletion of node pool,
refactor `ipam.Check()` to return allocated subnet if it exists.