### PR TITLE
Exclude capi deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,14 @@
     {
       "matchPackageNames": ["sigs.k8s.io/controller-runtime"],
       "allowedVersions": "< 0.7.0"
+    },
+    {
+      "matchPackageNames": ["github.com/giantswarm/apiextensions"],
+      "allowedVersions": ">= 4.0.0"
+    },
+    {
+      "excludePackagePatterns": ["sigs.k8s.io/cluster-api*"],
+      "groupName": "capi modules"
     }
   ],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],


### PR DESCRIPTION
Trying `renovate` feature to exclude dependencies from getting automatic updates. If this works I'll make a PR so this is applied to all giantswarm repositories. 

We want to control CAPI upgrades instead of receiving automatic PR's to upgrade.