### PR TITLE
- Bump `k8scc` to enable `auditd` monitoring for `execve` syscalls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix handling of `MachinePools'` status fields for empty node pools.
 
+### Changed
+
+- Bump `k8scc` to enable `auditd` monitoring for `execve` syscalls.
+
 ## [5.21.0] - 2022-06-22
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/giantswarm/exporterkit v1.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v13 v13.8.0
+	github.com/giantswarm/k8scloudconfig/v13 v13.9.0
 	github.com/giantswarm/k8smetadata v0.9.3
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -445,8 +445,8 @@ github.com/giantswarm/k8sclient/v6 v6.0.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7
 github.com/giantswarm/k8sclient/v6 v6.1.0/go.mod h1:mF0FgQHqCrAhk5EGiyN7RfgMMsz7CP3GoaFsfZ5KHps=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v13 v13.8.0 h1:Gwf4PDfuJ99ZqdN1HNTTkiLZvYqyBa4Dyt+8myV2ksM=
-github.com/giantswarm/k8scloudconfig/v13 v13.8.0/go.mod h1:uw5pSpp9onfUrBxkW7vMxTvOBFmETYCO8pNhvi20Qe8=
+github.com/giantswarm/k8scloudconfig/v13 v13.9.0 h1:b/73htq1yjI8sPttrjPjQ/HSQcWTQ1zeNZlLmU5I87g=
+github.com/giantswarm/k8scloudconfig/v13 v13.9.0/go.mod h1:uw5pSpp9onfUrBxkW7vMxTvOBFmETYCO8pNhvi20Qe8=
 github.com/giantswarm/k8smetadata v0.6.0/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/k8smetadata v0.9.3 h1:YJJ5NJzjIQImNZc96ia2zh1PEkMt9+G+HalA8ZL8qxQ=
 github.com/giantswarm/k8smetadata v0.9.3/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/22498