### PR TITLE
Fix empty nodepool status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix handling of `MachinePools'` status fields for empty node pools.
+
 ## [5.21.0] - 2022-06-22
 
 ### Changed

--- a/service/controller/machinepool/handler/nodestatus/create.go
+++ b/service/controller/machinepool/handler/nodestatus/create.go
@@ -2,6 +2,7 @@ package nodestatus
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/giantswarm/apiextensions/v6/pkg/label"
 	"github.com/giantswarm/microerror"
@@ -46,25 +47,17 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return nil
 	}
 
-	machinePool.Spec.ProviderIDList = azureMachinePool.Spec.ProviderIDList
-	if len(azureMachinePool.Spec.ProviderIDList) == 0 {
-		r.logger.Debugf(ctx, "AzureMachinePool.Spec.ProviderIDList haven't been set yet")
-		r.logger.Debugf(ctx, "canceling resource")
-		return nil
-	}
+	if !reflect.DeepEqual(machinePool.Spec.ProviderIDList, azureMachinePool.Spec.ProviderIDList) {
+		machinePool.Spec.ProviderIDList = azureMachinePool.Spec.ProviderIDList
 
-	err = r.ctrlClient.Update(ctx, &machinePool)
-	if apierrors.IsConflict(err) {
-		r.logger.Debugf(ctx, "conflict trying to save object in k8s API concurrently")
-		r.logger.Debugf(ctx, "cancelling resource")
-		return nil
-	} else if err != nil {
-		return microerror.Mask(err)
-	}
-
-	err = r.ctrlClient.Get(ctx, ctrlclient.ObjectKey{Name: machinePool.Name, Namespace: machinePool.Namespace}, &machinePool)
-	if err != nil {
-		return microerror.Mask(err)
+		err = r.ctrlClient.Update(ctx, &machinePool)
+		if apierrors.IsConflict(err) {
+			r.logger.Debugf(ctx, "conflict trying to save object in k8s API concurrently")
+			r.logger.Debugf(ctx, "cancelling resource")
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
 	}
 
 	tenantClusterK8sClient, err := r.tenantClientFactory.GetClient(ctx, cluster)
@@ -77,15 +70,23 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	nodeRefsResult, err := r.getNodeReferences(ctx, tenantClusterK8sClient, machinePool.Name, machinePool.Spec.ProviderIDList)
+	err = r.ctrlClient.Get(ctx, ctrlclient.ObjectKey{Name: machinePool.Name, Namespace: machinePool.Namespace}, &machinePool)
 	if err != nil {
-		if IsErrNoAvailableNodes(err) {
-			r.logger.Debugf(ctx, "Cannot assign NodeRefs to MachinePool, no matching Nodes")
-			r.logger.Debugf(ctx, "canceling resource")
-			return nil
-		}
-
 		return microerror.Mask(err)
+	}
+
+	var nodeRefsResult getNodeReferencesResult
+	if len(machinePool.Spec.ProviderIDList) > 0 {
+		nodeRefsResult, err = r.getNodeReferences(ctx, tenantClusterK8sClient, machinePool.Name, machinePool.Spec.ProviderIDList)
+		if err != nil {
+			if IsErrNoAvailableNodes(err) {
+				r.logger.Debugf(ctx, "Cannot assign NodeRefs to MachinePool, no matching Nodes")
+				r.logger.Debugf(ctx, "canceling resource")
+				return nil
+			}
+
+			return microerror.Mask(err)
+		}
 	}
 
 	machinePool.Status.Replicas = azureMachinePool.Status.Replicas


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/22624

when a NP moved from > 0 to 0 replicas, the status never got updated.
With this PR it does.

```
$ kubectl --context=gs-godsmack -n org-giantswarm get machinepools v5ow3  -o yaml | yq .status                                                                         whitesbook: Wed Jun 29 13:32:02 2022

availableReplicas: 1
...
nodeRefs:
  - name: nodepool-v5ow3-000000
    uid: 7d2e3e09-99da-4caf-882f-d344235619e1
readyReplicas: 1
replicas: 1
```

scaled NP to zero replicas

```
$ kubectl --context=gs-godsmack -n org-giantswarm get machinepools v5ow3  -o yaml | yq .status                                                                         whitesbook: Wed Jun 29 13:41:07 2022

...
replicas: 0
```

