### PR TITLE
Implement migration for worker network fw rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Re-configure workers' network security group rules when upgrading from pre-NP cluster.
 - Release allocated subnet when deleting node pool.
 
 ## [5.0.0-beta5] - 2020-11-18

--- a/client/azure_client_set.go
+++ b/client/azure_client_set.go
@@ -251,6 +251,13 @@ func newNatGatewaysClient(authorizer autorest.Authorizer, metricsCollector colle
 	return &client, nil
 }
 
+func newNetworkSecurityGroupsClient(authorizer autorest.Authorizer, metricsCollector collector.AzureAPIMetrics, subscriptionID, partnerID string) (interface{}, error) {
+	client := network.NewSecurityGroupsClient(subscriptionID)
+	prepareClient(&client.Client, authorizer, metricsCollector, "network_security_groups", subscriptionID, partnerID)
+
+	return &client, nil
+}
+
 func newPublicIPAddressesClient(authorizer autorest.Authorizer, metricsCollector collector.AzureAPIMetrics, subscriptionID, partnerID string) (*network.PublicIPAddressesClient, error) {
 	client := network.NewPublicIPAddressesClient(subscriptionID)
 	prepareClient(&client.Client, authorizer, metricsCollector, "public_ip_addresses", subscriptionID, partnerID)
@@ -388,6 +395,10 @@ func toSubnetsClient(client interface{}) *network.SubnetsClient {
 
 func toNatGatewaysClient(client interface{}) *network.NatGatewaysClient {
 	return client.(*network.NatGatewaysClient)
+}
+
+func toNetworkSecurityGroupsClient(client interface{}) *network.SecurityGroupsClient {
+	return client.(*network.SecurityGroupsClient)
 }
 
 func toResourceSkusClient(client interface{}) *compute.ResourceSkusClient {

--- a/client/factory.go
+++ b/client/factory.go
@@ -222,6 +222,17 @@ func (f *Factory) GetNatGatewaysClient(credentialNamespace, credentialName strin
 	return toNatGatewaysClient(client), nil
 }
 
+// GetNetworkSecurityGroupsClient returns *network.SecurityGroupsClient that is used for management of Network Security Groups.
+// The created client is cached for the time period specified in the factory config.
+func (f *Factory) GetNetworkSecurityGroupsClient(credentialNamespace, credentialName string) (*network.SecurityGroupsClient, error) {
+	client, err := f.getClient(credentialNamespace, credentialName, "NetworkSecurityGroupsClient", newNetworkSecurityGroupsClient)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return toNetworkSecurityGroupsClient(client), nil
+}
+
 // GetResourceSkusClient returns *compute.ResourceSkusClient that is used for reading VM instance types.
 // The created client is cached for the time period specified in the factory config.
 func (f *Factory) GetResourceSkusClient(credentialNamespace, credentialName string) (*compute.ResourceSkusClient, error) {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.1-pike"
+	version            = "5.0.1-dev"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.1-porcula"
+	version            = "5.0.1-dev"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.1-dev"
+	version            = "5.0.1-porcula"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.1-dev"
+	version            = "5.0.1-pike"
 )
 
 func Description() string {

--- a/service/controller/resource/workermigration/create.go
+++ b/service/controller/resource/workermigration/create.go
@@ -63,6 +63,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring that legacy workers are migrated to node pool")
 
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensure worker security group rules are updated")
+	err = r.ensureSecurityGroupRulesUpdated(ctx, cr, azureAPI)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensured worker security group rules are updated")
+
 	r.logger.LogCtx(ctx, "level", "debug", "message", "finding legacy workers VMSS")
 	var legacyVMSS azure.VMSS
 	{
@@ -88,13 +95,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "found legacy workers VMSS")
-
-	r.logger.LogCtx(ctx, "level", "debug", "message", "ensure worker security group rules are updated")
-	err = r.ensureSecurityGroupRulesUpdated(ctx, cr, azureAPI)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-	r.logger.LogCtx(ctx, "level", "debug", "message", "ensured worker security group rules are updated")
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring AzureMachinePool CR exists for legacy workers VMSS")
 	azureMachinePool, err := r.ensureAzureMachinePoolExists(ctx, cr, *legacyVMSS.Sku.Name)

--- a/service/controller/resource/workermigration/create.go
+++ b/service/controller/resource/workermigration/create.go
@@ -89,6 +89,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "found legacy workers VMSS")
 
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensure worker security group rules are updated")
+	err = r.ensureSecurityGroupRulesUpdated(ctx, cr, azureAPI)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensured worker security group rules are updated")
+
 	r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring AzureMachinePool CR exists for legacy workers VMSS")
 	azureMachinePool, err := r.ensureAzureMachinePoolExists(ctx, cr, *legacyVMSS.Sku.Name)
 	if err != nil {

--- a/service/controller/resource/workermigration/create_test.go
+++ b/service/controller/resource/workermigration/create_test.go
@@ -115,6 +115,12 @@ func TestMigrationCreatesMachinePoolCRs(t *testing.T) {
 
 	m.
 		EXPECT().
+		ListNetworkSecurityGroups(gomock.Any(), key.ResourceGroupName(*cr)).
+		Return(nil, nil).
+		Times(1)
+
+	m.
+		EXPECT().
 		GetVMSS(gomock.Any(), key.ResourceGroupName(*cr), key.WorkerVMSSName(*cr)).
 		Return(newBuiltinVMSS(3, key.WorkerVMSSName(*cr)), nil).
 		Times(1)
@@ -216,6 +222,12 @@ func TestMigrationCreatesDrainerConfigCRs(t *testing.T) {
 
 	mockAzureAPI.
 		EXPECT().
+		ListNetworkSecurityGroups(gomock.Any(), key.ResourceGroupName(*cr)).
+		Return(nil, nil).
+		Times(1)
+
+	mockAzureAPI.
+		EXPECT().
 		GetVMSS(gomock.Any(), key.ResourceGroupName(*cr), key.WorkerVMSSName(*cr)).
 		Return(newBuiltinVMSS(3, key.WorkerVMSSName(*cr)), nil).
 		Times(1)
@@ -289,6 +301,12 @@ func TestVMSSIsNotDeletedBeforeDrainingIsDone(t *testing.T) {
 	cr := o.(*providerv1alpha1.AzureConfig)
 
 	ensureNodePoolIsReady(t, ctrlClient, cr)
+
+	mockAzureAPI.
+		EXPECT().
+		ListNetworkSecurityGroups(gomock.Any(), key.ResourceGroupName(*cr)).
+		Return(nil, nil).
+		Times(1)
 
 	mockAzureAPI.
 		EXPECT().
@@ -366,6 +384,12 @@ func TestVMSSIsDeletedOnceDrainingIsDone(t *testing.T) {
 
 	ensureNodePoolIsReady(t, ctrlClient, cr)
 	setDrainerConfigsAsDrained(t, ctrlClient, cr)
+
+	mockAzureAPI.
+		EXPECT().
+		ListNetworkSecurityGroups(gomock.Any(), key.ResourceGroupName(*cr)).
+		Return(nil, nil).
+		Times(1)
 
 	mockAzureAPI.
 		EXPECT().
@@ -451,6 +475,12 @@ func TestLegacyWorkerDeploymentIsDeleted(t *testing.T) {
 
 	mockAzureAPI.
 		EXPECT().
+		ListNetworkSecurityGroups(gomock.Any(), key.ResourceGroupName(*cr)).
+		Return(nil, nil).
+		Times(1)
+
+	mockAzureAPI.
+		EXPECT().
 		GetVMSS(gomock.Any(), key.ResourceGroupName(*cr), key.WorkerVMSSName(*cr)).
 		Return(newBuiltinVMSS(3, key.WorkerVMSSName(*cr)), nil).
 		Times(1)
@@ -517,6 +547,12 @@ func TestLegacyWorkerDeploymentDeletionDoesntErrorInNotFoundCase(t *testing.T) {
 
 	mockAzureAPI.
 		EXPECT().
+		ListNetworkSecurityGroups(gomock.Any(), key.ResourceGroupName(*cr)).
+		Return(nil, nil).
+		Times(1)
+
+	mockAzureAPI.
+		EXPECT().
 		GetVMSS(gomock.Any(), key.ResourceGroupName(*cr), key.WorkerVMSSName(*cr)).
 		Return(newBuiltinVMSS(3, key.WorkerVMSSName(*cr)), nil).
 		Times(1)
@@ -569,6 +605,12 @@ func TestFinishedMigration(t *testing.T) {
 		t.Fatal(err)
 	}
 	cr := o.(*providerv1alpha1.AzureConfig)
+
+	m.
+		EXPECT().
+		ListNetworkSecurityGroups(gomock.Any(), key.ResourceGroupName(*cr)).
+		Return(nil, nil).
+		Times(0)
 
 	m.
 		EXPECT().

--- a/service/controller/resource/workermigration/create_test.go
+++ b/service/controller/resource/workermigration/create_test.go
@@ -610,7 +610,7 @@ func TestFinishedMigration(t *testing.T) {
 		EXPECT().
 		ListNetworkSecurityGroups(gomock.Any(), key.ResourceGroupName(*cr)).
 		Return(nil, nil).
-		Times(0)
+		Times(1)
 
 	m.
 		EXPECT().

--- a/service/controller/resource/workermigration/internal/azure/spec.go
+++ b/service/controller/resource/workermigration/internal/azure/spec.go
@@ -4,10 +4,12 @@ import (
 	"context"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-11-01/network"
 )
 
 type VMSS *compute.VirtualMachineScaleSet
 type VMSSNodes []compute.VirtualMachineScaleSetVM
+type SecurityGroups []network.SecurityGroup
 
 type API interface {
 	// GetVMSS gets VMSS metadata from Azure API.
@@ -21,4 +23,10 @@ type API interface {
 
 	// ListVMSSNodes lists VMs in given VMSS via Azure API.
 	ListVMSSNodes(ctx context.Context, resourceGroupName, vmssName string) (VMSSNodes, error)
+
+	// ListNetworkSecurityGroups lists all network security groups in given resource group via Azure API.
+	ListNetworkSecurityGroups(ctx context.Context, resourceGroupName string) (SecurityGroups, error)
+
+	// CreateOrUpdateNetworkSecurityGroup creates or updates existing network security group via Azure API.
+	CreateOrUpdateNetworkSecurityGroup(ctx context.Context, resourceGroupName, networkSecurityGroupName string, securityGroup network.SecurityGroup) error
 }

--- a/service/controller/resource/workermigration/internal/mock_azure/api.go
+++ b/service/controller/resource/workermigration/internal/mock_azure/api.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-11-01/network"
 	gomock "github.com/golang/mock/gomock"
 
 	azure "github.com/giantswarm/azure-operator/v5/service/controller/resource/workermigration/internal/azure"
@@ -92,4 +93,33 @@ func (m *MockAPI) ListVMSSNodes(ctx context.Context, resourceGroupName, vmssName
 func (mr *MockAPIMockRecorder) ListVMSSNodes(ctx, resourceGroupName, vmssName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListVMSSNodes", reflect.TypeOf((*MockAPI)(nil).ListVMSSNodes), ctx, resourceGroupName, vmssName)
+}
+
+// ListNetworkSecurityGroups mocks base method
+func (m *MockAPI) ListNetworkSecurityGroups(ctx context.Context, resourceGroupName string) (azure.SecurityGroups, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNetworkSecurityGroups", ctx, resourceGroupName)
+	ret0, _ := ret[0].(azure.SecurityGroups)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNetworkSecurityGroups indicates an expected call of ListNetworkSecurityGroups
+func (mr *MockAPIMockRecorder) ListNetworkSecurityGroups(ctx, resourceGroupName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNetworkSecurityGroups", reflect.TypeOf((*MockAPI)(nil).ListNetworkSecurityGroups), ctx, resourceGroupName)
+}
+
+// CreateOrUpdateNetworkSecurityGroup mocks base method
+func (m *MockAPI) CreateOrUpdateNetworkSecurityGroup(ctx context.Context, resourceGroupName, networkSecurityGroupName string, securityGroup network.SecurityGroup) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrUpdateNetworkSecurityGroup", ctx, resourceGroupName, networkSecurityGroupName, securityGroup)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateOrUpdateNetworkSecurityGroup indicates an expected call of CreateOrUpdateNetworkSecurityGroup
+func (mr *MockAPIMockRecorder) CreateOrUpdateNetworkSecurityGroup(ctx, resourceGroupName, networkSecurityGroupName, securityGroup interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateNetworkSecurityGroup", reflect.TypeOf((*MockAPI)(nil).CreateOrUpdateNetworkSecurityGroup), ctx, resourceGroupName, networkSecurityGroupName, securityGroup)
 }

--- a/service/controller/resource/workermigration/security_groups.go
+++ b/service/controller/resource/workermigration/security_groups.go
@@ -1,0 +1,79 @@
+package workermigration
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-11-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	providerv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/azure-operator/v5/service/controller/key"
+	"github.com/giantswarm/azure-operator/v5/service/controller/resource/workermigration/internal/azure"
+)
+
+// Security group rules that need destination CIDR update from built-in worker subnet to VNET CIDR.
+var workerSecurityGroupRulesToUpdate = []string{
+	"allowCadvisor",
+	"allowKubelet",
+	"allowNodeExporter",
+	"allowKubeStateMetrics",
+	"sshHostClusterToWorkerSubnetRule",
+}
+
+func (r *Resource) ensureSecurityGroupRulesUpdated(ctx context.Context, cr providerv1alpha1.AzureConfig, azureAPI azure.API) error {
+	var err error
+	var securityGroups azure.SecurityGroups
+	{
+		securityGroups, err = azureAPI.ListNetworkSecurityGroups(ctx, key.ResourceGroupName(cr))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	for _, sg := range securityGroups {
+		if sg.Name != nil && *sg.Name == key.WorkerSecurityGroupName(cr) {
+			err := r.ensureDestinationCIDRUpdated(ctx, cr, azureAPI, sg, workerSecurityGroupRulesToUpdate)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *Resource) ensureDestinationCIDRUpdated(ctx context.Context, cr providerv1alpha1.AzureConfig, azureAPI azure.API, securityGroup network.SecurityGroup, rulesToUpdate []string) error {
+	if securityGroup.SecurityGroupPropertiesFormat == nil || securityGroup.SecurityGroupPropertiesFormat.SecurityRules == nil {
+		return microerror.Maskf(executionFailedError, "security group rules are missing from Azure API response")
+	}
+
+	var needUpdate bool
+	for _, rule := range *securityGroup.SecurityRules {
+		if rule.Name != nil && contains(rulesToUpdate, *rule.Name) {
+			if rule.DestinationAddressPrefix == nil || *rule.DestinationAddressPrefix != key.VnetCIDR(cr) {
+				rule.DestinationAddressPrefix = to.StringPtr(key.VnetCIDR(cr))
+				needUpdate = true
+			}
+		}
+	}
+
+	if needUpdate {
+		err := azureAPI.CreateOrUpdateNetworkSecurityGroup(ctx, key.ResourceGroupName(cr), *securityGroup.Name, securityGroup)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	return nil
+}
+
+func contains(xs []string, v string) bool {
+	for _, x := range xs {
+		if x == v {
+			return true
+		}
+	}
+
+	return false
+}

--- a/service/controller/resource/workermigration/security_groups.go
+++ b/service/controller/resource/workermigration/security_groups.go
@@ -12,6 +12,11 @@ import (
 	"github.com/giantswarm/azure-operator/v5/service/controller/resource/workermigration/internal/azure"
 )
 
+// Security group rules that are obsolete and needs to be GC'd.
+var workerSecurityGroupRulesToDelete = []string{
+	"defaultInClusterRule",
+}
+
 // Security group rules that need destination CIDR update from built-in worker subnet to VNET CIDR.
 var workerSecurityGroupRulesToUpdate = []string{
 	"allowCadvisor",
@@ -33,7 +38,7 @@ func (r *Resource) ensureSecurityGroupRulesUpdated(ctx context.Context, cr provi
 
 	for _, sg := range securityGroups {
 		if sg.Name != nil && *sg.Name == key.WorkerSecurityGroupName(cr) {
-			err := r.ensureDestinationCIDRUpdated(ctx, cr, azureAPI, sg, workerSecurityGroupRulesToUpdate)
+			err := r.ensureSecurityGroupUpdated(ctx, cr, azureAPI, sg, workerSecurityGroupRulesToDelete, workerSecurityGroupRulesToUpdate)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -43,13 +48,23 @@ func (r *Resource) ensureSecurityGroupRulesUpdated(ctx context.Context, cr provi
 	return nil
 }
 
-func (r *Resource) ensureDestinationCIDRUpdated(ctx context.Context, cr providerv1alpha1.AzureConfig, azureAPI azure.API, securityGroup network.SecurityGroup, rulesToUpdate []string) error {
+func (r *Resource) ensureSecurityGroupUpdated(ctx context.Context, cr providerv1alpha1.AzureConfig, azureAPI azure.API, securityGroup network.SecurityGroup, rulesToDelete, rulesToUpdate []string) error {
 	if securityGroup.SecurityGroupPropertiesFormat == nil || securityGroup.SecurityGroupPropertiesFormat.SecurityRules == nil {
 		return microerror.Maskf(executionFailedError, "security group rules are missing from Azure API response")
 	}
 
 	var needUpdate bool
-	for _, rule := range *securityGroup.SecurityRules {
+	rules := *securityGroup.SecurityRules
+	for i := 0; i < len(rules); i++ {
+		rule := rules[i]
+
+		if rule.Name != nil && contains(rulesToDelete, *rule.Name) {
+			rules = append(rules[:i], rules[i+1:]...)
+			needUpdate = true
+			i--
+			continue
+		}
+
 		if rule.Name != nil && contains(rulesToUpdate, *rule.Name) {
 			if rule.DestinationAddressPrefix == nil || *rule.DestinationAddressPrefix != key.VnetCIDR(cr) {
 				rule.DestinationAddressPrefix = to.StringPtr(key.VnetCIDR(cr))
@@ -57,6 +72,7 @@ func (r *Resource) ensureDestinationCIDRUpdated(ctx context.Context, cr provider
 			}
 		}
 	}
+	*securityGroup.SecurityRules = rules
 
 	if needUpdate {
 		err := azureAPI.CreateOrUpdateNetworkSecurityGroup(ctx, key.ResourceGroupName(cr), *securityGroup.Name, securityGroup)


### PR DESCRIPTION
Due to change prevention in network security group rules (to guard
customers' custom rules) the firewall rules don't get updated on cluster
upgrade and therefore the destination CIDR for some rules is wrong.

This change implements a migration path to replace built-in worker
subnet CIDR with VNET one.