### PR TITLE
add support for customizing `controller-manager` `terminated-pod-gc-threshold` value through annotation `controllermanager.giantswarm.io/terminated-pod-gc-threshold`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for customizing `controller-manager` `terminated-pod-gc-threshold` value through annotation `giantswarm.io/controllermanager-terminated-pod-gc-threshold`
+
 ### Removed
 
 - Scripts: Remove `migrate-nginx-ingress-controller.sh`. ([#1729](https://github.com/giantswarm/azure-operator/pull/1729))

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/giantswarm/exporterkit v1.0.0
 	github.com/giantswarm/ipam v0.3.0
 	github.com/giantswarm/k8sclient/v7 v7.0.1
-	github.com/giantswarm/k8scloudconfig/v17 v17.0.0
+	github.com/giantswarm/k8scloudconfig/v17 v17.2.0
 	github.com/giantswarm/k8smetadata v0.19.0
 	github.com/giantswarm/kubelock/v2 v2.0.0
 	github.com/giantswarm/microendpoint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -383,8 +383,8 @@ github.com/giantswarm/ipam v0.3.0/go.mod h1:xG4cMEKwHlbE0aZ7x2H5j7o81U13LIStA73X
 github.com/giantswarm/k8sclient/v4 v4.0.0/go.mod h1:jTwQ8q0YbJJu3ZxbjoI6hkXeuvKm15xyI/c+zwxnUH0=
 github.com/giantswarm/k8sclient/v7 v7.0.1 h1:UmRwgsw5Uda27tpIblPo7nWjp/nq5qwqxEPHWcvzsHk=
 github.com/giantswarm/k8sclient/v7 v7.0.1/go.mod h1:zJTXammjLHSiukMIO4+a6eUDgzj/lJxEXFZ22mC0WXc=
-github.com/giantswarm/k8scloudconfig/v17 v17.0.0 h1:pUC8VApkWPO7tC32ut/tZVUi6TdwtEe3+P309mBLEN8=
-github.com/giantswarm/k8scloudconfig/v17 v17.0.0/go.mod h1:peChY0p9SloYvoQfx5zCXIU6T//QdkG4y8LgFEWyuE4=
+github.com/giantswarm/k8scloudconfig/v17 v17.2.0 h1:qtSF8pRPZmOdgPwxWgJ7LVHjxwWP63HDP8R0kv2JMPc=
+github.com/giantswarm/k8scloudconfig/v17 v17.2.0/go.mod h1:peChY0p9SloYvoQfx5zCXIU6T//QdkG4y8LgFEWyuE4=
 github.com/giantswarm/k8smetadata v0.19.0 h1:wLzAwpuEW0FaOmR3EqaIpGpoRTg80aHFm5/cQKdn+DY=
 github.com/giantswarm/k8smetadata v0.19.0/go.mod h1:QiQAyaZnwco1U0lENLF0Kp4bSN4dIPwIlHWEvUo3ES8=
 github.com/giantswarm/kubelock/v2 v2.0.0 h1:s5mJc32HD0cX7hRS3sZ+d0J7d7g9CZtz9uxyDv+24II=

--- a/service/controller/cloudconfig/master_template.go
+++ b/service/controller/cloudconfig/master_template.go
@@ -91,6 +91,8 @@ func (c CloudConfig) NewMasterTemplate(ctx context.Context, data IgnitionTemplat
 			},
 		}
 
+		params.ControllerManagerTerminatedPodGcThreshold = key.ControllerManagerTerminatedPodGcThreshold(data.Cluster)
+
 		encryptedEncryptionConfig, err := encrypter.Encrypt(data.EncryptionConf)
 		if err != nil {
 			return "", microerror.Mask(err)

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -695,6 +695,22 @@ func MachinePoolID(getter LabelsGetter) (string, error) {
 	return machinePoolID, nil
 }
 
+func ControllerManagerTerminatedPodGcThreshold(cluster *capi.Cluster) int {
+	str := cluster.Annotations["controllermanager.giantswarm.io/terminated-pod-gc-threshold"]
+	if str != "" {
+		i, err := strconv.Atoi(str)
+		if err != nil {
+			// when 0 is returned than the default value configured in k8scloudconfig will be used
+			return 0
+		}
+
+		return int(i)
+	}
+
+	// when 0 is returned than the default value configured in k8scloudconfig will be used
+	return 0
+}
+
 func NodePoolInstanceName(nodePoolName, instanceID string) string {
 	idB36, err := vmssInstanceIDBase36(instanceID)
 	if err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/klingel/issues/91
