### PR TITLE
Better error checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Consider case when API is down when checking if Master node is upgrading during node pool reconciliation.
+
 ## [5.10.1] - 2021-12-02
 
 ### Changed


### PR DESCRIPTION
When we are upgrading a cluster we ensure if the master node is upgraded before we move on with node pools.
In a previous release we changed the way we check this situation, by looking to the WC k8s API as well.
During cluster creation this leads to runtime errors in azure operator, because master is not up and thus the API is down.

This PR considers this case and avoids erroring. 
End goal is to avoid useless `OperatorKitErrorRateTooHigh` alerts.
