### PR TITLE
Azureclusterconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Deal with AzureClusterConfig CR to avoid cluster operator conflict.
+
 ## [5.11.0] - 2021-12-10
 
 ### Removed

--- a/helm/azure-operator/templates/rbac.yaml
+++ b/helm/azure-operator/templates/rbac.yaml
@@ -27,6 +27,7 @@ rules:
   - apiGroups:
       - core.giantswarm.io
     resources:
+      - azureclusterconfigs
       - drainerconfigs
       - sparks
       - sparks/status

--- a/service/controller/azurecluster/controller.go
+++ b/service/controller/azurecluster/controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/giantswarm/azure-operator/v5/pkg/project"
 	"github.com/giantswarm/azure-operator/v5/service/collector"
 	"github.com/giantswarm/azure-operator/v5/service/controller/azurecluster/handler/azureclusterconditions"
+	"github.com/giantswarm/azure-operator/v5/service/controller/azurecluster/handler/azureclusterconfig"
 	"github.com/giantswarm/azure-operator/v5/service/controller/azurecluster/handler/azureclusteridentity"
 	"github.com/giantswarm/azure-operator/v5/service/controller/azurecluster/handler/azureclusterupgrade"
 	"github.com/giantswarm/azure-operator/v5/service/controller/azurecluster/handler/azureconfig"
@@ -154,6 +155,19 @@ func newAzureClusterResources(config ControllerConfig, certsSearcher certs.Inter
 		}
 	}
 
+	var azureClusterConfigResource *azureclusterconfig.Resource
+	{
+		c := azureclusterconfig.Config{
+			CtrlClient: config.K8sClient.CtrlClient(),
+			Logger:     config.Logger,
+		}
+
+		azureClusterConfigResource, err = azureclusterconfig.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var azureClusterUpgradeResource resource.Interface
 	{
 		c := azureclusterupgrade.Config{
@@ -248,6 +262,7 @@ func newAzureClusterResources(config ControllerConfig, certsSearcher certs.Inter
 		azureClusterConditionsResource,
 		releaseResource,
 		azureclusteridentityResource,
+		azureClusterConfigResource,
 		azureConfigResource,
 		subnetResource,
 	}

--- a/service/controller/azurecluster/handler/azureclusterconfig/create.go
+++ b/service/controller/azurecluster/handler/azureclusterconfig/create.go
@@ -1,0 +1,61 @@
+package azureclusterconfig
+
+import (
+	"context"
+	"fmt"
+
+	corev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/giantswarm/azure-operator/v5/pkg/label"
+	"github.com/giantswarm/azure-operator/v5/service/controller/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	azureCluster, err := key.ToAzureCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var azureClusterConfig corev1alpha1.AzureClusterConfig
+	{
+		nsName := types.NamespacedName{
+			Name:      clusterConfigName(key.ClusterName(&azureCluster)),
+			Namespace: metav1.NamespaceDefault,
+		}
+		err = r.ctrlClient.Get(ctx, nsName, &azureClusterConfig)
+		if errors.IsNotFound(err) {
+			r.logger.Debugf(ctx, "azureclusterconfig did not exist, nothing to do")
+			r.logger.Debugf(ctx, "canceling resource")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	r.logger.Debugf(ctx, "ensuring azureclusterconfig's %q label is up to date", label.ClusterOperatorVersion)
+	{
+		currentClusterOperatorVersion := azureClusterConfig.GetLabels()[label.ClusterOperatorVersion]
+		desiredClusterOperatorVersion := azureCluster.GetLabels()[label.ClusterOperatorVersion]
+
+		if currentClusterOperatorVersion != desiredClusterOperatorVersion {
+			r.logger.Debugf(ctx, "updating %q label on azureclusterconfig")
+			azureClusterConfig.Labels[label.ClusterOperatorVersion] = desiredClusterOperatorVersion
+
+			err = r.ctrlClient.Update(ctx, &azureClusterConfig)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			r.logger.Debugf(ctx, "updated %q label on azureclusterconfig")
+		}
+	}
+
+	return nil
+}
+
+func clusterConfigName(clusterID string) string {
+	return fmt.Sprintf("%s-%s", clusterID, "azure-cluster-config")
+}

--- a/service/controller/azurecluster/handler/azureclusterconfig/create.go
+++ b/service/controller/azurecluster/handler/azureclusterconfig/create.go
@@ -42,14 +42,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		desiredClusterOperatorVersion := azureCluster.GetLabels()[label.ClusterOperatorVersion]
 
 		if currentClusterOperatorVersion != desiredClusterOperatorVersion {
-			r.logger.Debugf(ctx, "updating %q label on azureclusterconfig")
+			r.logger.Debugf(ctx, "updating %q label on azureclusterconfig", label.ClusterOperatorVersion)
 			azureClusterConfig.Labels[label.ClusterOperatorVersion] = desiredClusterOperatorVersion
 
 			err = r.ctrlClient.Update(ctx, &azureClusterConfig)
 			if err != nil {
 				return microerror.Mask(err)
 			}
-			r.logger.Debugf(ctx, "updated %q label on azureclusterconfig")
+			r.logger.Debugf(ctx, "updated %q label on azureclusterconfig", label.ClusterOperatorVersion)
 		}
 	}
 

--- a/service/controller/azurecluster/handler/azureclusterconfig/delete.go
+++ b/service/controller/azurecluster/handler/azureclusterconfig/delete.go
@@ -1,0 +1,86 @@
+package azureclusterconfig
+
+import (
+	"context"
+
+	corev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/v4/pkg/controller/context/finalizerskeptcontext"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/azure-operator/v5/service/controller/key"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	azureCluster, err := key.ToAzureCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.Debugf(ctx, "ensuring AzureClusterConfig deletion")
+
+	var azureClusterConfig corev1alpha1.AzureClusterConfig
+	{
+		nsName := types.NamespacedName{
+			Name:      clusterConfigName(key.ClusterID(&azureCluster)),
+			Namespace: metav1.NamespaceDefault,
+		}
+		err = r.ctrlClient.Get(ctx, nsName, &azureClusterConfig)
+		if errors.IsNotFound(err) {
+			// Done. AzureClusterConfig is gone and finalizer can be released.
+			r.logger.Debugf(ctx, "AzureClusterConfig deleted")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	// Wait until AzureClusterConfig is gone.
+	finalizerskeptcontext.SetKept(ctx)
+
+	if key.IsDeleted(&azureClusterConfig) {
+		r.logger.Debugf(ctx, "AzureClusterConfig deletion in progress")
+
+		err = r.ensureFinalizersRemoved(ctx, azureClusterConfig)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.Debugf(ctx, "canceling resource")
+		return nil
+	}
+
+	err = r.ctrlClient.Delete(ctx, &azureClusterConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.Debugf(ctx, "ensured AzureClusterConfig deletion")
+
+	err = r.ensureFinalizersRemoved(ctx, azureClusterConfig)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}
+
+func (r *Resource) ensureFinalizersRemoved(ctx context.Context, azureClusterConfig corev1alpha1.AzureClusterConfig) error {
+	// There is no operator reconciling AzureClusterConfig CR any more.
+	// I remove all finalizers to avoid deletion being stuck.
+	if len(azureClusterConfig.Finalizers) > 0 {
+		r.logger.Debugf(ctx, "clearing finalizers from AzureClusterConfig")
+		patch := client.MergeFrom(azureClusterConfig.DeepCopy())
+		azureClusterConfig.Finalizers = make([]string, 0)
+		err := r.ctrlClient.Patch(ctx, &azureClusterConfig, patch)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		r.logger.Debugf(ctx, "cleared finalizers from AzureClusterConfig")
+	}
+
+	return nil
+}

--- a/service/controller/azurecluster/handler/azureclusterconfig/error.go
+++ b/service/controller/azurecluster/handler/azureclusterconfig/error.go
@@ -1,0 +1,14 @@
+package azureclusterconfig
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/azurecluster/handler/azureclusterconfig/resource.go
+++ b/service/controller/azurecluster/handler/azureclusterconfig/resource.go
@@ -1,0 +1,41 @@
+package azureclusterconfig
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	Name = "azureclusterconfig"
+)
+
+type Config struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+}
+
+type Resource struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	newResource := &Resource{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20174 and https://github.com/giantswarm/roadmap/issues/646

Despite the fact the `AzureClusterConfig` CR is unused since release 16.1.0, to deal with upgraded clusters that already had that CR we need to bump the `cluster-operator` version label in `AzureClusterConfig` to avoid the legacy cluster operator and the new one fighting against default apps.

This PR does just that.