### PR TITLE
Fix catching k8s API errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure that availability zones are kept unchanged during migration from 12.x to 13.x.
 - Don't set `MachinePool.Status.InfrastructureReady` in `nodestatus` handler.
-- Update `giantswarm/conditions-handler` to `v0.1.2`.
 - Ensure autoscaler annotations during migration from 12.x to 13.x.
+- Improve handling errors when accessing Kubernetes API.
 
 ## [5.1.0] - 2020-12-14
 

--- a/service/controller/resource/clusterupgrade/create.go
+++ b/service/controller/resource/clusterupgrade/create.go
@@ -144,7 +144,12 @@ func (r *Resource) ensureMasterHasUpgraded(ctx context.Context, cluster capiv1al
 
 	nodeList := &corev1.NodeList{}
 	err = tenantClusterK8sClient.List(ctx, nodeList, client.MatchingLabels{"kubernetes.io/role": "master"})
-	if err != nil {
+	if tenantcluster.IsAPINotAvailableError(err) {
+		r.logger.Debugf(ctx, "tenant API not available yet")
+		r.logger.Debugf(ctx, "canceling resource")
+
+		return false, nil
+	} else if err != nil {
 		return false, microerror.Mask(err)
 	}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15156

What's in the box:
- Fixes issue where API conflict error happens in `azuremachinepooolconditions` handler when updating `AzureMachinePool` CR.
- Fixes issue where, during cluster upgrade, workload cluster API call fails due to API being unavailable.
