### PR TITLE
Ensure the MC's network space is never used for WCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure the management cluster's network space is never used for workload clusters.
+
 ## [5.2.0] - 2021-01-14
 
 ### Changed

--- a/service/controller/azure_config.go
+++ b/service/controller/azure_config.go
@@ -67,12 +67,13 @@ type AzureConfigConfig struct {
 
 	ClusterVNetMaskBits int
 
-	Ignition         setting.Ignition
-	IPAMNetworkRange net.IPNet
-	OIDC             setting.OIDC
-	SSHUserList      employees.SSHUserList
-	SSOPublicKey     string
-	TemplateVersion  string
+	Ignition          setting.Ignition
+	IPAMNetworkRange  net.IPNet
+	IPAMReservedCIDRs []net.IPNet
+	OIDC              setting.OIDC
+	SSHUserList       employees.SSHUserList
+	SSOPublicKey      string
+	TemplateVersion   string
 
 	DockerhubToken  string
 	RegistryDomain  string
@@ -496,7 +497,8 @@ func newAzureConfigResources(config AzureConfigConfig, certsSearcher certs.Inter
 			InstallationName:      config.InstallationName,
 			Logger:                config.Logger,
 
-			NetworkRange: config.IPAMNetworkRange,
+			NetworkRange:  config.IPAMNetworkRange,
+			ReservedCIDRs: config.IPAMReservedCIDRs,
 		}
 
 		virtualNetworkCollector, err = ipam.NewVirtualNetworkCollector(c)

--- a/service/controller/resource/ipam/virtualnetwork_collector.go
+++ b/service/controller/resource/ipam/virtualnetwork_collector.go
@@ -29,7 +29,8 @@ type VirtualNetworkCollectorConfig struct {
 	K8sClient             k8sclient.Interface
 	Logger                micrologger.Logger
 
-	NetworkRange net.IPNet
+	NetworkRange  net.IPNet
+	ReservedCIDRs []net.IPNet
 }
 
 type VirtualNetworkCollector struct {
@@ -39,7 +40,8 @@ type VirtualNetworkCollector struct {
 	k8sclient             k8sclient.Interface
 	logger                micrologger.Logger
 
-	networkRange net.IPNet
+	networkRange  net.IPNet
+	reservedCIDRs []net.IPNet
 }
 
 func NewVirtualNetworkCollector(config VirtualNetworkCollectorConfig) (*VirtualNetworkCollector, error) {
@@ -70,7 +72,8 @@ func NewVirtualNetworkCollector(config VirtualNetworkCollectorConfig) (*VirtualN
 		installationName:      config.InstallationName,
 		logger:                config.Logger,
 
-		networkRange: config.NetworkRange,
+		networkRange:  config.NetworkRange,
+		reservedCIDRs: config.ReservedCIDRs,
 	}
 
 	return c, nil
@@ -79,7 +82,7 @@ func NewVirtualNetworkCollector(config VirtualNetworkCollectorConfig) (*VirtualN
 func (c *VirtualNetworkCollector) Collect(ctx context.Context, _ interface{}) ([]net.IPNet, error) {
 	var err error
 	var mutex sync.Mutex
-	var reservedVirtualNetworks []net.IPNet
+	reservedVirtualNetworks := c.reservedCIDRs
 
 	g := &errgroup.Group{}
 

--- a/service/controller/resource/ipam/virtualnetwork_collector.go
+++ b/service/controller/resource/ipam/virtualnetwork_collector.go
@@ -82,7 +82,8 @@ func NewVirtualNetworkCollector(config VirtualNetworkCollectorConfig) (*VirtualN
 func (c *VirtualNetworkCollector) Collect(ctx context.Context, _ interface{}) ([]net.IPNet, error) {
 	var err error
 	var mutex sync.Mutex
-	reservedVirtualNetworks := c.reservedCIDRs
+	var reservedVirtualNetworks []net.IPNet
+	reservedVirtualNetworks = append(reservedVirtualNetworks, c.reservedCIDRs...)
 
 	g := &errgroup.Group{}
 

--- a/service/service.go
+++ b/service/service.go
@@ -237,6 +237,15 @@ func New(config Config) (*Service, error) {
 		ipamNetworkRange = *ipnet
 	}
 
+	var reservedCIDRs []net.IPNet
+	{
+		_, ipnet, err := net.ParseCIDR(config.Viper.GetString(config.Flag.Service.Azure.HostCluster.CIDR))
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		reservedCIDRs = append(reservedCIDRs, *ipnet)
+	}
+
 	// These credentials will be used when creating AzureClients for Control Plane clusters.
 	gsClientCredentialsConfig, err := credential.NewAzureCredentials(
 		config.Viper.GetString(config.Flag.Service.Azure.ClientID),
@@ -331,6 +340,7 @@ func New(config Config) (*Service, error) {
 			Ignition:              Ignition,
 			InstallationName:      config.Viper.GetString(config.Flag.Service.Installation.Name),
 			IPAMNetworkRange:      ipamNetworkRange,
+			IPAMReservedCIDRs:     reservedCIDRs,
 			K8sClient:             k8sClient,
 			Locker:                kubeLockLocker,
 			Logger:                config.Logger,


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/15264

this PR enforces the fact that the management cluster's address space is not available for workload clusters.