### PR TITLE
Set `AzureMachine.Status.Ready` according to AzureMachine's Ready condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update sigs.k8s.io/cluster-api-provider-azure to v1.0.2
 - Update sigs.k8s.io/controller-runtime to v0.10.3
 
+### Fixed
+
+- Set `AzureMachine.Status.Ready` according to AzureMachine's Ready condition.
+
 ## [5.18.0] - 2022-03-21
 
 ### Added

--- a/service/controller/azuremachine/handler/azuremachineconditions/conditionready.go
+++ b/service/controller/azuremachine/handler/azuremachineconditions/conditionready.go
@@ -43,5 +43,8 @@ func (r *Resource) ensureReadyCondition(ctx context.Context, azureMachine *capz.
 	// Now check current Ready condition so we can log the value
 	r.logConditionStatus(ctx, azureMachine, capi.ReadyCondition)
 	r.logger.Debugf(ctx, "ensured condition Ready")
+
+	azureMachine.Status.Ready = capiconditions.IsTrue(azureMachine, capi.ReadyCondition)
+
 	return nil
 }


### PR DESCRIPTION
Towards:  https://github.com/giantswarm/giantswarm/issues/21366
`kubectl get azuremachine` shows a `Ready` column that displays data from the `status.ready` field.
We never update that field, but rather rely on the `Ready` condition in the status.
this PR sets the `status.ready` field to the same value as the `Ready` condition