### PR TITLE
Fix namespace in secret reference of `AzureClusterIdentity`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix namespace in secret reference of `AzureClusterIdentity`.
+
 ## [5.8.0] - 2021-07-13
 
 ### Added

--- a/service/controller/azurecluster/handler/azureclusteridentity/naming.go
+++ b/service/controller/azurecluster/handler/azureclusteridentity/naming.go
@@ -17,7 +17,3 @@ func newSecretName(legacySecret corev1.Secret) string {
 
 	return fmt.Sprintf("%s%s", newNamePrefix, name)
 }
-
-func newSecretNamespace(legacySecret corev1.Secret) string {
-	return legacySecret.Namespace
-}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/18171

Since version 5.7.1 newly created azureclusteridentity CRs were referencing the secret in a wrong namespace.
This PR fixes that error.

Tested, works fine