### PR TITLE
Update Spark release label when cluster is upgraded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use go embed in place of pkger.
 
+### Fixed
+
+- Ensure Spark CR release version label is updated when upgrading a cluster.
+
 ## [5.8.1] - 2021-07-22
 
 ### Fixed

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.8.2-sparkupdate"
+	version            = "5.8.2-dev"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.8.2-dev"
+	version            = "5.8.2-sparkupdate"
 )
 
 func Description() string {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/18210

## Motivation

Spark CR release label is not updated when we upgrade a cluster. Until now that was not an issue, because we did not use Spark CR release label anywhere.

After merging new Spark CR webhook handler in azure-admission-controller https://github.com/giantswarm/azure-admission-controller/pull/279, this issue will mean that some older Spark CRs will be ignored by azure-admission-controller. ATM not even that should cause any issues, but for the sake of keeping our CRs in a correct state, here's a little fix.

## Implementation and testing

- [x] Update Spark CR release label when MachinePool CR release label is updated.
- [x] Test in a test management cluster.
