### PR TITLE
Fix scaling up node pool VMSS during an upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- When scaling up node pool VMSS during an upgrade, consider the real number of old workers running and not the value in the `MachinePool` CR to handle the case when the Autoscaler changed the size.
+
 ## [5.2.1] - 2021-01-20
 
 ### Fixed


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/15281

Instead of using the `MachinePool` replicas field to calculate the size of the node pool when doubling it, use the current number of nodes.