### PR TITLE
Avoid overriding the NP size when the scaling is changed by autoscaler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Avoid blocking the whole `AzureConfig` handler on cluster creation because we can't update the `StorageClasses`.
+- Avoid overriding the NP size when the scaling is changed by autoscaler. 
 
 ## [5.4.0] - 2021-02-05
 

--- a/service/controller/azuremachinepool/handler/nodepool/template/template.go
+++ b/service/controller/azuremachinepool/handler/nodepool/template/template.go
@@ -81,7 +81,7 @@ func Diff(currentDeployment azureresource.DeploymentExtended, desiredDeployment 
 	if !reflect.DeepEqual(currentParameters.DataDisks, desiredParameters.DataDisks) {
 		changes = append(changes, "dataDisks")
 	}
-	if !reflect.DeepEqual(currentParameters.Scaling, desiredParameters.Scaling) {
+	if currentParameters.Scaling.MinReplicas != desiredParameters.Scaling.MinReplicas || currentParameters.Scaling.MaxReplicas != desiredParameters.Scaling.MaxReplicas {
 		changes = append(changes, "scaling")
 	}
 	if !reflect.DeepEqual(currentParameters.OSImage, desiredParameters.OSImage) {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/15845

The `NodePool` handler compares the desired ARM deployment with the latest ARM deployment supplied to check if there are any changes that require the deployment to be updated.
One of the fields that is compared is the `scaling` field, that contains the min, max and current number of replicas for the NP.

When we first submit the deployment (new node pool) the "current" field is set to the same value as the "min" field.
From that moment on, if "min" != "max" (i.e. autoscaling is enabled) the "current" field is not reliable any more, because the autoscaler can change it any time.

That means that everytime the cluster autoscaler changed the size of a NP, azure operator considered the node pool deployment to be out of date and reapplied the deployment, basically fighting against with the cluster autoscaler.

This PR ignores the `current` field and only considers the `min` and `max` to decide if the deployment needs to be applied or not.