### PR TITLE
Roll nodes if cgroups change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make nodepool nodes roll in case the user switches between cgroups v1 and v2.
+
 ## [5.15.0] - 2022-02-16
 
 ### Changed

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -14,7 +14,7 @@ const (
 const (
 	OperatorVersion        = "azure-operator.giantswarm.io/version"
 	ClusterOperatorVersion = "cluster-operator.giantswarm.io/version"
-	CGroupVersion          = ""
+	CGroupVersion          = "cgroup.giantswarm.io/version"
 	ReleaseVersion         = "release.giantswarm.io/version"
 	SingleTenantSP         = "giantswarm.io/single-tenant-service-principal"
 

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -14,6 +14,7 @@ const (
 const (
 	OperatorVersion        = "azure-operator.giantswarm.io/version"
 	ClusterOperatorVersion = "cluster-operator.giantswarm.io/version"
+	CGroupVersion          = ""
 	ReleaseVersion         = "release.giantswarm.io/version"
 	SingleTenantSP         = "giantswarm.io/single-tenant-service-principal"
 

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -14,7 +14,7 @@ const (
 const (
 	OperatorVersion        = "azure-operator.giantswarm.io/version"
 	ClusterOperatorVersion = "cluster-operator.giantswarm.io/version"
-	CGroupVersion          = "cgroup.giantswarm.io/version"
+	CGroupVersion          = "cgroups.giantswarm.io/version"
 	ReleaseVersion         = "release.giantswarm.io/version"
 	SingleTenantSP         = "giantswarm.io/single-tenant-service-principal"
 

--- a/service/controller/azuremachinepool/handler/nodepool/create_scale_workers.go
+++ b/service/controller/azuremachinepool/handler/nodepool/create_scale_workers.go
@@ -196,7 +196,7 @@ func (r *Resource) splitInstancesByUpdatedStatus(ctx context.Context, azureMachi
 	var newInstances []compute.VirtualMachineScaleSetVM
 	{
 		for _, i := range allWorkerInstances {
-			old, err := r.isWorkerInstanceFromPreviousRelease(ctx, cluster, azureMachinePool.Name, i)
+			old, err := r.isWorkerInstanceFromPreviousRelease(ctx, cluster, azureMachinePool, i)
 			if err != nil {
 				return nil, nil, microerror.Mask(err)
 			}
@@ -236,11 +236,13 @@ func (r *Resource) getK8sWorkerNodeForInstance(ctx context.Context, tenantCluste
 	return nil, nil
 }
 
-func (r *Resource) isWorkerInstanceFromPreviousRelease(ctx context.Context, cluster *capiv1alpha3.Cluster, nodePoolId string, instance compute.VirtualMachineScaleSetVM) (bool, error) {
+func (r *Resource) isWorkerInstanceFromPreviousRelease(ctx context.Context, cluster *capiv1alpha3.Cluster, azureMachinePool capzv1alpha3.AzureMachinePool, instance compute.VirtualMachineScaleSetVM) (bool, error) {
 	tenantClusterK8sClient, err := r.tenantClientFactory.GetClient(ctx, cluster)
 	if err != nil {
 		return false, microerror.Mask(err)
 	}
+
+	nodePoolId := azureMachinePool.Name
 
 	n, err := r.getK8sWorkerNodeForInstance(ctx, tenantClusterK8sClient, nodePoolId, instance)
 	if err != nil {
@@ -254,6 +256,11 @@ func (r *Resource) isWorkerInstanceFromPreviousRelease(ctx context.Context, clus
 		return false, nil
 	}
 
+	machinePool, err := r.getOwnerMachinePool(ctx, azureMachinePool.ObjectMeta)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
 	myVersion := semver.New(project.Version())
 
 	v, exists := n.GetLabels()[label.OperatorVersion]
@@ -263,6 +270,14 @@ func (r *Resource) isWorkerInstanceFromPreviousRelease(ctx context.Context, clus
 		if nodeVersion.LessThan(*myVersion) {
 			return true, nil
 		}
+	}
+
+	// CGroups have changed.
+	nodeCgroupVersion, _ := n.GetLabels()[label.CGroupVersion]
+	vmssCgroupVersion := key.CGroupVersion(machinePool)
+	if nodeCgroupVersion != vmssCgroupVersion {
+		// Cgroups version changed in the node pool
+		return true, nil
 	}
 
 	// Kubernetes version has changed, node is outdated.

--- a/service/controller/azuremachinepool/handler/nodepool/create_scale_workers.go
+++ b/service/controller/azuremachinepool/handler/nodepool/create_scale_workers.go
@@ -273,7 +273,7 @@ func (r *Resource) isWorkerInstanceFromPreviousRelease(ctx context.Context, clus
 	}
 
 	// CGroups have changed.
-	nodeCgroupVersion, _ := n.GetLabels()[label.CGroupVersion]
+	nodeCgroupVersion := n.GetLabels()[label.CGroupVersion]
 	vmssCgroupVersion := key.CGroupVersion(machinePool)
 	if nodeCgroupVersion != vmssCgroupVersion {
 		// Cgroups version changed in the node pool

--- a/service/controller/azuremachinepool/handler/nodepool/deployment.go
+++ b/service/controller/azuremachinepool/handler/nodepool/deployment.go
@@ -10,9 +10,7 @@ import (
 	azureresource "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
 	"github.com/Azure/azure-storage-blob-go/azblob"
-	"github.com/coreos/go-semver/semver"
 	releasev1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/release/v1alpha1"
-	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -100,34 +98,9 @@ func (r Resource) getDesiredDeployment(ctx context.Context, storageAccountsClien
 		}
 	}
 
-	var cgroupsVersion string
-	{
-		// cgroups v2 is only supported since flatcar 2983.2.0
-		target, err := semver.NewVersion(distroVersion)
-		if err != nil {
-			return azureresource.Deployment{}, microerror.Mask(err)
-		}
-		min, err := semver.NewVersion("2983.2.0")
-		if err != nil {
-			return azureresource.Deployment{}, microerror.Mask(err)
-		}
-		if target.Compare(*min) < 0 {
-			// Flatcar version does not support cgroups v2.
-			cgroupsVersion = "v1"
-		} else {
-			cgroupsVersion = "v2"
-			if machinePool.Annotations != nil {
-				_, found := machinePool.Annotations[annotation.NodeForceCGroupsV1]
-				if found {
-					cgroupsVersion = "v1"
-				}
-			}
-		}
-	}
-
 	templateParameters := template.Parameters{
 		AzureOperatorVersion:        project.Version(),
-		CGroupsVersion:              cgroupsVersion,
+		CGroupsVersion:              key.CGroupVersion(machinePool),
 		ClusterID:                   azureCluster.GetName(),
 		DataDisks:                   azureMachinePool.Spec.Template.DataDisks,
 		EnableAcceleratedNetworking: enableAcceleratedNetworking,

--- a/service/controller/azuremachinepool/handler/nodepool/template/main.json
+++ b/service/controller/azuremachinepool/handler/nodepool/template/main.json
@@ -8,6 +8,12 @@
         "description": "Version of the azure operator that created the deployment."
       }
     },
+    "cGroupsVersion": {
+      "type": "string",
+      "metadata": {
+        "description": "CGroups version being used for the node pool. Either 'v1' or 'v2'."
+      }
+    },
     "clusterID": {
       "type": "string",
       "metadata": {
@@ -185,6 +191,7 @@
       "zones": "[if(greater(length(parameters('zones')),0), parameters('zones'), json('null'))]",
       "tags": {
         "provider": "[toUpper(parameters('GiantSwarmTags').provider)]",
+        "cgroups-version": "[parameters('cGroupsVersion')]",
         "cluster-autoscaler-enabled": "[if(equals(parameters('minReplicas'),parameters('maxReplicas')), 'false', 'true')]",
         "cluster-autoscaler-name": "[parameters('clusterID')]",
         "gs-azure-operator.giantswarm.io-version": "[parameters('azureOperatorVersion')]",

--- a/service/controller/azuremachinepool/handler/nodepool/template/parameters.go
+++ b/service/controller/azuremachinepool/handler/nodepool/template/parameters.go
@@ -10,6 +10,7 @@ import (
 type Parameters struct {
 	AzureOperatorVersion        string
 	ClusterID                   string
+	CGroupsVersion              string
 	DataDisks                   []v1alpha3.DataDisk
 	EnableAcceleratedNetworking bool
 	KubernetesVersion           string
@@ -77,6 +78,7 @@ func (p Parameters) ToDeployParams() map[string]interface{} {
 	armDeploymentParameters := map[string]interface{}{}
 	armDeploymentParameters["azureOperatorVersion"] = toARMParam(p.AzureOperatorVersion)
 	armDeploymentParameters["clusterID"] = toARMParam(p.ClusterID)
+	armDeploymentParameters["cGroupsVersion"] = toARMParam(p.CGroupsVersion)
 	armDeploymentParameters["dataDisks"] = toARMParam(dataDisks)
 	armDeploymentParameters["enableAcceleratedNetworking"] = toARMParam(p.EnableAcceleratedNetworking)
 	armDeploymentParameters["kubernetesVersion"] = toARMParam(p.KubernetesVersion)
@@ -157,6 +159,7 @@ func newParameters(parameters map[string]interface{}, cast func(param interface{
 	// Finally return typed parameters.
 	return Parameters{
 		AzureOperatorVersion:        cast(parameters["azureOperatorVersion"]).(string),
+		CGroupsVersion:              cast(parameters["cGroupsVersion"]).(string),
 		ClusterID:                   cast(parameters["clusterID"]).(string),
 		DataDisks:                   dataDisks,
 		EnableAcceleratedNetworking: cast(parameters["enableAcceleratedNetworking"]).(bool),

--- a/service/controller/azuremachinepool/handler/nodepool/template/template.go
+++ b/service/controller/azuremachinepool/handler/nodepool/template/template.go
@@ -88,6 +88,9 @@ func Diff(currentDeployment azureresource.DeploymentExtended, desiredDeployment 
 	if !reflect.DeepEqual(currentParameters.Zones, desiredParameters.Zones) {
 		changes = append(changes, "zones")
 	}
+	if currentParameters.CGroupsVersion != desiredParameters.CGroupsVersion {
+		changes = append(changes, "cgroupsversion")
+	}
 
 	return changes, nil
 }

--- a/service/controller/cloudconfig/worker_template.go
+++ b/service/controller/cloudconfig/worker_template.go
@@ -3,12 +3,15 @@ package cloudconfig
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 
 	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v11/pkg/template"
 	"github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
 
+	"github.com/giantswarm/azure-operator/v5/pkg/label"
 	"github.com/giantswarm/azure-operator/v5/service/controller/encrypter"
+	"github.com/giantswarm/azure-operator/v5/service/controller/key"
 	"github.com/giantswarm/azure-operator/v5/service/controller/templates/ignition"
 )
 
@@ -32,6 +35,8 @@ func (c CloudConfig) NewWorkerTemplate(ctx context.Context, data IgnitionTemplat
 
 		params = k8scloudconfig.Params{}
 		params.Cluster = data.CustomObject.Spec.Cluster
+		// Add node label for cgroups version
+		params.Cluster.Kubernetes.Kubelet.Labels = fmt.Sprintf("%s,%s=%s", params.Cluster.Kubernetes.Kubelet.Labels, label.CGroupVersion, key.CGroupVersion(data.MachinePool))
 		params.CalicoPolicyOnly = true
 		params.Kubernetes = k8scloudconfig.Kubernetes{
 			Kubelet: k8scloudconfig.KubernetesDockerOptions{

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -12,6 +12,7 @@ import (
 	providerv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/provider/v1alpha1"
 	apiextensionslabels "github.com/giantswarm/apiextensions/v3/pkg/label"
 	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v11/pkg/template"
+	k8smetaannotation "github.com/giantswarm/k8smetadata/pkg/annotation"
 	"github.com/giantswarm/microerror"
 	v1 "k8s.io/api/core/v1"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
@@ -745,6 +746,18 @@ func NodePoolSpotInstancesMaxPrice(azureMachinePool *expcapzv1alpha3.AzureMachin
 	}
 
 	return azureMachinePool.Spec.Template.SpotVMOptions.MaxPrice.AsDec().String()
+}
+
+func CGroupVersion(machinePool *expcapiv1alpha3.MachinePool) string {
+	cgroupsVersion := "v2"
+	if machinePool.Annotations != nil {
+		_, found := machinePool.Annotations[k8smetaannotation.NodeForceCGroupsV1]
+		if found {
+			cgroupsVersion = "v1"
+		}
+	}
+
+	return cgroupsVersion
 }
 
 func vmssInstanceIDBase36(instanceID string) (string, error) {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/845

This PR makes nodes in a node pool roll automatically when there is a switch between groups v1 and v2 or vice versa