### PR TITLE
avoid saving the azuremachine CR too often

### DIFF
--- a/pkg/helpers/azuremachine.go
+++ b/pkg/helpers/azuremachine.go
@@ -6,7 +6,6 @@ import (
 	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,15 +59,6 @@ func InitAzureMachineAnnotations(ctx context.Context, ctrlClient client.Client, 
 	// - Also ,we cannot know if AzureMachine release label was already updated
 	//   or not, as that is done in Cluster controller.
 	azureMachine.Annotations[annotation.LastDeployedReleaseVersion] = clusterLastDeployedReleaseVersion
-
-	err = ctrlClient.Update(ctx, azureMachine)
-	if errors.IsConflict(err) {
-		logger.Debugf(ctx, "conflict trying to save object in k8s API concurrently", "stack", microerror.JSON(microerror.Mask(err)))
-		logger.Debugf(ctx, "cancelling resource")
-		return nil
-	} else if err != nil {
-		return microerror.Mask(err)
-	}
 
 	return nil
 }

--- a/pkg/helpers/azuremachine.go
+++ b/pkg/helpers/azuremachine.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,5 +60,15 @@ func InitAzureMachineAnnotations(ctx context.Context, ctrlClient client.Client, 
 	// - Also ,we cannot know if AzureMachine release label was already updated
 	//   or not, as that is done in Cluster controller.
 	azureMachine.Annotations[annotation.LastDeployedReleaseVersion] = clusterLastDeployedReleaseVersion
+
+	err = ctrlClient.Update(ctx, azureMachine)
+	if errors.IsConflict(err) {
+		logger.Debugf(ctx, "conflict trying to save object in k8s API concurrently", "stack", microerror.JSON(microerror.Mask(err)))
+		logger.Debugf(ctx, "cancelling resource")
+		return nil
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
 	return nil
 }

--- a/service/controller/azuremachine/handler/azuremachinemetadata/create.go
+++ b/service/controller/azuremachine/handler/azuremachinemetadata/create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/giantswarm/azure-operator/v5/pkg/helpers"
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
@@ -23,15 +22,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, cr interface{}) error {
 	// annotation set correctly in both places.
 	err = helpers.InitAzureMachineAnnotations(ctx, r.ctrlClient, r.logger, &azureMachine)
 	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	err = r.ctrlClient.Update(ctx, &azureMachine)
-	if errors.IsConflict(err) {
-		r.logger.Debugf(ctx, "conflict trying to save object in k8s API concurrently", "stack", microerror.JSON(microerror.Mask(err)))
-		r.logger.Debugf(ctx, "cancelling resource")
-		return nil
-	} else if err != nil {
 		return microerror.Mask(err)
 	}
 

--- a/service/controller/azuremachine/handler/azuremachinemetadata/create.go
+++ b/service/controller/azuremachine/handler/azuremachinemetadata/create.go
@@ -3,7 +3,9 @@ package azuremachinemetadata
 import (
 	"context"
 
+	"github.com/giantswarm/apiextensions/v3/pkg/annotation"
 	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/giantswarm/azure-operator/v5/pkg/helpers"
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
@@ -16,6 +18,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, cr interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	changed := false
+	_, annotationWasSet := azureMachine.Annotations[annotation.LastDeployedReleaseVersion]
+
 	// We need this for existing clusters, and we do it both in Cluster
 	// controller (clusterupgrade) and in AzureMachine controller, because we
 	// do not know which controller/handler will be executed first, and we need
@@ -23,6 +28,20 @@ func (r *Resource) EnsureCreated(ctx context.Context, cr interface{}) error {
 	err = helpers.InitAzureMachineAnnotations(ctx, r.ctrlClient, r.logger, &azureMachine)
 	if err != nil {
 		return microerror.Mask(err)
+	}
+
+	_, annotationIsSet := azureMachine.Annotations[annotation.LastDeployedReleaseVersion]
+	changed = !annotationWasSet && annotationIsSet
+
+	if changed {
+		err = r.ctrlClient.Update(ctx, &azureMachine)
+		if errors.IsConflict(err) {
+			r.logger.Debugf(ctx, "conflict trying to save object in k8s API concurrently", "stack", microerror.JSON(microerror.Mask(err)))
+			r.logger.Debugf(ctx, "cancelling resource")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
 	r.logger.Debugf(ctx, "ensured that azuremachine has release.giantswarm.io/last-deployed-version annotation initialized")


### PR DESCRIPTION
This handler was calling `Update` on the `AzureMachine` CR at every reconciliation loop, regardless of any changes being made to the CR.
This triggered a loop in the handler that was running in an infinite sequence.
This PR check for changes in the CR and avoid saving if there isn't any