### PR TITLE
Hardcode sentry DSN because it makes no sense to inject it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/giantswarm/k8scloudconfig/v9 v9.1.3
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v0.2.0
-	github.com/giantswarm/microerror v0.2.1
+	github.com/giantswarm/microerror v0.3.0
 	github.com/giantswarm/microkit v0.2.2
 	github.com/giantswarm/micrologger v0.3.4
 	github.com/giantswarm/operatorkit/v2 v2.0.2

--- a/go.sum
+++ b/go.sum
@@ -356,6 +356,8 @@ github.com/giantswarm/microendpoint v0.2.0/go.mod h1:SSkSp4Q4iSW7vwkil+/E3IXy9Q8
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=
 github.com/giantswarm/microerror v0.2.1 h1:4y88WstqZ4OSSq6T/TvTJaefRe/JbrbuwoWQNVxOOyU=
 github.com/giantswarm/microerror v0.2.1/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=
+github.com/giantswarm/microerror v0.3.0 h1:V/9cXlIEddNGaRYiA0vYJmgM2+sTQy+k8M7kVjOy4XM=
+github.com/giantswarm/microerror v0.3.0/go.mod h1:g8oCEMFAoEs70riRRmj9+6eiz7SqNxYl+2OfxFh1po0=
 github.com/giantswarm/microkit v0.2.0/go.mod h1:1vDHFUN+ZsUahZJ2hgZxcU7nG35Rj484t8Y5akhdRIM=
 github.com/giantswarm/microkit v0.2.2 h1:BNK55FyS+AXls6mH+81Iloo3z2+FRWqeEz2jYb7ZUhc=
 github.com/giantswarm/microkit v0.2.2/go.mod h1:XCj0vA/+jHiM03XDMlcWuvYdgZQyNS3O7ZVHDOUCYA8=

--- a/helm/azure-operator/templates/configmap.yaml
+++ b/helm/azure-operator/templates/configmap.yaml
@@ -89,7 +89,5 @@ data:
       tenant:
         ssh:
           ssoPublicKey: '{{ .Values.Installation.V1.Guest.SSH.SSOPublicKey }}'
-      {{- if .Values.Installation.V1.Sentry }}
       sentry:
-        dsn: '{{ .Values.Installation.V1.Sentry.DSN }}'
-      {{- end }}
+        dsn: 'https://632f9667d01c47719beb5b405962de53@o346224.ingest.sentry.io/5544796'


### PR DESCRIPTION
It doesn't make sense to inject the DNS from the installations repo.
All versions of azure operator should send data to the same project in sentry otherwise having a central error collector doesn't make sense.
For this reason I harcdoded the DSN in the helm chart.

I also bumped to latest microerror