### PR TITLE
Don't wait for new workers to be up during spot instances NP upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Avoid creating too many worker nodes at the same time when upgrading node pools.
+- Don't wait for new workers to be up during spot instances node pools upgrades.
 
 ## [5.6.0] - 2021-04-21
 

--- a/service/controller/azuremachinepool/handler/nodepool/create_wait_for_nodes_to_become_ready.go
+++ b/service/controller/azuremachinepool/handler/nodepool/create_wait_for_nodes_to_become_ready.go
@@ -31,6 +31,11 @@ func (r *Resource) waitForWorkersToBecomeReadyTransition(ctx context.Context, ob
 		return currentState, nil
 	}
 
+	if azureMachinePool.Spec.Template.SpotVMOptions != nil {
+		r.Logger.Debugf(ctx, "Skipping state %s because node pool is using Spot Instances.", currentState)
+		return TerminateOldWorkerInstances, nil
+	}
+
 	tenantClusterK8sClient, err := r.tenantClientFactory.GetClient(ctx, cluster)
 	if tenantcluster.IsAPINotAvailableError(err) {
 		r.Logger.Debugf(ctx, "tenant API not available yet")


### PR DESCRIPTION
This PR changes the upgrade strategy to avoid deadlocks during upgrade of spot instances node pools if there is no capacity to double the node pool size.