### PR TITLE
Cluster operator master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- When looking for the encryption secret, search on all namespaces (to support latest cluster-operator).
+
 ## [5.10.0] - 2021-11-08
 
 ### Changed

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.10.1-dev"
+	version            = "5.10.0"
 )
 
 func Description() string {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "azure-operator"
 	source      string = "https://github.com/giantswarm/azure-operator"
-	version            = "5.10.0"
+	version            = "5.10.1-dev"
 )
 
 func Description() string {

--- a/service/controller/cloudconfig/cloud_config.go
+++ b/service/controller/cloudconfig/cloud_config.go
@@ -104,7 +104,7 @@ func New(config Config) (*CloudConfig, error) {
 func (c CloudConfig) getEncryptionkey(ctx context.Context, customObject providerv1alpha1.AzureConfig) (string, error) {
 	secretList := &corev1.SecretList{}
 	{
-		c.logger.Debugf(ctx, "try to find encryption secret in namespace %#q", customObject.Namespace)
+		c.logger.Debugf(ctx, "try to find encryption secret")
 		err := c.ctrlClient.List(
 			ctx,
 			secretList,

--- a/service/controller/cloudconfig/cloud_config.go
+++ b/service/controller/cloudconfig/cloud_config.go
@@ -108,7 +108,6 @@ func (c CloudConfig) getEncryptionkey(ctx context.Context, customObject provider
 		err := c.ctrlClient.List(
 			ctx,
 			secretList,
-			ctrl.InNamespace(customObject.Namespace),
 			ctrl.MatchingLabels{
 				randomKeyLabel:              randomKeyLabelValue,
 				apiextensionslabels.Cluster: key.ClusterID(&customObject),
@@ -116,22 +115,6 @@ func (c CloudConfig) getEncryptionkey(ctx context.Context, customObject provider
 		)
 		if err != nil {
 			return "", microerror.Mask(err)
-		}
-
-		if secretList.Size() < 1 {
-			c.logger.Debugf(ctx, "try to find encryption secret in namespace %#q", corev1.NamespaceDefault)
-			err := c.ctrlClient.List(
-				ctx,
-				secretList,
-				ctrl.InNamespace(corev1.NamespaceDefault),
-				ctrl.MatchingLabels{
-					randomKeyLabel:              randomKeyLabelValue,
-					apiextensionslabels.Cluster: key.ClusterID(&customObject),
-				},
-			)
-			if err != nil {
-				return "", microerror.Mask(err)
-			}
 		}
 	}
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/554

Newest cluster operator stores the encryption secret in the org namespace. With this PR we check for the secret by label, ignoring the namespace.