### PR TITLE
Fix upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix a race condition when upgrading node pools with 0 replicas.
+- Fix Upgrading condition for node pools with autoscaler enabled.
+
 ## [5.5.0] - 2021-02-22
 
 ### Added

--- a/service/controller/azuremachinepool/handler/nodepool/create_scale_workers.go
+++ b/service/controller/azuremachinepool/handler/nodepool/create_scale_workers.go
@@ -104,8 +104,7 @@ func (r *Resource) scaleUpWorkerVMSSTransition(ctx context.Context, obj interfac
 	r.Logger.Debugf(ctx, "The desired number of workers is: %d", desiredWorkerCount)
 
 	if desiredWorkerCount == 0 {
-		// The node pool is empty, the upgrade process is not finished.
-
+		// The node pool is empty, the upgrade process can stop here.
 		r.Logger.Debugf(ctx, "The size of the Node Pool is 0: upgrade is complete")
 		return DeploymentUninitialized, nil
 	}

--- a/service/controller/azuremachinepool/handler/nodepool/create_scale_workers.go
+++ b/service/controller/azuremachinepool/handler/nodepool/create_scale_workers.go
@@ -103,6 +103,13 @@ func (r *Resource) scaleUpWorkerVMSSTransition(ctx context.Context, obj interfac
 	desiredWorkerCount := int64(len(oldInstances) * 2)
 	r.Logger.Debugf(ctx, "The desired number of workers is: %d", desiredWorkerCount)
 
+	if desiredWorkerCount == 0 {
+		// The node pool is empty, the upgrade process is not finished.
+
+		r.Logger.Debugf(ctx, "The size of the Node Pool is 0: upgrade is complete")
+		return DeploymentUninitialized, nil
+	}
+
 	if desiredWorkerCount > int64(len(oldInstances)+len(newInstances)) {
 		// Disable cluster autoscaler for this nodepool.
 		err = r.disableClusterAutoscaler(ctx, azureMachinePool)

--- a/service/controller/machinepool/handler/machinepoolupgrade/lastdeployedreleaseversion.go
+++ b/service/controller/machinepool/handler/machinepoolupgrade/lastdeployedreleaseversion.go
@@ -136,10 +136,10 @@ func allNodePoolNodesUpToDate(ctx context.Context, tenantClusterClient client.Cl
 
 	// azure-admission-controller ensures that machinePool.Spec.Replicas is
 	// always set
-	requiredReplicas := *machinePool.Spec.Replicas
+	minRequiredReplicas := key.NodePoolMinReplicas(machinePool)
 
 	// We want that all required replicas are up-to-date.
-	requiredReplicasAreUpToDate := upToDateNodesCount >= requiredReplicas
+	requiredReplicasAreUpToDate := upToDateNodesCount >= minRequiredReplicas
 
 	// We also want that old nodes are removed.
 	oldNodesAreRemoved := outdatedNodes == 0


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/15884

this PR addresses 2 problems:

1. upgrading node pools with zero replicas didn't ever finish
2. the upgrade conditions didn't work reliably for autoscaling node pools

