### PR TITLE
Bump k8scc to 15.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump k8scc to support improve reliability of calico deployment process for new clusters.
+
 ## [7.0.0] - 2023-01-11
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/giantswarm/exporterkit v1.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v15 v15.4.0
+	github.com/giantswarm/k8scloudconfig/v15 v15.4.5-0.20230126165215-4c912250dc59
 	github.com/giantswarm/k8smetadata v0.9.3
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/giantswarm/exporterkit v1.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v15 v15.4.5-0.20230126171928-213a6411a7dc
+	github.com/giantswarm/k8scloudconfig/v15 v15.5.0
 	github.com/giantswarm/k8smetadata v0.9.3
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/giantswarm/exporterkit v1.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v15 v15.4.5-0.20230126165215-4c912250dc59
+	github.com/giantswarm/k8scloudconfig/v15 v15.4.5-0.20230126171928-213a6411a7dc
 	github.com/giantswarm/k8smetadata v0.9.3
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -396,8 +396,8 @@ github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73X
 github.com/giantswarm/k8sclient/v4 v4.0.0/go.mod h1:jTwQ8q0YbJJu3ZxbjoI6hkXeuvKm15xyI/c+zwxnUH0=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v15 v15.4.0 h1:bv92A4t7BjpR3WiHLx75wgmwThv5w61P476RojPvnQQ=
-github.com/giantswarm/k8scloudconfig/v15 v15.4.0/go.mod h1:U/8wnDDk6aiL7g81AtB0dfnyJjiubJNlaUgBakHRgNo=
+github.com/giantswarm/k8scloudconfig/v15 v15.4.5-0.20230126165215-4c912250dc59 h1:HVynMDH42q9Ej+ZiP9CzQdQQLIKWIz3DUCnllgWvz90=
+github.com/giantswarm/k8scloudconfig/v15 v15.4.5-0.20230126165215-4c912250dc59/go.mod h1:U/8wnDDk6aiL7g81AtB0dfnyJjiubJNlaUgBakHRgNo=
 github.com/giantswarm/k8smetadata v0.9.3 h1:YJJ5NJzjIQImNZc96ia2zh1PEkMt9+G+HalA8ZL8qxQ=
 github.com/giantswarm/k8smetadata v0.9.3/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v2 v2.0.0 h1:s5mJc32HD0cX7hRS3sZ+d0J7d7g9CZtz9uxyDv+24II=

--- a/go.sum
+++ b/go.sum
@@ -396,8 +396,8 @@ github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73X
 github.com/giantswarm/k8sclient/v4 v4.0.0/go.mod h1:jTwQ8q0YbJJu3ZxbjoI6hkXeuvKm15xyI/c+zwxnUH0=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v15 v15.4.5-0.20230126165215-4c912250dc59 h1:HVynMDH42q9Ej+ZiP9CzQdQQLIKWIz3DUCnllgWvz90=
-github.com/giantswarm/k8scloudconfig/v15 v15.4.5-0.20230126165215-4c912250dc59/go.mod h1:U/8wnDDk6aiL7g81AtB0dfnyJjiubJNlaUgBakHRgNo=
+github.com/giantswarm/k8scloudconfig/v15 v15.4.5-0.20230126171928-213a6411a7dc h1:ugPHXrR0fB//fw6WJ2+7GNHQNMXhQ8PcvW1R3+vlld8=
+github.com/giantswarm/k8scloudconfig/v15 v15.4.5-0.20230126171928-213a6411a7dc/go.mod h1:U/8wnDDk6aiL7g81AtB0dfnyJjiubJNlaUgBakHRgNo=
 github.com/giantswarm/k8smetadata v0.9.3 h1:YJJ5NJzjIQImNZc96ia2zh1PEkMt9+G+HalA8ZL8qxQ=
 github.com/giantswarm/k8smetadata v0.9.3/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v2 v2.0.0 h1:s5mJc32HD0cX7hRS3sZ+d0J7d7g9CZtz9uxyDv+24II=

--- a/go.sum
+++ b/go.sum
@@ -396,8 +396,8 @@ github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73X
 github.com/giantswarm/k8sclient/v4 v4.0.0/go.mod h1:jTwQ8q0YbJJu3ZxbjoI6hkXeuvKm15xyI/c+zwxnUH0=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v15 v15.4.5-0.20230126171928-213a6411a7dc h1:ugPHXrR0fB//fw6WJ2+7GNHQNMXhQ8PcvW1R3+vlld8=
-github.com/giantswarm/k8scloudconfig/v15 v15.4.5-0.20230126171928-213a6411a7dc/go.mod h1:U/8wnDDk6aiL7g81AtB0dfnyJjiubJNlaUgBakHRgNo=
+github.com/giantswarm/k8scloudconfig/v15 v15.5.0 h1:WbXZTe2r4aq5Of2UtfyoRvcnTdtBXcxSL41FtlYzuqs=
+github.com/giantswarm/k8scloudconfig/v15 v15.5.0/go.mod h1:U/8wnDDk6aiL7g81AtB0dfnyJjiubJNlaUgBakHRgNo=
 github.com/giantswarm/k8smetadata v0.9.3 h1:YJJ5NJzjIQImNZc96ia2zh1PEkMt9+G+HalA8ZL8qxQ=
 github.com/giantswarm/k8smetadata v0.9.3/go.mod h1:k3DYCMdspxhk7efLkQdX1b8UZ71ijOCG3ZoIU8+5xgw=
 github.com/giantswarm/kubelock/v2 v2.0.0 h1:s5mJc32HD0cX7hRS3sZ+d0J7d7g9CZtz9uxyDv+24II=


### PR DESCRIPTION
to improve reliability of calico bootstrapping on new clusters