### PR TITLE
Ensure giantswarm user is always first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure giantswarm user is always created first.
+
 ## [6.0.1] - 2022-08-31
 
 ### Fixed

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -544,11 +544,18 @@ func ToClusterKubernetesSSHUser(s employees.SSHUserList) []v1alpha1.ClusterKuber
 	var ret []v1alpha1.ClusterKubernetesSSHUser
 
 	for name, keys := range s {
-		ret = append(ret, v1alpha1.ClusterKubernetesSSHUser{
+		u := v1alpha1.ClusterKubernetesSSHUser{
 			Name: name,
 			// v1alpha1 type currently supports only one ssh key per user.
 			PublicKey: keys[0],
-		})
+		}
+
+		// we want giantswarm user always first in the list.
+		if name == "giantswarm" {
+			ret = append([]v1alpha1.ClusterKubernetesSSHUser{u}, ret...)
+		} else {
+			ret = append(ret, u)
+		}
 	}
 
 	return ret


### PR DESCRIPTION
Ensure giantswarm user is always created first in the VM to avoid cert-exporter failing to scrape because of lack of permissions.