### PR TITLE
When deleting a node pool, also delete the VMSS role assignment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid creating too many worker nodes at the same time when upgrading node pools.
 - Don't wait for new workers to be up during spot instances node pools upgrades.
 
+### Fixed
+
+- When deleting a node pool, also delete the VMSS role assignment.
+
 ## [5.6.0] - 2021-04-21
 
 ### Changed

--- a/client/azure_client_set.go
+++ b/client/azure_client_set.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/2019-03-01/authorization/mgmt/authorization"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-11-01/network"
@@ -349,6 +350,13 @@ func newResourceSkusClient(authorizer autorest.Authorizer, metricsCollector coll
 	return &client, nil
 }
 
+func newRoleAssignmentsClient(authorizer autorest.Authorizer, metricsCollector collector.AzureAPIMetrics, subscriptionID, partnerID string) (interface{}, error) {
+	client := authorization.NewRoleAssignmentsClient(subscriptionID)
+	prepareClient(&client.Client, authorizer, metricsCollector, "role_assignments", subscriptionID, partnerID)
+
+	return &client, nil
+}
+
 func toDeploymentsClient(client interface{}) *resources.DeploymentsClient {
 	return client.(*resources.DeploymentsClient)
 }
@@ -419,4 +427,8 @@ func toVirtualNetworkGatewaysClient(client interface{}) *network.VirtualNetworkG
 
 func toVirtualNetworkGatewayConnectionsClient(client interface{}) *network.VirtualNetworkGatewayConnectionsClient {
 	return client.(*network.VirtualNetworkGatewayConnectionsClient)
+}
+
+func toRoleAssignmentsClient(client interface{}) *authorization.RoleAssignmentsClient {
+	return client.(*authorization.RoleAssignmentsClient)
 }

--- a/client/factory.go
+++ b/client/factory.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-11-01/network"
@@ -278,6 +279,15 @@ func (f *Factory) GetVirtualNetworkGatewayConnectionsClient(credentialNamespace,
 	}
 
 	return toVirtualNetworkGatewayConnectionsClient(client), nil
+}
+
+func (f *Factory) GetRoleAssignmentsClient(credentialNamespace, credentialName string) (*authorization.RoleAssignmentsClient, error) {
+	client, err := f.getClient(credentialNamespace, credentialName, "RoleAssignmentsClient", newRoleAssignmentsClient)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return toRoleAssignmentsClient(client), nil
 }
 
 func (f *Factory) getClient(credentialNamespace, credentialName string, clientType string, createClient clientCreatorFunc) (interface{}, error) {

--- a/client/organization_factory.go
+++ b/client/organization_factory.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/authorization/mgmt/authorization"
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2018-05-01/dns"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-11-01/network"
@@ -44,6 +45,7 @@ type Interface interface {
 	GetVirtualNetworkGatewaysClient(ctx context.Context, objectMeta v1.ObjectMeta) (*network.VirtualNetworkGatewaysClient, error)
 	GetVirtualNetworkGatewayConnectionsClient(ctx context.Context, objectMeta v1.ObjectMeta) (*network.VirtualNetworkGatewayConnectionsClient, error)
 	GetPublicIpAddressesClient(ctx context.Context, objectMeta v1.ObjectMeta) (*network.PublicIPAddressesClient, error)
+	GetRoleAssignmentsClient(ctx context.Context, objectMeta v1.ObjectMeta) (*authorization.RoleAssignmentsClient, error)
 }
 
 type OrganizationFactoryConfig struct {
@@ -217,6 +219,15 @@ func (f *OrganizationFactory) GetPublicIpAddressesClient(ctx context.Context, ob
 	}
 
 	return f.factory.GetPublicIPAddressesClient(credentialSecret.Namespace, credentialSecret.Name)
+}
+
+func (f *OrganizationFactory) GetRoleAssignmentsClient(ctx context.Context, objectMeta v1.ObjectMeta) (*authorization.RoleAssignmentsClient, error) {
+	credentialSecret, err := f.GetCredentialSecret(ctx, objectMeta)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return f.factory.GetRoleAssignmentsClient(credentialSecret.Namespace, credentialSecret.Name)
 }
 
 func (f *OrganizationFactory) GetCredentialSecret(ctx context.Context, objectMeta v1.ObjectMeta) (*v1alpha1.CredentialSecret, error) {

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/giantswarm/exporterkit v0.2.1
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v5 v5.11.0
-	github.com/giantswarm/k8scloudconfig/v10 v10.1.0
+	github.com/giantswarm/k8scloudconfig/v10 v10.4.0
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v0.2.0
 	github.com/giantswarm/microerror v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -260,7 +260,6 @@ github.com/giantswarm/apiextensions/v2 v2.6.2 h1:ECdw6G5QCr5TN95SIFtD63PfNVS7vBn
 github.com/giantswarm/apiextensions/v2 v2.6.2/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
 github.com/giantswarm/apiextensions/v3 v3.17.0/go.mod h1:N4SS083wjVR3GEL/pqWycva4yUtYrlU5lUKhRtZJ7EY=
 github.com/giantswarm/apiextensions/v3 v3.18.1/go.mod h1:N4SS083wjVR3GEL/pqWycva4yUtYrlU5lUKhRtZJ7EY=
-github.com/giantswarm/apiextensions/v3 v3.19.0/go.mod h1:6KBexBTOZJ+amkorxw722t2HS57f+rf/8LeSSFfQNmo=
 github.com/giantswarm/apiextensions/v3 v3.22.0 h1:Nkn0POdMBks58zDVCaDJ4HDkbDC0qU6bD9uV5tcKlp0=
 github.com/giantswarm/apiextensions/v3 v3.22.0/go.mod h1:6KBexBTOZJ+amkorxw722t2HS57f+rf/8LeSSFfQNmo=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
@@ -289,8 +288,8 @@ github.com/giantswarm/k8sclient/v4 v4.0.0/go.mod h1:jTwQ8q0YbJJu3ZxbjoI6hkXeuvKm
 github.com/giantswarm/k8sclient/v5 v5.10.0/go.mod h1:HHSHvERGfLhNqTsqKBUQSQ5VXGhLfVRojplYwio6jDU=
 github.com/giantswarm/k8sclient/v5 v5.11.0 h1:LZwtscRz53Wz+hf0Sc7L1PEJdeUTDzgUjai4+9EbNjY=
 github.com/giantswarm/k8sclient/v5 v5.11.0/go.mod h1:3if9oaz3gwTKMuVNxU8vJfrzADyTuExOj+uu8N0+LsM=
-github.com/giantswarm/k8scloudconfig/v10 v10.1.0 h1:CzHYwsZzBZSaXjxlw/nkHRsM24Zvy1IMSd8i5TrqUAM=
-github.com/giantswarm/k8scloudconfig/v10 v10.1.0/go.mod h1:7H3sgQSpcGMhsl0xmb9iTlh/G3I9mEQCjvc1WhLSg0Q=
+github.com/giantswarm/k8scloudconfig/v10 v10.4.0 h1:8Gx6LURkXgIX+nUdSlGZj5RAZLmQOqvioyNVF0C488w=
+github.com/giantswarm/k8scloudconfig/v10 v10.4.0/go.mod h1:rlodvoomT6bjyH8jS8RSQ8ccHQyJKfqreEdKplIhfSU=
 github.com/giantswarm/kubelock/v2 v2.0.0 h1:s5mJc32HD0cX7hRS3sZ+d0J7d7g9CZtz9uxyDv+24II=
 github.com/giantswarm/kubelock/v2 v2.0.0/go.mod h1:x0bQ6poerC12lXz2j0k01kjV8xx9qg6OVfbGe6dFjcM=
 github.com/giantswarm/microendpoint v0.2.0 h1:xCAqAVRjTw/4ifEuBeNavALdbQsLk6+k/ukzdy0GWZE=


### PR DESCRIPTION
When deleting a node pool, we did not delete the role assignment created to use managed identity.
That meant it was impossible to re-create a node pool with the same name (because role assignment creation used to fail).

This PR aims at solving this issue by deleting the role assignment when deleting a node pool