### PR TITLE
Bring back default helm values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't reimage master instances unless the masters VMSS has the right model.
 - Don't wait for new workers to be up during spot instances node pools upgrades.
 - Bumped `k8scloudconfig` to `10.5.0` to support kubernetes 1.20.
-- Removed Docker registry and Dockerhub token from Helm values.
 
 ### Fixed
 

--- a/helm/azure-operator/values.yaml
+++ b/helm/azure-operator/values.yaml
@@ -61,3 +61,7 @@ workloadCluster:
   name: ""
   ssh:
     ssoPublicKey: ""
+registry:
+  domain: ""
+  dockerhub:
+    token: ""


### PR DESCRIPTION
I don't know how shit works, so [I deleted the wrong values](https://github.com/giantswarm/azure-operator/pull/1439/files). I'm bringing them back with a twist. Instead of defaulting to quay.io like before, I keep defaults as empty strings to make it less confusing. All these values will be overwritten by our deployment pipeline.