### PR TITLE
fix ownerReferences' uids during migration to non-exp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.20.0] - 2022-06-07
 
+
+### Fixed
+
+- Add pause annotation before deleting old machinepool and azuremachinepool CRs during migration to non-exp.
+- Update ownerReference UIDs during migration to non-exp.
+
 ### Changed
 
 - Bumped k8scc to latest version to fix `localhost` node name problem.

--- a/service/controller/azurecluster/handler/azureclusteridentity/create.go
+++ b/service/controller/azurecluster/handler/azureclusteridentity/create.go
@@ -279,10 +279,7 @@ func getAzureClusterIdentitySpec(azureCluster *capz.AzureCluster, legacySecret c
 			Name:      newName,
 			Namespace: newNamespace,
 		},
-		TenantID: tenantID,
-		AllowedNamespaces: &capz.AllowedNamespaces{
-			NamespaceList: make([]string, 0),
-			Selector:      nil,
-		},
+		TenantID:          tenantID,
+		AllowedNamespaces: nil,
 	}
 }

--- a/service/controller/machinepoolexp/handler/migration/resource.go
+++ b/service/controller/machinepoolexp/handler/migration/resource.go
@@ -54,22 +54,17 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		Namespace: oldMachinePool.Namespace,
 		Name:      oldMachinePool.Name,
 	}
-	err = r.ensureNewMachinePoolCreated(ctx, oldMachinePool)
+	mp, err := r.ensureNewMachinePoolCreated(ctx, oldMachinePool)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	err = r.ensureNewAzureMachinePoolCreated(ctx, namespacedName)
+	err = r.ensureNewAzureMachinePoolCreated(ctx, namespacedName, mp)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
 	err = r.ensureNewMachinePoolReferencesUpdated(ctx, namespacedName)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	err = r.ensureNewAzureMachinePoolReferencesUpdated(ctx, namespacedName)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/machinepoolexp/handler/migration/testdata/case-0-Simple-MachinePool_AzureMachinePool.golden
+++ b/service/controller/machinepoolexp/handler/migration/testdata/case-0-Simple-MachinePool_AzureMachinePool.golden
@@ -21,8 +21,8 @@ metadata:
     controller: true
     kind: MachinePool
     name: 5suzw
-    uid: 52212476-9aaf-4c5c-8f86-68d382ff5d78
-  resourceVersion: "2"
+    uid: ""
+  resourceVersion: "1"
 spec:
   identity: None
   location: westeurope


### PR DESCRIPTION
During upgrades from 17.0.1 to latest azure operator master, the node pools's backing VMSSes were deleted and recreated.
There were a few reasons for that

- after being copied to the new apiVersions, the `machinePool` and `azureMachinePool` CRs were deleted. Despite the fact the finalizers were removed, it could happen that the controller did one last reconciliation loop for the deletion event. Solved by adding the pause annotations just before deleting the CR.
- the ownerReference on the `azureMachinePool` CR were correctly updated to point to the new machinePool apiVersion, but the uid of the machinepool was still the old one. This meant when the old machinePool (the experimental one) was deleted by azure-operator, `controller-manager` thought the new azuremachinepool was orphaned, and garbage collected it. Fixed by adjusting the UID during creation of non-exp CRs.

