### PR TITLE
handle api not available case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid blocking the whole `AzureConfig` handler on cluster creation because we can't update the `StorageClasses`.
+
 ## [5.4.0] - 2021-02-05
 
 ### Changed

--- a/service/controller/azureconfig/handler/volumebindingmigration/resource.go
+++ b/service/controller/azureconfig/handler/volumebindingmigration/resource.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	providerv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -65,7 +66,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	var tenantClusterK8sClient ctrl.Client
 	{
 		tenantClusterK8sClient, err = r.getTenantClusterClient(ctx, &cr)
-		if err != nil {
+		if tenant.IsAPINotAvailable(err) || tenantcluster.IsTimeout(err) {
+			// The kubernetes API is not reachable. This usually happens when a new cluster is being created.
+			// This makes the whole controller to fail and stops next handlers from being executed even if they are
+			// safe to run. We don't want that to happen so we just return and we'll try again during next loop.
+			r.logger.Debugf(ctx, "Kubernetes API is not available, can't proceed.")
+			return nil
+		} else if err != nil {
 			return microerror.Mask(err)
 		}
 	}

--- a/service/controller/azureconfig/handler/volumebindingmigration/resource.go
+++ b/service/controller/azureconfig/handler/volumebindingmigration/resource.go
@@ -70,7 +70,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			// The kubernetes API is not reachable. This usually happens when a new cluster is being created.
 			// This makes the whole controller to fail and stops next handlers from being executed even if they are
 			// safe to run. We don't want that to happen so we just return and we'll try again during next loop.
-			r.logger.Debugf(ctx, "Kubernetes API is not available, can't proceed.")
+			r.logger.Debugf(ctx, "tenant API not available yet")
+			r.logger.Debugf(ctx, "canceling resource")
+
 			return nil
 		} else if err != nil {
 			return microerror.Mask(err)


### PR DESCRIPTION
The `volumebindingmigration` handler fails when there is no Kubernetes API available, blocking all the following handlers in the same controller from being executed.
This slows down cluster creation by a few minutes.

This PR adds a specific check for `Api not available` error and allows the following handlers to run normally even when there is no API available.

The  `volumebindingmigration` runs at every reconciliation loop so this is not creating any issue.