### PR TITLE
Fix udev rules to fix /boot automount 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix udev rules that caused `/boot` automount to fail
+
 ### Changed
 
 - Upgrade `k8scloudconfig` to `v10.8.1` from `v10.5.0`.

--- a/service/controller/cloudconfig/master_template.go
+++ b/service/controller/cloudconfig/master_template.go
@@ -200,6 +200,19 @@ func (me *masterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 			},
 			Permissions: FilePermission,
 		},
+		{ // Only needed until https://github.com/kinvolk/init/pull/41 is included into flatcar image.
+			AssetContent: ignition.UdevRules,
+			Path:         "/etc/udev/rules.d/66-azure-storage.rules",
+			Owner: k8scloudconfig.Owner{
+				Group: k8scloudconfig.Group{
+					Name: FileOwnerGroupName,
+				},
+				User: k8scloudconfig.User{
+					Name: FileOwnerUserName,
+				},
+			},
+			Permissions: CloudProviderFilePermission,
+		},
 	}
 
 	data := me.templateData(me.certFiles)

--- a/service/controller/cloudconfig/worker_template.go
+++ b/service/controller/cloudconfig/worker_template.go
@@ -89,6 +89,19 @@ func (we *workerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 			},
 			Permissions: CloudProviderFilePermission,
 		},
+		{ // Only needed until https://github.com/kinvolk/init/pull/41 is included into flatcar image.
+			AssetContent: ignition.UdevRules,
+			Path:         "/etc/udev/rules.d/66-azure-storage.rules",
+			Owner: k8scloudconfig.Owner{
+				Group: k8scloudconfig.Group{
+					Name: FileOwnerGroupName,
+				},
+				User: k8scloudconfig.User{
+					Name: FileOwnerUserName,
+				},
+			},
+			Permissions: CloudProviderFilePermission,
+		},
 	}
 
 	data := we.templateData(we.certFiles)

--- a/service/controller/templates/ignition/azure-udev-rules.go
+++ b/service/controller/templates/ignition/azure-udev-rules.go
@@ -1,0 +1,35 @@
+package ignition
+
+// Only needed until https://github.com/kinvolk/init/pull/41 is included into flatcar image.
+
+const UdevRules = `
+
+ACTION=="add|change", SUBSYSTEM=="block", ENV{ID_VENDOR}=="Msft", ENV{ID_MODEL}=="Virtual_Disk", GOTO="azure_disk"
+GOTO="azure_end"
+
+LABEL="azure_disk"
+# Root has a GUID of 0000 as the second value
+# The resource/resource has GUID of 0001 as the second value
+ATTRS{device_id}=="?00000000-0000-*", ENV{fabric_name}="root", GOTO="azure_names"
+ATTRS{device_id}=="?00000000-0001-*", ENV{fabric_name}="resource", GOTO="azure_names"
+# Wellknown SCSI controllers
+ATTRS{device_id}=="{f8b3781a-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi0", GOTO="azure_datadisk"
+ATTRS{device_id}=="{f8b3781b-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi1", GOTO="azure_datadisk"
+ATTRS{device_id}=="{f8b3781c-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi2", GOTO="azure_datadisk"
+ATTRS{device_id}=="{f8b3781d-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi3", GOTO="azure_datadisk"
+GOTO="azure_end"
+
+# Retrieve LUN number for datadisks
+LABEL="azure_datadisk"
+ENV{DEVTYPE}=="partition", PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/../device|cut -d: -f4'", ENV{fabric_name}="$env{fabric_scsi_controller}/lun$result", GOTO="azure_names"
+PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/device|cut -d: -f4'", ENV{fabric_name}="$env{fabric_scsi_controller}/lun$result", GOTO="azure_names"
+GOTO="azure_end"
+
+# Create the symlinks
+LABEL="azure_names"
+ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/$env{fabric_name}", TAG+="systemd"
+ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/$env{fabric_name}-part%n", TAG+="systemd"
+
+LABEL="azure_end"
+
+`

--- a/service/controller/templates/ignition/azure-udev-rules.go
+++ b/service/controller/templates/ignition/azure-udev-rules.go
@@ -31,5 +31,4 @@ ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/$env{fabric_name}", TAG+="systemd"
 ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/$env{fabric_name}-part%n", TAG+="systemd"
 
 LABEL="azure_end"
-
 `


### PR DESCRIPTION
`/boot` automount currently fails because the udev rules are missing TAG=systemd on azure storage boot device.

This is fixed upstream with https://github.com/kinvolk/init/pull/41.  Until that change is merged and in the flatcar base image, this change is required to fix the automount issue.

