### PR TITLE
Don't panic on unallocated subnet entries

### DIFF
--- a/pkg/handler/ipam/azure_machinepool_subnet_collector.go
+++ b/pkg/handler/ipam/azure_machinepool_subnet_collector.go
@@ -141,6 +141,10 @@ func (c *AzureMachinePoolSubnetCollector) collectSubnetsFromAzureClusterCR(ctx c
 	// Collect all the subnets from AzureCluster.Spec.NetworkSpec.Subnets field. If the Subnets
 	// field is not set, this function will simply return nil.
 	for _, subnet := range azureCluster.Spec.NetworkSpec.Subnets {
+		if len(subnet.CIDRBlocks) == 0 {
+			continue
+		}
+
 		_, subnetIPNet, err := net.ParseCIDR(subnet.CIDRBlocks[0])
 		if err != nil {
 			return nil, microerror.Mask(err)
@@ -148,7 +152,7 @@ func (c *AzureMachinePoolSubnetCollector) collectSubnetsFromAzureClusterCR(ctx c
 		azureClusterCRSubnets = append(azureClusterCRSubnets, *subnetIPNet)
 	}
 
-	c.logger.Debugf(ctx, "found allocated subnets in AzureCluster CR")
+	c.logger.Debugf(ctx, "found %d allocated subnets in AzureCluster CR", len(azureClusterCRSubnets))
 	return azureClusterCRSubnets, nil
 }
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.4.1-panic"
+	version            = "5.4.1-dev"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.4.1-dev"
+	version            = "5.4.1-panic"
 )
 
 func Description() string {

--- a/service/controller/azurecluster/handler/subnet/resource.go
+++ b/service/controller/azurecluster/handler/subnet/resource.go
@@ -148,6 +148,11 @@ func (r *Resource) ensureSubnets(ctx context.Context, deploymentsClient *azurere
 			return microerror.Mask(err)
 		}
 
+		if len(azureCluster.Spec.NetworkSpec.Subnets[i].CIDRBlocks) == 0 {
+			// Skip subnets that don't have CIDR allocated yet.
+			continue
+		}
+
 		parameters, err := r.getDeploymentParameters(azureCluster, *natGw.ID, azureCluster.Spec.NetworkSpec.Subnets[i])
 		if err != nil {
 			return microerror.Mask(err)


### PR DESCRIPTION
Don't panic if AzureCluster CR has a subnet without defined CIDBlocks.
While this is not necessarily strictly valid in all use cases, the code
should still handle the situation gracefully.