### PR TITLE
Delegate Storage account type selection for master VM's disks to Azure api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Delegate Storage account type selection for master VM's disks to Azure API.
+
 ## [5.9.0] - 2021-09-13
 
 ### Changed

--- a/service/controller/azureconfig/controller.go
+++ b/service/controller/azureconfig/controller.go
@@ -48,6 +48,7 @@ import (
 	"github.com/giantswarm/azure-operator/v5/service/controller/cloudconfig"
 	"github.com/giantswarm/azure-operator/v5/service/controller/controllercontext"
 	"github.com/giantswarm/azure-operator/v5/service/controller/debugger"
+	"github.com/giantswarm/azure-operator/v5/service/controller/internal/vmsku"
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
 	"github.com/giantswarm/azure-operator/v5/service/controller/setting"
 )
@@ -230,6 +231,18 @@ func newAzureConfigResources(config ControllerConfig, certsSearcher certs.Interf
 			Logger:     config.Logger,
 		}
 		organizationClientFactory = client.NewOrganizationFactory(c)
+	}
+
+	var vmSKU *vmsku.VMSKUs
+	{
+		vmSKU, err = vmsku.New(vmsku.Config{
+			AzureClientSet: config.CPAzureClientSet,
+			Location:       config.Azure.Location,
+			Logger:         config.Logger,
+		})
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
 	}
 
 	var newDebugger *debugger.Debugger
@@ -435,6 +448,7 @@ func newAzureConfigResources(config ControllerConfig, certsSearcher certs.Interf
 			Config:                   nodesConfig,
 			CtrlClient:               config.K8sClient.CtrlClient(),
 			TenantRestConfigProvider: tenantRestConfigProvider,
+			VMSKU:                    vmSKU,
 		}
 
 		mastersResource, err = masters.New(c)

--- a/service/controller/azureconfig/handler/masters/resource.go
+++ b/service/controller/azureconfig/handler/masters/resource.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/azure-operator/v5/pkg/handler/nodes"
+	"github.com/giantswarm/azure-operator/v5/service/controller/internal/vmsku"
 	"github.com/giantswarm/azure-operator/v5/service/controller/key"
 )
 
@@ -22,12 +23,14 @@ type Config struct {
 	nodes.Config
 	CtrlClient               client.Client
 	TenantRestConfigProvider *tenantcluster.TenantCluster
+	VMSKU                    *vmsku.VMSKUs
 }
 
 type Resource struct {
 	nodes.Resource
 	ctrlClient               client.Client
 	tenantRestConfigProvider *tenantcluster.TenantCluster
+	vmSku                    *vmsku.VMSKUs
 }
 
 func New(config Config) (*Resource, error) {
@@ -36,6 +39,9 @@ func New(config Config) (*Resource, error) {
 	}
 	if config.TenantRestConfigProvider == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.TenantRestConfigProvider must not be empty", config)
+	}
+	if config.VMSKU == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.VMSKU must not be empty", config)
 	}
 
 	config.Name = Name
@@ -48,6 +54,7 @@ func New(config Config) (*Resource, error) {
 		Resource:                 *nodes,
 		ctrlClient:               config.CtrlClient,
 		tenantRestConfigProvider: config.TenantRestConfigProvider,
+		vmSku:                    config.VMSKU,
 	}
 	stateMachine := r.createStateMachine()
 	r.SetStateMachine(stateMachine)

--- a/service/controller/azureconfig/handler/masters/template/main.json
+++ b/service/controller/azureconfig/handler/masters/template/main.json
@@ -41,6 +41,12 @@
         "description":"Output value of the master subnet ID as referenced from the virtual network setup."
       }
     },
+    "storageAccountType": {
+      "type": "string",
+      "metadata": {
+        "description": "Storage Account Type to use for managed disks. Either 'Standard_LRS' or 'Premium_LRS'"
+      }
+    },
     "vmssMSIEnabled":{
       "type":"bool"
     },
@@ -54,91 +60,7 @@
   },
   "variables":{
     "apiVersion":"2017-08-01",
-    "kubernetesLBBackendID":"[concat(resourceId('Microsoft.Network/loadBalancers', 'kubernetes'), '/backendAddressPools/kubernetes')]",
-    "vmssStandardLrsSize":[
-      "Standard_A0",
-      "Standard_A1",
-      "Standard_A10",
-      "Standard_A11",
-      "Standard_A1_v2",
-      "Standard_A2",
-      "Standard_A2_v2",
-      "Standard_A2m_v2",
-      "Standard_A3",
-      "Standard_A4",
-      "Standard_A4_v2",
-      "Standard_A4m_v2",
-      "Standard_A5",
-      "Standard_A6",
-      "Standard_A7",
-      "Standard_A8",
-      "Standard_A8_v2",
-      "Standard_A8m_v2",
-      "Standard_A9",
-      "Standard_D1",
-      "Standard_D11",
-      "Standard_D11_v2",
-      "Standard_D11_v2_Promo",
-      "Standard_D12",
-      "Standard_D12_v2",
-      "Standard_D12_v2_Promo",
-      "Standard_D13",
-      "Standard_D13_v2",
-      "Standard_D13_v2_Promo",
-      "Standard_D14",
-      "Standard_D14_v2",
-      "Standard_D14_v2_Promo",
-      "Standard_D15_v2",
-      "Standard_D16_v3",
-      "Standard_D1_v2",
-      "Standard_D2",
-      "Standard_D2_v2",
-      "Standard_D2_v2_Promo",
-      "Standard_D2_v3",
-      "Standard_D3",
-      "Standard_D32_v3",
-      "Standard_D3_v2",
-      "Standard_D3_v2_Promo",
-      "Standard_D4",
-      "Standard_D4_v2",
-      "Standard_D4_v2_Promo",
-      "Standard_D4_v3",
-      "Standard_D5_v2",
-      "Standard_D5_v2_Promo",
-      "Standard_D64_v3",
-      "Standard_D8_v3",
-      "Standard_E16_v3",
-      "Standard_E2_v3",
-      "Standard_E32_v3",
-      "Standard_E4_v3",
-      "Standard_E64_v3",
-      "Standard_E8_v3",
-      "Standard_E8a_v4",
-      "Standard_E8as_v4",
-      "Standard_F1",
-      "Standard_F16",
-      "Standard_F2",
-      "Standard_F4",
-      "Standard_F8",
-      "Standard_G1",
-      "Standard_G2",
-      "Standard_G3",
-      "Standard_G4",
-      "Standard_G5",
-      "Standard_H16",
-      "Standard_H16m",
-      "Standard_H16mr",
-      "Standard_H16r",
-      "Standard_H8",
-      "Standard_H8m",
-      "Standard_NC12",
-      "Standard_NC24",
-      "Standard_NC24r",
-      "Standard_NC6",
-      "Standard_NV12",
-      "Standard_NV24",
-      "Standard_NV6"
-    ]
+    "kubernetesLBBackendID":"[concat(resourceId('Microsoft.Network/loadBalancers', 'kubernetes'), '/backendAddressPools/kubernetes')]"
   },
   "resources":[
     {
@@ -362,7 +284,7 @@
             "value":"[length(parameters('masterNodes'))]"
           },
           "vmssStorageAccountType":{
-            "value":"[if(contains(variables('vmssStandardLrsSize'), parameters('masterNodes')[0].vmSize), 'Standard_LRS', 'Premium_LRS')]"
+            "value":"[parameters('storageAccountType')]"
           },
           "vmssVmDataDisks":{
             "value":[
@@ -372,7 +294,7 @@
                 "diskSizeGB": 100,
                 "managedDisk":
                 {
-                  "storageAccountType": "[if(contains(variables('vmssStandardLrsSize'), parameters('masterNodes')[0].vmSize), 'Standard_LRS', 'Premium_LRS')]"
+                  "storageAccountType": "[parameters('storageAccountType')]"
                 },
                 "lun": 0
               },
@@ -382,7 +304,7 @@
                 "diskSizeGB": "[if(greater(parameters('masterNodes')[0].dockerVolumeSizeGB, 0), parameters('masterNodes')[0].dockerVolumeSizeGB, 50)]",
                 "managedDisk":
                 {
-                  "storageAccountType": "[if(contains(variables('vmssStandardLrsSize'), parameters('masterNodes')[0].vmSize), 'Standard_LRS', 'Premium_LRS')]"
+                  "storageAccountType": "[parameters('storageAccountType')]"
                 },
                 "lun": 1
               },
@@ -392,7 +314,7 @@
                 "diskSizeGB": "[if(greater(parameters('masterNodes')[0].kubeletVolumeSizeGB, 0), parameters('masterNodes')[0].kubeletVolumeSizeGB, 100)]",
                 "managedDisk":
                 {
-                  "storageAccountType": "[if(contains(variables('vmssStandardLrsSize'), parameters('masterNodes')[0].vmSize), 'Standard_LRS', 'Premium_LRS')]"
+                  "storageAccountType": "[parameters('storageAccountType')]"
                 },
                 "lun": 2
               }

--- a/service/controller/internal/vmsku/vmsku.go
+++ b/service/controller/internal/vmsku/vmsku.go
@@ -18,6 +18,7 @@ const (
 	CapabilitySupported = "True"
 
 	CapabilityAcceleratedNetworking = "AcceleratedNetworkingEnabled"
+	CapabilityPremiumIO             = "PremiumIO"
 )
 
 type Config struct {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/19150

This PR removes hardcoded check for VM types supporting premium storage and uses the azure API to check that.
This allows to automatically use new VM types in the future without releasing a new version of Azure Operator.