### PR TITLE
Make `azure-operator` PSS restricted compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Tighten pod and container security contexts for PSS restricted policies.
+
 ### Fixed
 
 - Fix handling of `MachinePools'` status fields for empty node pools.

--- a/helm/azure-operator/templates/deployment.yaml
+++ b/helm/azure-operator/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
+        {{- with .Values.podSecurityContext }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
@@ -87,3 +90,9 @@ spec:
           limits:
             cpu: 250m
             memory: 250Mi
+        securityContext:
+          runAsUser: {{ .Values.userID }}
+          runAsGroup: {{ .Values.groupID }}
+          {{- with .Values.securityContext }}
+            {{- . | toYaml | nindent 10 }}
+          {{- end }}

--- a/helm/azure-operator/templates/psp.yaml
+++ b/helm/azure-operator/templates/psp.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "resource.psp.name" . }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 spec:
   privileged: false
   fsGroup:

--- a/helm/azure-operator/values.yaml
+++ b/helm/azure-operator/values.yaml
@@ -29,7 +29,6 @@ securityContext:
     drop:
     - ALL
   privileged: false
-  readOnlyRootFilesystem: true
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault

--- a/helm/azure-operator/values.yaml
+++ b/helm/azure-operator/values.yaml
@@ -16,6 +16,24 @@ ports:
       port: 8000
       protocol: "TCP"
 
+# Pod securityContext
+podSecurityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container securityContext
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  privileged: false
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
 azure:
   environmentName: ""
   managementCluster:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/256

Adds the runtime/default seccomp profile and sets more explicitly restrictive security contexts to comply with `restricted` Pod Security Standards.