### PR TITLE
Check error using wrapped error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rely on k8s nodes instead of Azure instances when counting up-to-date nodes to decide if upgrade has finished.
 - Fixed logic that decides whether or not to update an `AzureMachine` based on the `release.giantswarm.io/last-deployed-version` annotation.
 - When deleting a node pool, also delete the VMSS role assignment.
+- Check errors coming from k8s API using the wrapped error.
 
 ## [5.6.0] - 2021-04-21
 

--- a/service/controller/azureconfig/handler/blobobject/desired.go
+++ b/service/controller/azureconfig/handler/blobobject/desired.go
@@ -109,7 +109,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	certificateEncryptionSecretName := key.CertificateEncryptionSecretName(&cr)
 
 	encrypter, err := r.toEncrypterObject(ctx, certificateEncryptionSecretName)
-	if apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(microerror.Cause(err)) {
 		r.logger.Debugf(ctx, "encryptionkey resource is not ready")
 		r.logger.Debugf(ctx, "canceling resource")
 		resourcecanceledcontext.SetCanceled(ctx)

--- a/service/controller/azureconfig/handler/masters/deployment.go
+++ b/service/controller/azureconfig/handler/masters/deployment.go
@@ -51,7 +51,7 @@ func (r Resource) newDeployment(ctx context.Context, obj providerv1alpha1.AzureC
 
 	certificateEncryptionSecretName := key.CertificateEncryptionSecretName(&obj)
 	encrypter, err := r.GetEncrypterObject(ctx, certificateEncryptionSecretName)
-	if apierrors.IsNotFound(err) {
+	if apierrors.IsNotFound(microerror.Cause(err)) {
 		r.Logger.Debugf(ctx, "encryptionkey secret is not found", "secretname", certificateEncryptionSecretName)
 		resourcecanceledcontext.SetCanceled(ctx)
 		r.Logger.Debugf(ctx, "canceling resource")

--- a/service/controller/azuremachinepool/handler/cloudconfigblob/create.go
+++ b/service/controller/azuremachinepool/handler/cloudconfigblob/create.go
@@ -46,7 +46,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	var payload string
 	{
 		payload, err = r.getCloudConfigFromBootstrapSecret(ctx, machinePool)
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(microerror.Cause(err)) {
 			r.logger.Debugf(ctx, "bootstrap CR or cloudconfig secret were not found")
 			r.logger.Debugf(ctx, "cancelling reconciliation")
 			reconciliationcanceledcontext.SetCanceled(ctx)

--- a/service/controller/azuremachinepool/handler/nodepool/create.go
+++ b/service/controller/azuremachinepool/handler/nodepool/create.go
@@ -62,7 +62,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		r.Logger.Debugf(ctx, "new state: %s", newState)
 		r.Logger.Debugf(ctx, "setting resource status to %#q", newState)
 		err = r.saveCurrentState(ctx, azureMachinePool, string(newState))
-		if apierrors.IsConflict(err) {
+		if apierrors.IsConflict(microerror.Cause(err)) {
 			r.Logger.Debugf(ctx, "conflict trying to save object in k8s API concurrently")
 			r.Logger.Debugf(ctx, "no state change")
 			return nil

--- a/service/controller/azuremachinepool/handler/nodepool/create_deployment_uninitialized.go
+++ b/service/controller/azuremachinepool/handler/nodepool/create_deployment_uninitialized.go
@@ -155,7 +155,7 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 		r.Debugger.LogFailedDeployment(ctx, currentDeployment, err)
 
 		err := r.saveAzureIDsInCR(ctx, virtualMachineScaleSetVMsClient, &azureMachinePool, vmss)
-		if apierrors.IsConflict(err) {
+		if apierrors.IsConflict(microerror.Cause(err)) {
 			r.Logger.Debugf(ctx, "conflict trying to save object in k8s API concurrently")
 			r.Logger.Debugf(ctx, "canceling resource")
 			return currentState, nil
@@ -179,7 +179,7 @@ func (r *Resource) deploymentUninitializedTransition(ctx context.Context, obj in
 		r.Logger.Debugf(ctx, "template and parameters unchanged")
 
 		err := r.saveAzureIDsInCR(ctx, virtualMachineScaleSetVMsClient, &azureMachinePool, vmss)
-		if apierrors.IsConflict(err) {
+		if apierrors.IsConflict(microerror.Cause(err)) {
 			r.Logger.Debugf(ctx, "conflict trying to save object in k8s API concurrently")
 			r.Logger.Debugf(ctx, "canceling resource")
 			return currentState, nil

--- a/service/controller/azuremachinepool/handler/spark/create.go
+++ b/service/controller/azuremachinepool/handler/spark/create.go
@@ -351,7 +351,7 @@ func (r *Resource) createIgnitionBlob(ctx context.Context, cluster *capiv1alpha3
 		certificateEncryptionSecretName := key.CertificateEncryptionSecretName(cluster)
 
 		encrypterObject, err = r.toEncrypterObject(ctx, certificateEncryptionSecretName)
-		if errors.IsNotFound(err) {
+		if errors.IsNotFound(microerror.Cause(err)) {
 			r.logger.Debugf(ctx, "encryptionkey resource is not ready")
 			return nil, microerror.Mask(requirementsNotMetError)
 		} else if err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17180

In the `apimachinery` version that we currently depend on, `errors.Is*` functions use a switch/case to check error type. In release `v0.19.0` onwards it uses `errors.As`, which takes into account the wrapped error. Until we upgrade to this release, we need these changes to actually check using the wrapped error.