### PR TITLE
Fix incorrect Upgrading condition transition from True to False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Only submit Subnet ARM deployment when Subnet name or Subnet CIDR change.
 - Use controller-runtime instead of typed clients.
+- Move provider-independent conditions implementation to external `giantswarm/conditions` and `giantswarm/conditions-handlers` modules.
+- Replaced Cluster `ProviderInfrastructureReady` with upstream `InfrastructureReady` condition.
+- Fix incorrect (too early) `Upgrading` condition transition from `True` to `False`.
 
 ### Added
 
 - Tenant cluster k8s client lookup is cached.
 - Add `terminate-unhealthy-node` feature to automaticaly terminate bad and unhealthy nodes in a Cluster.
+- Cluster `ControlPlaneReady` condition.
+- AzureMachine `Ready`, `SubnetReady` and `VMSSReady` conditions.
+- MachinePool `Creating` condition.
 
 ### Fixed
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/giantswarm/badnodedetector v1.0.1
 	github.com/giantswarm/certs/v3 v3.1.0
 	github.com/giantswarm/conditions v0.2.0
-	github.com/giantswarm/conditions-handler v0.1.0
+	github.com/giantswarm/conditions-handler v0.1.1
 	github.com/giantswarm/e2e-harness/v3 v3.0.0
 	github.com/giantswarm/e2eclients v0.2.0
 	github.com/giantswarm/e2esetup/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -328,8 +328,8 @@ github.com/giantswarm/cluster-api-provider-azure v0.4.9-gsalpha2 h1:rkmGkanOvFi/
 github.com/giantswarm/cluster-api-provider-azure v0.4.9-gsalpha2/go.mod h1:iD4hxYobC6/eAlBOcrE6NAIwEDHcD174Uck5FmZZx8U=
 github.com/giantswarm/conditions v0.2.0 h1:sOS319rNgfRl/LuzeEmCcyjYa8V4GCtR4NtwyfNTAmo=
 github.com/giantswarm/conditions v0.2.0/go.mod h1:Bp0zSox1MdFV20MTvjXOr8li+v11OLX/8kponaIGVrw=
-github.com/giantswarm/conditions-handler v0.1.0 h1:18gHM6V8FpdgfvoDs8T78i/KRar1Nh+50Pen8uyyyjo=
-github.com/giantswarm/conditions-handler v0.1.0/go.mod h1:cA+BxmL9uAa7tMdCOEEzEj9nHv9HL//e7kA/ulh+TQQ=
+github.com/giantswarm/conditions-handler v0.1.1 h1:nUJM79l3TUxHzsnMzVUWVC5eKxPa2dltkWoQz04FBsE=
+github.com/giantswarm/conditions-handler v0.1.1/go.mod h1:3XmDH+Amxf2sPPqCHohTORpmKIVsx+5EF9/5HF0i5A4=
 github.com/giantswarm/e2e-harness/v3 v3.0.0 h1:o9lQRIqrOOkJIgMSsN2pjSM7XeXm3PODNCD7H4Wi3V8=
 github.com/giantswarm/e2e-harness/v3 v3.0.0/go.mod h1:NjvAx1Ad357m77SFS0+VOD9Qecp2x7vFTMSLwyAyS5U=
 github.com/giantswarm/e2eclients v0.2.0 h1:fk3/dU1tAt9NHgSZwz4C9Bm15E9lFuNfYYneLjkw5Sg=
@@ -370,7 +370,6 @@ github.com/giantswarm/microkit v0.2.2 h1:BNK55FyS+AXls6mH+81Iloo3z2+FRWqeEz2jYb7
 github.com/giantswarm/microkit v0.2.2/go.mod h1:XCj0vA/+jHiM03XDMlcWuvYdgZQyNS3O7ZVHDOUCYA8=
 github.com/giantswarm/micrologger v0.3.1/go.mod h1:PjAgtcJ922ZMX/Aa05IPi0bdYvOj2P7pZ7+6dBShMQs=
 github.com/giantswarm/micrologger v0.3.3/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeVyhdHKblFX6QoMQ=
-github.com/giantswarm/micrologger v0.3.4/go.mod h1:fkzQdDBC6HjJq4nllBDt6XB4t4yeVyhdHKblFX6QoMQ=
 github.com/giantswarm/micrologger v0.4.0 h1:2EpnX86HKpqUNY8C4qbB2SzniB4bgES8Cd/mYrVyOrI=
 github.com/giantswarm/micrologger v0.4.0/go.mod h1:xsD5laBXORMy/P34IHZMK0y/D1gTkYtASUL4gUm5KN4=
 github.com/giantswarm/microstorage v0.2.0 h1:0m2W2wbWU0x4TRuqlC1U3Ibqt783E6/q8ZpLvELDkHc=

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.1.0-upgradingfix"
+	version            = "5.1.0-dev"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.1-newconditions"
+	version            = "5.1.0-upgradingfix"
 )
 
 func Description() string {

--- a/service/controller/azure_machine_pool.go
+++ b/service/controller/azure_machine_pool.go
@@ -193,8 +193,9 @@ func NewAzureMachinePoolResourceSet(config AzureMachinePoolConfig) ([]resource.I
 	}
 
 	nodesConfig := nodes.Config{
-		Debugger: newDebugger,
-		Logger:   config.Logger,
+		CtrlClient: config.K8sClient.CtrlClient(),
+		Debugger:   newDebugger,
+		Logger:     config.Logger,
 
 		Azure:         config.Azure,
 		ClientFactory: organizationClientFactory,
@@ -217,7 +218,6 @@ func NewAzureMachinePoolResourceSet(config AzureMachinePoolConfig) ([]resource.I
 		c := nodepool.Config{
 			Config:              nodesConfig,
 			CredentialProvider:  config.CredentialProvider,
-			CtrlClient:          config.K8sClient.CtrlClient(),
 			TenantClientFactory: cachedTenantClientFactory,
 			VMSKU:               vmSKU,
 		}

--- a/service/controller/resource/azuremachineconditions/create.go
+++ b/service/controller/resource/azuremachineconditions/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
 )
@@ -22,7 +23,11 @@ func (r *Resource) EnsureCreated(ctx context.Context, cr interface{}) error {
 	}
 
 	err = r.ctrlClient.Status().Update(ctx, &azureMachine)
-	if err != nil {
+	if apierrors.IsConflict(err) {
+		r.logger.Debugf(ctx, "conflict trying to save object in k8s API concurrently", "stack", microerror.JSON(microerror.Mask(err)))
+		r.logger.Debugf(ctx, "cancelling resource")
+		return nil
+	} else if err != nil {
 		return microerror.Mask(err)
 	}
 

--- a/service/controller/resource/clusterreleaseversion/checkupgradeprogress.go
+++ b/service/controller/resource/clusterreleaseversion/checkupgradeprogress.go
@@ -96,7 +96,7 @@ func (r *Resource) isUpgradeCompleted(ctx context.Context, cluster *capi.Cluster
 	// (2) Or we declare Upgrading to be completed if nothing happened for 20
 	// minutes, which could currently happen if we were upgrading some
 	// component which is not covered by any Ready status condition.
-	const upgradingWithoutReadyUpdateThreshold = 45 * time.Minute
+	const upgradingWithoutReadyUpdateThreshold = 60 * time.Minute
 	isReadyDuringEntireUpgradeProcess := time.Now().After(upgradingCondition.LastTransitionTime.Add(upgradingWithoutReadyUpdateThreshold))
 
 	if (becameReadyWhileUpgrading && allNodePoolsUpgraded) || isReadyDuringEntireUpgradeProcess {

--- a/service/controller/resource/clusterreleaseversion/checkupgradeprogress.go
+++ b/service/controller/resource/clusterreleaseversion/checkupgradeprogress.go
@@ -121,21 +121,6 @@ func (r *Resource) isUpgradeCompleted(ctx context.Context, cluster *capi.Cluster
 		return true, nil
 	}
 
-	// (3) Finally, if nothing happened for 2 hours and cluster is still not
-	// ready, we declare upgrading as completed, albeit unsuccessfully.
-	// If we left Upgrading to be stuck with status True, further cluster
-	// upgrades would be blocked by the admission controller, so this is a
-	// fail-safe.
-	const upgradingFinalTimeout = 120 * time.Minute
-	upgradingFinalTimeoutReached :=
-		time.Now().After(upgradingCondition.LastTransitionTime.Add(upgradingFinalTimeout))
-
-	if upgradingFinalTimeoutReached {
-		// Cluster upgrade is taking too long, declaring it as completed.
-		r.logger.Errorf(ctx, nil, "cluster upgrade is taking over %s, declaring upgrade completed", upgradingFinalTimeout)
-		return true, nil
-	}
-
 	// Cluster upgrade is still in progress.
 	r.logger.Debugf(ctx, "cluster upgrade is still in progress")
 	return false, nil

--- a/service/controller/resource/clusterreleaseversion/checkupgradeprogress.go
+++ b/service/controller/resource/clusterreleaseversion/checkupgradeprogress.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"time"
 
+	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/conditions/pkg/conditions"
 	"github.com/giantswarm/microerror"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capiconditions "sigs.k8s.io/cluster-api/util/conditions"
+
+	"github.com/giantswarm/azure-operator/v5/pkg/helpers"
+	"github.com/giantswarm/azure-operator/v5/service/controller/key"
 )
 
 func (r *Resource) isUpgradeCompleted(ctx context.Context, cluster *capi.Cluster) (bool, error) {
@@ -44,13 +48,58 @@ func (r *Resource) isUpgradeCompleted(ctx context.Context, cluster *capi.Cluster
 	// been completed.
 	becameReadyWhileUpgrading := readyCondition.LastTransitionTime.After(upgradingCondition.LastTransitionTime.Time)
 
+	machinePools, err := helpers.GetMachinePoolsByMetadata(ctx, r.ctrlClient, cluster.ObjectMeta)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	desiredClusterReleaseVersion := key.ReleaseVersion(cluster)
+
+	allNodePoolsUpgraded := true
+	for _, machinePool := range machinePools.Items {
+		if conditions.IsCreatingTrue(&machinePool) {
+			// A node pool is being created, this is the case for first upgrade
+			// to node pools release, as cluster upgrade will trigger first node
+			// pool creation.
+			allNodePoolsUpgraded = false
+			break
+		}
+
+		if conditions.IsUpgradingTrue(&machinePool) {
+			// A node pool is being upgraded.
+			allNodePoolsUpgraded = false
+			break
+		}
+
+		desiredMachinePoolReleaseVersion := key.ReleaseVersion(&machinePool)
+		if desiredMachinePoolReleaseVersion != desiredClusterReleaseVersion {
+			// A node pool upgrade has not been started yet.
+			allNodePoolsUpgraded = false
+			break
+		}
+
+		machinePoolLastDeployedReleaseVersion, machinePoolLastDeployedReleaseVersionSet := machinePool.Annotations[annotation.LastDeployedReleaseVersion]
+		if !machinePoolLastDeployedReleaseVersionSet {
+			// A node pool is still not created. This should be caught above in
+			// Creating check, but let's err on the side of caution here.
+			allNodePoolsUpgraded = false
+			break
+		}
+
+		if machinePoolLastDeployedReleaseVersion != desiredClusterReleaseVersion {
+			// A node pool has not yet been upgraded to the desired release version.
+			allNodePoolsUpgraded = false
+			break
+		}
+	}
+
 	// (2) Or we declare Upgrading to be completed if nothing happened for 20
 	// minutes, which could currently happen if we were upgrading some
 	// component which is not covered by any Ready status condition.
 	const upgradingWithoutReadyUpdateThreshold = 45 * time.Minute
 	isReadyDuringEntireUpgradeProcess := time.Now().After(upgradingCondition.LastTransitionTime.Add(upgradingWithoutReadyUpdateThreshold))
 
-	if becameReadyWhileUpgrading || isReadyDuringEntireUpgradeProcess {
+	if (becameReadyWhileUpgrading && allNodePoolsUpgraded) || isReadyDuringEntireUpgradeProcess {
 		// Cluster is ready, and either (1) or (2) is true, so we consider the upgrade to be completed
 		r.logger.Debugf(ctx, "cluster upgrade has been completed")
 		return true, nil

--- a/service/controller/resource/nodepool/resource.go
+++ b/service/controller/resource/nodepool/resource.go
@@ -2,7 +2,7 @@ package nodepool
 
 import (
 	"github.com/Azure/go-autorest/autorest/azure/auth"
-	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/giantswarm/microerror"
 
 	"github.com/giantswarm/azure-operator/v5/pkg/credential"
 	"github.com/giantswarm/azure-operator/v5/pkg/tenantcluster"
@@ -17,7 +17,6 @@ const (
 type Config struct {
 	nodes.Config
 	CredentialProvider        credential.Provider
-	CtrlClient                ctrlclient.Client
 	GSClientCredentialsConfig auth.ClientCredentialsConfig
 	TenantClientFactory       tenantcluster.Factory
 	VMSKU                     *vmsku.VMSKUs
@@ -27,21 +26,20 @@ type Config struct {
 type Resource struct {
 	nodes.Resource
 	CredentialProvider  credential.Provider
-	CtrlClient          ctrlclient.Client
 	tenantClientFactory tenantcluster.Factory
 	vmsku               *vmsku.VMSKUs
 }
 
 func New(config Config) (*Resource, error) {
+	config.Name = Name
+	nodesResource, err := nodes.New(config.Config)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	r := &Resource{
-		Resource: nodes.Resource{
-			Logger:        config.Logger,
-			Debugger:      config.Debugger,
-			Azure:         config.Azure,
-			ClientFactory: config.ClientFactory,
-		},
+		Resource:            *nodesResource,
 		CredentialProvider:  config.CredentialProvider,
-		CtrlClient:          config.CtrlClient,
 		tenantClientFactory: config.TenantClientFactory,
 		vmsku:               config.VMSKU,
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14140

`Cluster` `Upgrading` condition is being updated based on `release.giantswarm.io/last-deployed-version` annotation (by comparing it to desired release version).
This fixes how the annotation is updated, and it waits for all node pools to be upgraded before setting/updating the annotation on the `Cluster` CR. That will make `Cluster` `Upgrading` condition to switch from `True` to `False` only when all node pools are upgraded.
