### PR TITLE
Bump conditions-handler to v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Enable VMSS termination events.
+- Bump `conditions-handler` to v0.2.1 to get `MachinePool` `ReplicasReady` fixes.
 
 ### Fixed
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/giantswarm/badnodedetector v1.0.1
 	github.com/giantswarm/certs/v3 v3.1.0
 	github.com/giantswarm/conditions v0.3.0
-	github.com/giantswarm/conditions-handler v0.2.0
+	github.com/giantswarm/conditions-handler v0.2.1-0.20210127132416-0ef62df886be
 	github.com/giantswarm/errors v0.2.3
 	github.com/giantswarm/exporterkit v0.2.0
 	github.com/giantswarm/ipam v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/giantswarm/badnodedetector v1.0.1
 	github.com/giantswarm/certs/v3 v3.1.0
 	github.com/giantswarm/conditions v0.3.0
-	github.com/giantswarm/conditions-handler v0.2.1-0.20210127132416-0ef62df886be
+	github.com/giantswarm/conditions-handler v0.2.1
 	github.com/giantswarm/errors v0.2.3
 	github.com/giantswarm/exporterkit v0.2.0
 	github.com/giantswarm/ipam v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,8 @@ github.com/giantswarm/conditions v0.3.0 h1:sv6b2dVXns2oT1VJ2UIuflJo24cC7EPXD7tdw
 github.com/giantswarm/conditions v0.3.0/go.mod h1:tFjYCLTT5NBJU+PYij0360yBHzETIpw3wnrettuzdsw=
 github.com/giantswarm/conditions-handler v0.2.0 h1:Ppaf3HaM0otfhnHLeL/64MsWDd6RMrv1tWlLycyBSHY=
 github.com/giantswarm/conditions-handler v0.2.0/go.mod h1:QXMJUNLZNwDCz60N4GxT39ETSw52idBfq65l0bx0tXg=
+github.com/giantswarm/conditions-handler v0.2.1-0.20210127132416-0ef62df886be h1:dt4eGOOBcAHUUpN4CHsuY2CcM/jHTyde06cNrom8LNA=
+github.com/giantswarm/conditions-handler v0.2.1-0.20210127132416-0ef62df886be/go.mod h1:QXMJUNLZNwDCz60N4GxT39ETSw52idBfq65l0bx0tXg=
 github.com/giantswarm/errors v0.2.3 h1:gE1dDSD0RNwYUah5hG6oUQh0unPyZ74tVwR1/PW3ZQ0=
 github.com/giantswarm/errors v0.2.3/go.mod h1:Oj1LIWs9Uoj6JGtK5HxTb50iZuqe9f60LDI0nLXA5vU=
 github.com/giantswarm/exporterkit v0.2.0 h1:+HTGl4fmT/1OkTox8HbV3JXeavmsZv94+2CDW8cSrq0=

--- a/go.sum
+++ b/go.sum
@@ -238,12 +238,10 @@ github.com/giantswarm/cluster-api v0.3.10-gs h1:l2LpZlN97t7RRwKf4OBfNA2h1oVnZXWC
 github.com/giantswarm/cluster-api v0.3.10-gs/go.mod h1:878STePVJcBNDYFY2eCsLuHXWs6qiH3INFItEwdfWaE=
 github.com/giantswarm/cluster-api-provider-azure v0.4.9-gsalpha2 h1:rkmGkanOvFi/Q7WRdqSkWm6M321q4yqavNtw+witIM0=
 github.com/giantswarm/cluster-api-provider-azure v0.4.9-gsalpha2/go.mod h1:iD4hxYobC6/eAlBOcrE6NAIwEDHcD174Uck5FmZZx8U=
-github.com/giantswarm/conditions v0.2.0 h1:sOS319rNgfRl/LuzeEmCcyjYa8V4GCtR4NtwyfNTAmo=
-github.com/giantswarm/conditions v0.2.0/go.mod h1:Bp0zSox1MdFV20MTvjXOr8li+v11OLX/8kponaIGVrw=
 github.com/giantswarm/conditions v0.3.0 h1:sv6b2dVXns2oT1VJ2UIuflJo24cC7EPXD7tdwPEYFkU=
 github.com/giantswarm/conditions v0.3.0/go.mod h1:tFjYCLTT5NBJU+PYij0360yBHzETIpw3wnrettuzdsw=
-github.com/giantswarm/conditions-handler v0.2.1-0.20210127132416-0ef62df886be h1:dt4eGOOBcAHUUpN4CHsuY2CcM/jHTyde06cNrom8LNA=
-github.com/giantswarm/conditions-handler v0.2.1-0.20210127132416-0ef62df886be/go.mod h1:QXMJUNLZNwDCz60N4GxT39ETSw52idBfq65l0bx0tXg=
+github.com/giantswarm/conditions-handler v0.2.1 h1:XUgJD0T+H+QsUN1oaPAlla+hL+qJqtNQF150snQSXy8=
+github.com/giantswarm/conditions-handler v0.2.1/go.mod h1:uEnndkR6svfI86fSu7LXVVhqHXqOB2speo6LVQ+rok8=
 github.com/giantswarm/errors v0.2.3 h1:gE1dDSD0RNwYUah5hG6oUQh0unPyZ74tVwR1/PW3ZQ0=
 github.com/giantswarm/errors v0.2.3/go.mod h1:Oj1LIWs9Uoj6JGtK5HxTb50iZuqe9f60LDI0nLXA5vU=
 github.com/giantswarm/exporterkit v0.2.0 h1:+HTGl4fmT/1OkTox8HbV3JXeavmsZv94+2CDW8cSrq0=

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,6 @@ github.com/giantswarm/conditions v0.2.0 h1:sOS319rNgfRl/LuzeEmCcyjYa8V4GCtR4Ntwy
 github.com/giantswarm/conditions v0.2.0/go.mod h1:Bp0zSox1MdFV20MTvjXOr8li+v11OLX/8kponaIGVrw=
 github.com/giantswarm/conditions v0.3.0 h1:sv6b2dVXns2oT1VJ2UIuflJo24cC7EPXD7tdwPEYFkU=
 github.com/giantswarm/conditions v0.3.0/go.mod h1:tFjYCLTT5NBJU+PYij0360yBHzETIpw3wnrettuzdsw=
-github.com/giantswarm/conditions-handler v0.2.0 h1:Ppaf3HaM0otfhnHLeL/64MsWDd6RMrv1tWlLycyBSHY=
-github.com/giantswarm/conditions-handler v0.2.0/go.mod h1:QXMJUNLZNwDCz60N4GxT39ETSw52idBfq65l0bx0tXg=
 github.com/giantswarm/conditions-handler v0.2.1-0.20210127132416-0ef62df886be h1:dt4eGOOBcAHUUpN4CHsuY2CcM/jHTyde06cNrom8LNA=
 github.com/giantswarm/conditions-handler v0.2.1-0.20210127132416-0ef62df886be/go.mod h1:QXMJUNLZNwDCz60N4GxT39ETSw52idBfq65l0bx0tXg=
 github.com/giantswarm/errors v0.2.3 h1:gE1dDSD0RNwYUah5hG6oUQh0unPyZ74tVwR1/PW3ZQ0=

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.2.2-dev"
+	version            = "5.2.2-replicasreadyfix"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.2.2-replicasreadyfix"
+	version            = "5.2.2-dev"
 )
 
 func Description() string {


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/15297

What's in the box:
- Bump `conditions-handler` to v0.2.1 to include `ReplicasReady` fix from https://github.com/giantswarm/conditions-handler/pull/20