### PR TITLE
Migrate master's security group rules on upgrade  (#1200)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Re-configure masters network security group to allow CP's public IPs to etcd LB ingress.
+
+## [5.0.0-beta6] - 2020-11-26
+
+### Fixed
+
 - Avoid returning errors when still waiting for tenant cluster k8s API to be ready.
 - Re-configure workers' network security group rules when upgrading from pre-NP cluster.
 - Release allocated subnet when deleting node pool.

--- a/client/azure_client_set.go
+++ b/client/azure_client_set.go
@@ -167,7 +167,7 @@ func NewAzureClientSet(clientCredentialsConfig auth.ClientCredentialsConfig, met
 		GroupsClient:                           toGroupsClient(groupsClient),
 		InterfacesClient:                       toInterfacesClient(interfacesClient),
 		NatGatewaysClient:                      toNatGatewaysClient(natGatewaysClient),
-		PublicIpAddressesClient:                publicIpAddressesClient,
+		PublicIpAddressesClient:                toPublicIPAddressesClient(publicIpAddressesClient),
 		ResourceSkusClient:                     toResourceSkusClient(resourcesSkusClient),
 		SecurityRulesClient:                    securityRulesClient,
 		SnapshotsClient:                        toSnapshotsClient(snapshotsClient),
@@ -258,7 +258,7 @@ func newNetworkSecurityGroupsClient(authorizer autorest.Authorizer, metricsColle
 	return &client, nil
 }
 
-func newPublicIPAddressesClient(authorizer autorest.Authorizer, metricsCollector collector.AzureAPIMetrics, subscriptionID, partnerID string) (*network.PublicIPAddressesClient, error) {
+func newPublicIPAddressesClient(authorizer autorest.Authorizer, metricsCollector collector.AzureAPIMetrics, subscriptionID, partnerID string) (interface{}, error) {
 	client := network.NewPublicIPAddressesClient(subscriptionID)
 	prepareClient(&client.Client, authorizer, metricsCollector, "public_ip_addresses", subscriptionID, partnerID)
 
@@ -399,6 +399,10 @@ func toNatGatewaysClient(client interface{}) *network.NatGatewaysClient {
 
 func toNetworkSecurityGroupsClient(client interface{}) *network.SecurityGroupsClient {
 	return client.(*network.SecurityGroupsClient)
+}
+
+func toPublicIPAddressesClient(client interface{}) *network.PublicIPAddressesClient {
+	return client.(*network.PublicIPAddressesClient)
 }
 
 func toResourceSkusClient(client interface{}) *compute.ResourceSkusClient {

--- a/client/factory.go
+++ b/client/factory.go
@@ -233,6 +233,15 @@ func (f *Factory) GetNetworkSecurityGroupsClient(credentialNamespace, credential
 	return toNetworkSecurityGroupsClient(client), nil
 }
 
+func (f *Factory) GetPublicIPAddressesClient(credentialNamespace, credentialName string) (*network.PublicIPAddressesClient, error) {
+	client, err := f.getClient(credentialNamespace, credentialName, "PublicIPAddressesClient", newPublicIPAddressesClient)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return toPublicIPAddressesClient(client), nil
+}
+
 // GetResourceSkusClient returns *compute.ResourceSkusClient that is used for reading VM instance types.
 // The created client is cached for the time period specified in the factory config.
 func (f *Factory) GetResourceSkusClient(credentialNamespace, credentialName string) (*compute.ResourceSkusClient, error) {

--- a/service/controller/azure_config.go
+++ b/service/controller/azure_config.go
@@ -450,7 +450,8 @@ func newAzureConfigResources(config AzureConfigConfig, certsSearcher certs.Inter
 			CtrlClient:    config.K8sClient.CtrlClient(),
 			Logger:        config.Logger,
 
-			Location: config.Azure.Location,
+			InstallationName: config.InstallationName,
+			Location:         config.Azure.Location,
 		}
 
 		workerMigrationResource, err = workermigration.New(c)

--- a/service/controller/resource/workermigration/create.go
+++ b/service/controller/resource/workermigration/create.go
@@ -63,12 +63,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "ensuring that legacy workers are migrated to node pool")
 
-	r.logger.LogCtx(ctx, "level", "debug", "message", "ensure worker security group rules are updated")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensure security group rules are updated")
 	err = r.ensureSecurityGroupRulesUpdated(ctx, cr, azureAPI)
 	if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(ctx, "level", "debug", "message", "ensured worker security group rules are updated")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "ensured security group rules are updated")
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "finding legacy workers VMSS")
 	var legacyVMSS azure.VMSS

--- a/service/controller/resource/workermigration/internal/azure/api.go
+++ b/service/controller/resource/workermigration/internal/azure/api.go
@@ -2,6 +2,7 @@ package azure
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-11-01/network"
@@ -125,4 +126,31 @@ func (a *api) CreateOrUpdateNetworkSecurityGroup(ctx context.Context, resourceGr
 	}
 
 	return nil
+}
+
+func (a *api) ListPublicIPs(ctx context.Context, resourceGroupName string) ([]string, error) {
+	client, err := a.clientFactory.GetPublicIPAddressesClient(a.credentials.Namespace, a.credentials.Name)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	allPublicIPs, err := client.ListComplete(ctx, resourceGroupName)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var ips []string
+	for allPublicIPs.NotDone() {
+		ip := allPublicIPs.Value()
+		// Masters use the API LB as egress gateway, the workers use the ingress LB.
+		if ip.Name != nil && *ip.Name == fmt.Sprintf("%s_ingress_ip", resourceGroupName) || *ip.Name == fmt.Sprintf("%s_api_ip", resourceGroupName) {
+			ips = append(ips, *ip.IPAddress)
+		}
+		err := allPublicIPs.NextWithContext(ctx)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return ips, nil
 }

--- a/service/controller/resource/workermigration/internal/azure/spec.go
+++ b/service/controller/resource/workermigration/internal/azure/spec.go
@@ -29,4 +29,7 @@ type API interface {
 
 	// CreateOrUpdateNetworkSecurityGroup creates or updates existing network security group via Azure API.
 	CreateOrUpdateNetworkSecurityGroup(ctx context.Context, resourceGroupName, networkSecurityGroupName string, securityGroup network.SecurityGroup) error
+
+	// List all Public IPs from a given resource group via Azure API.
+	ListPublicIPs(ctx context.Context, resourceGroupName string) ([]string, error)
 }

--- a/service/controller/resource/workermigration/internal/mock_azure/api.go
+++ b/service/controller/resource/workermigration/internal/mock_azure/api.go
@@ -123,3 +123,18 @@ func (mr *MockAPIMockRecorder) CreateOrUpdateNetworkSecurityGroup(ctx, resourceG
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdateNetworkSecurityGroup", reflect.TypeOf((*MockAPI)(nil).CreateOrUpdateNetworkSecurityGroup), ctx, resourceGroupName, networkSecurityGroupName, securityGroup)
 }
+
+// ListPublicIPs mocks base method
+func (m *MockAPI) ListPublicIPs(ctx context.Context, resourceGroupName string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPublicIPs", ctx, resourceGroupName)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPublicIPs indicates an expected call of ListPublicIPs
+func (mr *MockAPIMockRecorder) ListPublicIPs(ctx, resourceGroupName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPublicIPs", reflect.TypeOf((*MockAPI)(nil).ListPublicIPs), ctx, resourceGroupName)
+}

--- a/service/controller/resource/workermigration/resource.go
+++ b/service/controller/resource/workermigration/resource.go
@@ -22,7 +22,8 @@ type Config struct {
 	CtrlClient    client.Client
 	Logger        micrologger.Logger
 
-	Location string
+	InstallationName string
+	Location         string
 }
 
 type Resource struct {
@@ -32,7 +33,8 @@ type Resource struct {
 	tenantClientFactory tenantcluster.Factory
 	wrapAzureAPI        func(cf *azureclient.Factory, credentials *providerv1alpha1.CredentialSecret) azure.API
 
-	location string
+	installationName string
+	location         string
 }
 
 func New(config Config) (*Resource, error) {
@@ -44,6 +46,9 @@ func New(config Config) (*Resource, error) {
 	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.InstallationName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.InstallationName must not be empty", config)
 	}
 	if config.Location == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Location must not be empty", config)
@@ -66,7 +71,8 @@ func New(config Config) (*Resource, error) {
 		tenantClientFactory: cachedTenantClientFactory,
 		wrapAzureAPI:        azure.GetAPI,
 
-		location: config.Location,
+		installationName: config.InstallationName,
+		location:         config.Location,
 	}
 
 	return newResource, nil


### PR DESCRIPTION
As part of preparation work towards HA masters the etcd LB was changed
from internal to external. This has the effect that control plane
cluster's clients are arriving from different source IPs and these must
be now updated into etcd LB ingress rules when upgrading a pre-NP
cluster.