### PR TITLE
Ensure `AzureCluster` CR has the `SubscriptionID` field set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add new handler that creates `AzureClusterIdentity` CRs and the related `Secrets` out of Giant Swarm's credential secrets. 
+- Add new handler that creates `AzureClusterIdentity` CRs and the related `Secrets` out of Giant Swarm's credential secrets.
+- Ensure `AzureCluster` CR has the `SubscriptionID` field set.
 
 ### Fixed
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/15602

this PR adds the migration logic needed to populate the `SubscriptionID` field of the `AzureCluster` CR based on the legacy organization secret