### PR TITLE
Move controllers to own packages

### DIFF
--- a/service/controller/azurecluster/controller.go
+++ b/service/controller/azurecluster/controller.go
@@ -1,4 +1,4 @@
-package controller
+package azurecluster
 
 import (
 	"context"
@@ -34,7 +34,7 @@ import (
 	"github.com/giantswarm/azure-operator/v5/service/controller/setting"
 )
 
-type AzureClusterConfig struct {
+type ControllerConfig struct {
 	CredentialProvider credential.Provider
 	InstallationName   string
 	K8sClient          k8sclient.Interface
@@ -57,7 +57,7 @@ type AzureClusterConfig struct {
 	SentryDSN string
 }
 
-func NewAzureCluster(config AzureClusterConfig) (*controller.Controller, error) {
+func NewController(config ControllerConfig) (*controller.Controller, error) {
 	var err error
 
 	var certsSearcher *certs.Searcher
@@ -111,7 +111,7 @@ func NewAzureCluster(config AzureClusterConfig) (*controller.Controller, error) 
 	return operatorkitController, nil
 }
 
-func newAzureClusterResources(config AzureClusterConfig, certsSearcher certs.Interface) ([]resource.Interface, error) {
+func newAzureClusterResources(config ControllerConfig, certsSearcher certs.Interface) ([]resource.Interface, error) {
 	var err error
 
 	var clientFactory *client.Factory

--- a/service/controller/azurecluster/error.go
+++ b/service/controller/azurecluster/error.go
@@ -1,4 +1,4 @@
-package controller
+package azurecluster
 
 import (
 	"github.com/giantswarm/microerror"

--- a/service/controller/azureconfig/controller.go
+++ b/service/controller/azureconfig/controller.go
@@ -1,4 +1,4 @@
-package controller
+package azureconfig
 
 import (
 	"context"
@@ -52,7 +52,7 @@ import (
 	"github.com/giantswarm/azure-operator/v5/service/controller/setting"
 )
 
-type AzureConfigConfig struct {
+type ControllerConfig struct {
 	CredentialProvider credential.Provider
 	InstallationName   string
 	K8sClient          k8sclient.Interface
@@ -83,11 +83,11 @@ type AzureConfigConfig struct {
 	SentryDSN string
 }
 
-type AzureConfig struct {
+type Controller struct {
 	*controller.Controller
 }
 
-func NewAzureConfig(config AzureConfigConfig) (*controller.Controller, error) {
+func NewController(config ControllerConfig) (*controller.Controller, error) {
 	if config.K8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
 	}
@@ -190,7 +190,7 @@ func NewAzureConfig(config AzureConfigConfig) (*controller.Controller, error) {
 	return operatorkitController, nil
 }
 
-func newAzureConfigResources(config AzureConfigConfig, certsSearcher certs.Interface) ([]resource.Interface, error) {
+func newAzureConfigResources(config ControllerConfig, certsSearcher certs.Interface) ([]resource.Interface, error) {
 	var err error
 
 	var tenantRestConfigProvider *tenantcluster.TenantCluster

--- a/service/controller/azureconfig/error.go
+++ b/service/controller/azureconfig/error.go
@@ -1,0 +1,14 @@
+package azureconfig
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/azuremachine/controller.go
+++ b/service/controller/azuremachine/controller.go
@@ -1,4 +1,4 @@
-package controller
+package azuremachine
 
 import (
 	"context"
@@ -21,7 +21,7 @@ import (
 	"github.com/giantswarm/azure-operator/v5/service/controller/resource/azuremachineconditions"
 )
 
-type AzureMachineConfig struct {
+type ControllerConfig struct {
 	AzureMetricsCollector collector.AzureAPIMetrics
 	CredentialProvider    credential.Provider
 	K8sClient             k8sclient.Interface
@@ -29,7 +29,7 @@ type AzureMachineConfig struct {
 	SentryDSN             string
 }
 
-func NewAzureMachine(config AzureMachineConfig) (*controller.Controller, error) {
+func NewController(config ControllerConfig) (*controller.Controller, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
@@ -75,7 +75,7 @@ func NewAzureMachine(config AzureMachineConfig) (*controller.Controller, error) 
 	return operatorkitController, nil
 }
 
-func NewAzureMachineResourceSet(config AzureMachineConfig) ([]resource.Interface, error) {
+func NewAzureMachineResourceSet(config ControllerConfig) ([]resource.Interface, error) {
 	var err error
 
 	var clientFactory *client.Factory

--- a/service/controller/azuremachine/error.go
+++ b/service/controller/azuremachine/error.go
@@ -1,0 +1,14 @@
+package azuremachine
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/azuremachinepool/error.go
+++ b/service/controller/azuremachinepool/error.go
@@ -1,0 +1,14 @@
+package azuremachinepool
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/cluster/controller.go
+++ b/service/controller/cluster/controller.go
@@ -1,4 +1,4 @@
-package controller
+package cluster
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"github.com/giantswarm/azure-operator/v5/service/controller/setting"
 )
 
-type ClusterConfig struct {
+type ControllerConfig struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
 	SentryDSN string
@@ -36,7 +36,7 @@ type ClusterConfig struct {
 	Debug setting.Debug
 }
 
-func NewCluster(config ClusterConfig) (*controller.Controller, error) {
+func NewController(config ControllerConfig) (*controller.Controller, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
@@ -82,7 +82,7 @@ func NewCluster(config ClusterConfig) (*controller.Controller, error) {
 	return operatorkitController, nil
 }
 
-func NewClusterResourceSet(config ClusterConfig) ([]resource.Interface, error) {
+func NewClusterResourceSet(config ControllerConfig) ([]resource.Interface, error) {
 	var err error
 
 	var clusterReleaseVersionResource resource.Interface

--- a/service/controller/cluster/error.go
+++ b/service/controller/cluster/error.go
@@ -1,0 +1,14 @@
+package cluster
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/machinepool/controller.go
+++ b/service/controller/machinepool/controller.go
@@ -1,4 +1,4 @@
-package controller
+package machinepool
 
 import (
 	"context"
@@ -27,13 +27,13 @@ import (
 	"github.com/giantswarm/azure-operator/v5/service/controller/resource/nodestatus"
 )
 
-type MachinePoolConfig struct {
+type ControllerConfig struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
 	SentryDSN string
 }
 
-func NewMachinePool(config MachinePoolConfig) (*controller.Controller, error) {
+func NewController(config ControllerConfig) (*controller.Controller, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
@@ -81,7 +81,7 @@ func NewMachinePool(config MachinePoolConfig) (*controller.Controller, error) {
 	return operatorkitController, nil
 }
 
-func NewMachinePoolResourceSet(config MachinePoolConfig) ([]resource.Interface, error) {
+func NewMachinePoolResourceSet(config ControllerConfig) ([]resource.Interface, error) {
 	var err error
 
 	var certsSearcher *certs.Searcher

--- a/service/controller/machinepool/error.go
+++ b/service/controller/machinepool/error.go
@@ -1,0 +1,14 @@
+package machinepool
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/spark/create.go
+++ b/service/controller/resource/spark/create.go
@@ -575,8 +575,8 @@ func (r *Resource) newCluster(cluster *capiv1alpha3.Cluster, azureCluster *capzv
 			return providerv1alpha1.Cluster{}, microerror.Mask(err)
 		}
 
-		commonCluster.Calico.CIDR = r.calico.CIDRSize
-		commonCluster.Calico.MTU = r.calico.MTU
+		commonCluster.Calico.CIDR = r.calicoCIDRSize
+		commonCluster.Calico.MTU = r.calicoMTU
 		commonCluster.Calico.Subnet = azureNetwork.Calico.String()
 	}
 

--- a/service/controller/resource/spark/resource.go
+++ b/service/controller/resource/spark/resource.go
@@ -13,7 +13,6 @@ import (
 	"github.com/giantswarm/azure-operator/v5/pkg/label"
 	"github.com/giantswarm/azure-operator/v5/service/controller/encrypter"
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
-	"github.com/giantswarm/azure-operator/v5/service/controller/resource/azureconfig"
 	"github.com/giantswarm/azure-operator/v5/service/controller/setting"
 
 	"github.com/giantswarm/microerror"
@@ -32,7 +31,9 @@ const (
 type Config struct {
 	APIServerSecurePort int
 	Azure               setting.Azure
-	Calico              azureconfig.CalicoConfig
+	CalicoCIDRSize      int
+	CalicoMTU           int
+	CalicoSubnet        string
 	CertsSearcher       certs.Interface
 	ClusterIPRange      string
 	CredentialProvider  credential.Provider
@@ -52,7 +53,9 @@ type Config struct {
 type Resource struct {
 	apiServerSecurePort int
 	azure               setting.Azure
-	calico              azureconfig.CalicoConfig
+	calicoCIDRSize      int
+	calicoMTU           int
+	calicoSubnet        string
 	certsSearcher       certs.Interface
 	clusterIPRange      string
 	credentialProvider  credential.Provider
@@ -78,8 +81,8 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Mask(err)
 	}
 
-	if config.Calico.MTU == 0 {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Calico.MTU must not be empty", config)
+	if config.CalicoMTU == 0 {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CalicoMTU must not be empty", config)
 	}
 
 	if config.CertsSearcher == nil {
@@ -125,7 +128,9 @@ func New(config Config) (*Resource, error) {
 	r := &Resource{
 		apiServerSecurePort: config.APIServerSecurePort,
 		azure:               config.Azure,
-		calico:              config.Calico,
+		calicoCIDRSize:      config.CalicoCIDRSize,
+		calicoMTU:           config.CalicoMTU,
+		calicoSubnet:        config.CalicoSubnet,
 		certsSearcher:       config.CertsSearcher,
 		clusterIPRange:      config.ClusterIPRange,
 		credentialProvider:  config.CredentialProvider,

--- a/service/controller/unhealthynode/controller.go
+++ b/service/controller/unhealthynode/controller.go
@@ -1,4 +1,4 @@
-package controller
+package unhealthynode
 
 import (
 	"context"
@@ -25,7 +25,7 @@ import (
 	"github.com/giantswarm/azure-operator/v5/service/controller/resource/terminateunhealthynode"
 )
 
-type TerminateUnhealthyNodeConfig struct {
+type ControllerConfig struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
 
@@ -34,11 +34,11 @@ type TerminateUnhealthyNodeConfig struct {
 	SentryDSN             string
 }
 
-type TerminateUnhealthyNode struct {
+type Controller struct {
 	*controller.Controller
 }
 
-func NewTerminateUnhealthyNode(config TerminateUnhealthyNodeConfig) (*controller.Controller, error) {
+func NewController(config ControllerConfig) (*controller.Controller, error) {
 	var err error
 
 	if config.K8sClient == nil {
@@ -107,7 +107,7 @@ func NewTerminateUnhealthyNode(config TerminateUnhealthyNodeConfig) (*controller
 	return operatorkitController, nil
 }
 
-func newTerminateUnhealthyNodeResources(config TerminateUnhealthyNodeConfig, certsSearcher *certs.Searcher) ([]resource.Interface, error) {
+func newTerminateUnhealthyNodeResources(config ControllerConfig, certsSearcher *certs.Searcher) ([]resource.Interface, error) {
 	var err error
 
 	var clientFactory *client.Factory

--- a/service/controller/unhealthynode/error.go
+++ b/service/controller/unhealthynode/error.go
@@ -1,0 +1,14 @@
+package unhealthynode
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}


### PR DESCRIPTION
This change moves each controller watching a given CR to its own
package. Refactoring of handlers will follow this.

Towards https://github.com/giantswarm/giantswarm/issues/14403