### PR TITLE
Remove check for `germanywestcentral` region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - When scaling up node pool VMSS during an upgrade, consider the real number of old workers running and not the value in the `MachinePool` CR to handle the case when the Autoscaler changed the size.
 
+### Removed
+
+- Remove check for `germanywestcentral` region and assume availability zone settings are correct in the CRs.
+
 ## [5.2.1] - 2021-01-20
 
 ### Fixed

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -89,10 +89,7 @@ const (
 )
 
 var (
-	instanceIDRegexp            = regexp.MustCompile(`-[^-]{6}$`)
-	LocationsThatDontSupportAZs = []string{
-		"germanywestcentral",
-	}
+	instanceIDRegexp = regexp.MustCompile(`-[^-]{6}$`)
 )
 
 func APISecurePort(customObject providerv1alpha1.AzureConfig) int {
@@ -480,12 +477,6 @@ func RouteTableName(customObject providerv1alpha1.AzureConfig) string {
 
 // AvailabilityZones returns the availability zones where the cluster will be created.
 func AvailabilityZones(customObject providerv1alpha1.AzureConfig, location string) []int {
-	for _, l := range LocationsThatDontSupportAZs {
-		if l == location {
-			return []int{}
-		}
-	}
-
 	if customObject.Spec.Azure.AvailabilityZones == nil {
 		return []int{}
 	}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/15372

this PR removes the explicit check for azure location == `germanywestcentral` and delegates availability zones check to the admission controller