### PR TITLE
systemd cgroup driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use systemd cgroup driver on masters and cgroups v2 worker nodes. 
 - Update github.com/Azure/azure-sdk-for-go to v58.1.0+incompatible
 - Update github.com/giantswarm/apiextensions to v6.0.0
 - Update github.com/giantswarm/certs to v4.0.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/giantswarm/exporterkit v1.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220512145829-bf40e7a1eba0
+	github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220523121029-41ceae8b1f91
 	github.com/giantswarm/k8smetadata v0.9.2
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/giantswarm/exporterkit v1.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220523121029-41ceae8b1f91
+	github.com/giantswarm/k8scloudconfig/v13 v13.6.0
 	github.com/giantswarm/k8smetadata v0.9.2
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/giantswarm/exporterkit v1.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v13 v13.4.0
+	github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220512145829-bf40e7a1eba0
 	github.com/giantswarm/k8smetadata v0.9.2
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -505,8 +505,8 @@ github.com/giantswarm/k8sclient/v6 v6.0.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7
 github.com/giantswarm/k8sclient/v6 v6.1.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7CP3GoaFsfZ5KHps=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220523121029-41ceae8b1f91 h1:LvOXsYHINounrygg8isefpf6tqj7kcHqr1Aix90TRNc=
-github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220523121029-41ceae8b1f91/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
+github.com/giantswarm/k8scloudconfig/v13 v13.6.0 h1:Eu5C5g2uwxyFdsozB/OhZFLfG20JTaNCqGpvEjrJ8bo=
+github.com/giantswarm/k8scloudconfig/v13 v13.6.0/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.9.2 h1:10lbS5DRJNES4iytNxc/5+3lsZfx+t+RvP1qZF2ymvc=
 github.com/giantswarm/k8smetadata v0.9.2/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=

--- a/go.sum
+++ b/go.sum
@@ -505,8 +505,8 @@ github.com/giantswarm/k8sclient/v6 v6.0.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7
 github.com/giantswarm/k8sclient/v6 v6.1.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7CP3GoaFsfZ5KHps=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220512145829-bf40e7a1eba0 h1:g50dLkRc1BfcCJYGoFMvIkxhctgLtW3c/a8wsSpQS4A=
-github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220512145829-bf40e7a1eba0/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
+github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220523121029-41ceae8b1f91 h1:LvOXsYHINounrygg8isefpf6tqj7kcHqr1Aix90TRNc=
+github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220523121029-41ceae8b1f91/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.9.2 h1:10lbS5DRJNES4iytNxc/5+3lsZfx+t+RvP1qZF2ymvc=
 github.com/giantswarm/k8smetadata v0.9.2/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=

--- a/go.sum
+++ b/go.sum
@@ -505,8 +505,6 @@ github.com/giantswarm/k8sclient/v6 v6.0.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7
 github.com/giantswarm/k8sclient/v6 v6.1.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7CP3GoaFsfZ5KHps=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v13 v13.4.0 h1:n2CrxEwKgi3SZ79sDz+JQGmERrN5vzeGmrQ9QwQOadM=
-github.com/giantswarm/k8scloudconfig/v13 v13.4.0/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
 github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220512145829-bf40e7a1eba0 h1:g50dLkRc1BfcCJYGoFMvIkxhctgLtW3c/a8wsSpQS4A=
 github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220512145829-bf40e7a1eba0/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=

--- a/go.sum
+++ b/go.sum
@@ -507,6 +507,8 @@ github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEP
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
 github.com/giantswarm/k8scloudconfig/v13 v13.4.0 h1:n2CrxEwKgi3SZ79sDz+JQGmERrN5vzeGmrQ9QwQOadM=
 github.com/giantswarm/k8scloudconfig/v13 v13.4.0/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
+github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220512145829-bf40e7a1eba0 h1:g50dLkRc1BfcCJYGoFMvIkxhctgLtW3c/a8wsSpQS4A=
+github.com/giantswarm/k8scloudconfig/v13 v13.5.1-0.20220512145829-bf40e7a1eba0/go.mod h1:DrdAwbdaCkDgRym8ijQs2NlB2xU03Amd6DY4748AHLM=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.9.2 h1:10lbS5DRJNES4iytNxc/5+3lsZfx+t+RvP1qZF2ymvc=
 github.com/giantswarm/k8smetadata v0.9.2/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1090

this PR bumps k8scc to switch to `systemd` group driver on master nodes and on cgroups v2-enabled node pools