### PR TITLE
Avoid AZ override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure that availability zones are kept unchanged during migration from 12.x to 13.x.
+
 ## [5.0.0] - 2020-12-01
 
 ### Fixed

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.0.1-dev"
+	version            = "5.0.1-azoverride"
 )
 
 func Description() string {

--- a/service/controller/resource/azureconfig/create.go
+++ b/service/controller/resource/azureconfig/create.go
@@ -127,6 +127,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "finding if existing azureconfig needs update")
 	{
+		// Ensure that availability zones are kept as-is.
+		mappedAzureConfig.Spec.Azure.AvailabilityZones = presentAzureConfig.Spec.Azure.AvailabilityZones
+
 		// Ensure that present network allocations are kept as-is.
 		mappedAzureConfig.Spec.Azure.VirtualNetwork = presentAzureConfig.Spec.Azure.VirtualNetwork
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14893

This PR avoids the change of Availability Zones in the AzureConfig CR when upgrading from 12.x to 13.x